### PR TITLE
More tests and admin server fixes

### DIFF
--- a/dbos/admin_server.go
+++ b/dbos/admin_server.go
@@ -107,7 +107,7 @@ type adminServer struct {
 
 // toListWorkflowResponse converts a WorkflowStatus to a map with all time fields in UTC
 // not super ergonomic but the DBOS console excepts unix timestamps
-func toListWorkflowResponse(ws WorkflowStatus) (map[string]any, err) {
+func toListWorkflowResponse(ws WorkflowStatus) (map[string]any, error) {
 	result := map[string]any{
 		"WorkflowUUID":       ws.ID,
 		"Status":             ws.Status,

--- a/dbos/admin_server.go
+++ b/dbos/admin_server.go
@@ -372,7 +372,10 @@ func newAdminServer(ctx *dbosContext, port int) *adminServer {
 			}
 		}
 
-		workflows, err := ListWorkflows(ctx, req.toListWorkflowsOptions()...)
+		req.Status = "" // We are not expecting a filter here but clear just in case
+		filters := req.toListWorkflowsOptions()
+		filters = append(filters, WithStatus([]WorkflowStatusType{WorkflowStatusEnqueued, WorkflowStatusPending}))
+		workflows, err := ListWorkflows(ctx, filters...)
 		if err != nil {
 			ctx.logger.Error("Failed to list queued workflows", "error", err)
 			http.Error(w, fmt.Sprintf("Failed to list queued workflows: %v", err), http.StatusInternalServerError)

--- a/dbos/admin_server.go
+++ b/dbos/admin_server.go
@@ -152,7 +152,7 @@ func toListWorkflowResponse(ws WorkflowStatus) (map[string]any, error) {
 		result["StartedAt"] = nil
 	}
 
-	if ws.Input != nil {
+	if ws.Input != nil && ws.Input != "" {
 		bytes, err := json.Marshal(ws.Input)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal input: %w", err)
@@ -160,7 +160,7 @@ func toListWorkflowResponse(ws WorkflowStatus) (map[string]any, error) {
 		result["Input"] = string(bytes)
 	}
 
-	if ws.Output != nil {
+	if ws.Output != nil && ws.Output != "" {
 		bytes, err := json.Marshal(ws.Output)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal output: %w", err)

--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -125,7 +125,7 @@ func TestAdminServer(t *testing.T) {
 				endpoint:       fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_WORKFLOW_QUEUES_METADATA_PATTERN, "GET /")),
 				expectedStatus: http.StatusOK,
 				validateResp: func(t *testing.T, resp *http.Response) {
-					var queueMetadata []QueueOptions
+					var queueMetadata []WorkflowQueue
 					err := json.NewDecoder(resp.Body).Decode(&queueMetadata)
 					require.NoError(t, err, "Failed to decode response as QueueMetadata array")
 					assert.NotNil(t, queueMetadata, "Expected non-nil queue metadata array")

--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -213,6 +213,152 @@ func TestAdminServer(t *testing.T) {
 		}
 	})
 
+	t.Run("List workflows input/output values", func(t *testing.T) {
+		resetTestDatabase(t, databaseURL)
+		ctx, err := NewDBOSContext(Config{
+			DatabaseURL: databaseURL,
+			AppName:     "test-app",
+			AdminServer: true,
+		})
+		require.NoError(t, err)
+
+		// Define a custom struct for testing
+		type TestStruct struct {
+			Name  string `json:"name"`
+			Value int    `json:"value"`
+		}
+
+		// Test workflow with int input/output
+		intWorkflow := func(dbosCtx DBOSContext, input int) (int, error) {
+			return input * 2, nil
+		}
+		RegisterWorkflow(ctx, intWorkflow)
+
+		// Test workflow with empty string input/output
+		emptyStringWorkflow := func(dbosCtx DBOSContext, input string) (string, error) {
+			return "", nil
+		}
+		RegisterWorkflow(ctx, emptyStringWorkflow)
+
+		// Test workflow with struct input/output
+		structWorkflow := func(dbosCtx DBOSContext, input TestStruct) (TestStruct, error) {
+			return TestStruct{Name: "output-" + input.Name, Value: input.Value * 2}, nil
+		}
+		RegisterWorkflow(ctx, structWorkflow)
+
+		err = ctx.Launch()
+		require.NoError(t, err)
+
+		// Ensure cleanup
+		defer func() {
+			if ctx != nil {
+				ctx.Cancel()
+			}
+		}()
+
+		// Give the server a moment to start
+		time.Sleep(100 * time.Millisecond)
+
+		client := &http.Client{Timeout: 5 * time.Second}
+		endpoint := fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /"))
+
+		// Create workflows with different input/output types
+		// 1. Integer workflow
+		intHandle, err := RunAsWorkflow(ctx, intWorkflow, 42)
+		require.NoError(t, err, "Failed to create int workflow")
+		intResult, err := intHandle.GetResult()
+		require.NoError(t, err, "Failed to get int workflow result")
+		assert.Equal(t, 84, intResult)
+
+		// 2. Empty string workflow
+		emptyStringHandle, err := RunAsWorkflow(ctx, emptyStringWorkflow, "")
+		require.NoError(t, err, "Failed to create empty string workflow")
+		emptyStringResult, err := emptyStringHandle.GetResult()
+		require.NoError(t, err, "Failed to get empty string workflow result")
+		assert.Equal(t, "", emptyStringResult)
+
+		// 3. Struct workflow
+		structInput := TestStruct{Name: "test", Value: 10}
+		structHandle, err := RunAsWorkflow(ctx, structWorkflow, structInput)
+		require.NoError(t, err, "Failed to create struct workflow")
+		structResult, err := structHandle.GetResult()
+		require.NoError(t, err, "Failed to get struct workflow result")
+		assert.Equal(t, TestStruct{Name: "output-test", Value: 20}, structResult)
+
+		// Query workflows with input/output loading enabled
+		// Filter by the workflow IDs we just created to avoid interference from other tests
+		reqBody := map[string]any{
+			"workflow_uuids": []string{
+				intHandle.GetWorkflowID(),
+				emptyStringHandle.GetWorkflowID(),
+				structHandle.GetWorkflowID(),
+			},
+			"load_input":  true,
+			"load_output": true,
+			"limit":       10,
+		}
+		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(mustMarshal(reqBody)))
+		require.NoError(t, err, "Failed to create request")
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err, "Failed to make request")
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var workflows []map[string]any
+		err = json.NewDecoder(resp.Body).Decode(&workflows)
+		require.NoError(t, err, "Failed to decode workflows response")
+
+		// Should have exactly 3 workflows
+		assert.Equal(t, 3, len(workflows), "Expected exactly 3 workflows")
+
+		// Verify each workflow's input/output marshaling
+		for _, wf := range workflows {
+			wfID := wf["WorkflowUUID"].(string)
+
+			// Check input and output fields exist and are strings (JSON marshaled)
+			if wfID == intHandle.GetWorkflowID() {
+				// Integer workflow: input and output should be marshaled as JSON strings
+				inputStr, ok := wf["Input"].(string)
+				require.True(t, ok, "Int workflow Input should be a string")
+				assert.Equal(t, "42", inputStr, "Int workflow input should be marshaled as '42'")
+
+				outputStr, ok := wf["Output"].(string)
+				require.True(t, ok, "Int workflow Output should be a string")
+				assert.Equal(t, "84", outputStr, "Int workflow output should be marshaled as '84'")
+
+			} else if wfID == emptyStringHandle.GetWorkflowID() {
+				// Empty string workflow: both input and output are empty strings
+				// According to the logic, empty strings should not have Input/Output fields
+				input, hasInput := wf["Input"]
+				require.Equal(t, "", input)
+				require.True(t, hasInput, "Empty string workflow should have Input field")
+
+				output, hasOutput := wf["Output"]
+				require.True(t, hasOutput, "Empty string workflow should have Output field")
+				require.Equal(t, "", output)
+
+			} else if wfID == structHandle.GetWorkflowID() {
+				// Struct workflow: input and output should be marshaled as JSON strings
+				inputStr, ok := wf["Input"].(string)
+				require.True(t, ok, "Struct workflow Input should be a string")
+				var inputStruct TestStruct
+				err = json.Unmarshal([]byte(inputStr), &inputStruct)
+				require.NoError(t, err, "Failed to unmarshal struct workflow input")
+				assert.Equal(t, structInput, inputStruct, "Struct workflow input should match")
+
+				outputStr, ok := wf["Output"].(string)
+				require.True(t, ok, "Struct workflow Output should be a string")
+				var outputStruct TestStruct
+				err = json.Unmarshal([]byte(outputStr), &outputStruct)
+				require.NoError(t, err, "Failed to unmarshal struct workflow output")
+				assert.Equal(t, TestStruct{Name: "output-test", Value: 20}, outputStruct, "Struct workflow output should match")
+			}
+		}
+	})
+
 	t.Run("List endpoints time filtering", func(t *testing.T) {
 		ctx, err := NewDBOSContext(Config{
 			DatabaseURL: databaseURL,

--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -125,7 +125,7 @@ func TestAdminServer(t *testing.T) {
 				endpoint:       fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_WORKFLOW_QUEUES_METADATA_PATTERN, "GET /")),
 				expectedStatus: http.StatusOK,
 				validateResp: func(t *testing.T, resp *http.Response) {
-					var queueMetadata []WorkflowQueue
+					var queueMetadata []QueueOptions
 					err := json.NewDecoder(resp.Body).Decode(&queueMetadata)
 					require.NoError(t, err, "Failed to decode response as QueueMetadata array")
 					assert.NotNil(t, queueMetadata, "Expected non-nil queue metadata array")

--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -360,6 +360,7 @@ func TestAdminServer(t *testing.T) {
 	})
 
 	t.Run("List endpoints time filtering", func(t *testing.T) {
+		resetTestDatabase(t, databaseURL)
 		ctx, err := NewDBOSContext(Config{
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",

--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -455,7 +455,6 @@ func TestAdminServer(t *testing.T) {
 			"start_time": timeBetween.Format(time.RFC3339Nano),
 			"limit":      10,
 		}
-		fmt.Println("Request body 2:", reqBody2, "timebetween", timeBetween.UnixMilli())
 		req2, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(mustMarshal(reqBody2)))
 		require.NoError(t, err, "Failed to create request 2")
 		req2.Header.Set("Content-Type", "application/json")
@@ -469,7 +468,6 @@ func TestAdminServer(t *testing.T) {
 		var workflows2 []map[string]any
 		err = json.NewDecoder(resp2.Body).Decode(&workflows2)
 		require.NoError(t, err, "Failed to decode workflows response 2")
-		fmt.Println(workflows2)
 
 		// Should have exactly 1 workflow (the second one)
 		assert.Equal(t, 1, len(workflows2), "Expected exactly 1 workflow with start_time after timeBetween")

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -235,7 +235,7 @@ func TestEnqueue(t *testing.T) {
 
 		// After first workflow completes, we should be able to enqueue with same deduplication ID
 		handle5, err := Enqueue[wfInput, string](clientCtx, queue.Name, "ServerWorkflow", wfInput{Input: "test-input"},
-			WithEnqueueWorkflowID(wfid2),   // Reuse the workflow ID that failed before
+			WithEnqueueWorkflowID(wfid2),        // Reuse the workflow ID that failed before
 			WithEnqueueDeduplicationID(dedupID), // Same deduplication ID as first workflow
 			WithEnqueueApplicationVersion(serverCtx.GetApplicationVersion()))
 		require.NoError(t, err, "failed to enqueue workflow with same dedup ID after completion")

--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -25,9 +25,9 @@ type RateLimiter struct {
 	Period float64 // Time period in seconds for the rate limit
 }
 
-// QueueOptions defines a named queue for workflow execution.
+// WorkflowQueue defines a named queue for workflow execution.
 // Queues provide controlled workflow execution with concurrency limits, priority scheduling, and rate limiting.
-type QueueOptions struct {
+type WorkflowQueue struct {
 	Name                 string       `json:"name"`                        // Unique queue name
 	WorkerConcurrency    *int         `json:"workerConcurrency,omitempty"` // Max concurrent workflows per executor
 	GlobalConcurrency    *int         `json:"concurrency,omitempty"`       // Max concurrent workflows across all executors
@@ -37,12 +37,12 @@ type QueueOptions struct {
 }
 
 // QueueOption is a functional option for configuring a workflow queue
-type QueueOption func(*QueueOptions)
+type QueueOption func(*WorkflowQueue)
 
 // WithWorkerConcurrency limits the number of workflows this executor can run concurrently from the queue.
 // This provides per-executor concurrency control.
 func WithWorkerConcurrency(concurrency int) QueueOption {
-	return func(q *QueueOptions) {
+	return func(q *WorkflowQueue) {
 		q.WorkerConcurrency = &concurrency
 	}
 }
@@ -50,7 +50,7 @@ func WithWorkerConcurrency(concurrency int) QueueOption {
 // WithGlobalConcurrency limits the total number of workflows that can run concurrently from the queue
 // across all executors. This provides global concurrency control.
 func WithGlobalConcurrency(concurrency int) QueueOption {
-	return func(q *QueueOptions) {
+	return func(q *WorkflowQueue) {
 		q.GlobalConcurrency = &concurrency
 	}
 }
@@ -58,7 +58,7 @@ func WithGlobalConcurrency(concurrency int) QueueOption {
 // WithPriorityEnabled enables priority-based scheduling for the queue.
 // When enabled, workflows with lower priority numbers are executed first.
 func WithPriorityEnabled(enabled bool) QueueOption {
-	return func(q *QueueOptions) {
+	return func(q *WorkflowQueue) {
 		q.PriorityEnabled = enabled
 	}
 }
@@ -66,7 +66,7 @@ func WithPriorityEnabled(enabled bool) QueueOption {
 // WithRateLimiter configures rate limiting for the queue to prevent overwhelming external services.
 // The rate limiter enforces a maximum number of workflow starts within a time period.
 func WithRateLimiter(limiter *RateLimiter) QueueOption {
-	return func(q *QueueOptions) {
+	return func(q *WorkflowQueue) {
 		q.RateLimit = limiter
 	}
 }
@@ -74,7 +74,7 @@ func WithRateLimiter(limiter *RateLimiter) QueueOption {
 // WithMaxTasksPerIteration sets the maximum number of workflows to dequeue in a single iteration.
 // This controls batch sizes for queue processing.
 func WithMaxTasksPerIteration(maxTasks int) QueueOption {
-	return func(q *QueueOptions) {
+	return func(q *WorkflowQueue) {
 		q.MaxTasksPerIteration = maxTasks
 	}
 }
@@ -96,10 +96,10 @@ func WithMaxTasksPerIteration(maxTasks int) QueueOption {
 //
 //	// Enqueue workflows to this queue:
 //	handle, err := dbos.RunAsWorkflow(ctx, SendEmailWorkflow, emailData, dbos.WithQueue("email-queue"))
-func NewWorkflowQueue(dbosCtx DBOSContext, name string, options ...QueueOption) QueueOptions {
+func NewWorkflowQueue(dbosCtx DBOSContext, name string, options ...QueueOption) WorkflowQueue {
 	ctx, ok := dbosCtx.(*dbosContext)
 	if !ok {
-		return QueueOptions{} // Do nothing if the concrete type is not dbosContext
+		return WorkflowQueue{} // Do nothing if the concrete type is not dbosContext
 	}
 	if ctx.launched.Load() {
 		panic("Cannot register workflow queue after DBOS has launched")
@@ -111,7 +111,7 @@ func NewWorkflowQueue(dbosCtx DBOSContext, name string, options ...QueueOption) 
 	}
 
 	// Create queue with default settings
-	q := QueueOptions{
+	q := WorkflowQueue{
 		Name:                 name,
 		WorkerConcurrency:    nil,
 		GlobalConcurrency:    nil,
@@ -142,7 +142,7 @@ type queueRunner struct {
 	jitterMax       float64
 
 	// Queue registry
-	workflowQueueRegistry map[string]QueueOptions
+	workflowQueueRegistry map[string]WorkflowQueue
 
 	// Channel to signal completion back to the DBOS context
 	completionChan chan struct{}
@@ -157,13 +157,13 @@ func newQueueRunner() *queueRunner {
 		scalebackFactor:       0.9,
 		jitterMin:             0.95,
 		jitterMax:             1.05,
-		workflowQueueRegistry: make(map[string]QueueOptions),
+		workflowQueueRegistry: make(map[string]WorkflowQueue),
 		completionChan:        make(chan struct{}),
 	}
 }
 
-func (qr *queueRunner) listQueues() []QueueOptions {
-	queues := make([]QueueOptions, 0, len(qr.workflowQueueRegistry))
+func (qr *queueRunner) listQueues() []WorkflowQueue {
+	queues := make([]WorkflowQueue, 0, len(qr.workflowQueueRegistry))
 	for _, queue := range qr.workflowQueueRegistry {
 		queues = append(queues, queue)
 	}

--- a/dbos/queues_test.go
+++ b/dbos/queues_test.go
@@ -233,13 +233,13 @@ func TestWorkflowQueues(t *testing.T) {
 		for {
 			dlqStatus, err := dlqHandle[0].GetStatus()
 			require.NoError(t, err, "failed to get status of DLQ workflow handle")
-			if dlqStatus.Status != WorkflowStatusRetriesExceeded && retries < 10 {
+			if dlqStatus.Status != WorkflowStatusMaxRecoveryAttemptsExceeded && retries < 10 {
 				time.Sleep(1 * time.Second) // Wait a bit before checking again
 				retries++
 				continue
 			}
 			require.NoError(t, err, "failed to get status of DLQ workflow handle")
-			assert.Equal(t, WorkflowStatusRetriesExceeded, dlqStatus.Status, "expected workflow to be in DLQ after max retries exceeded")
+			assert.Equal(t, WorkflowStatusMaxRecoveryAttemptsExceeded, dlqStatus.Status, "expected workflow to be in DLQ after max retries exceeded")
 			handles = append(handles, dlqHandle[0])
 			break
 		}

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -236,7 +236,7 @@ func TestSetEventSerialize(t *testing.T) {
 		assert.Equal(t, "user-defined-event-set", result)
 
 		// Retrieve the event to verify it was properly serialized and can be deserialized
-		retrievedEvent, err := GetEvent[UserDefinedEventData](executor, setHandle.GetWorkflowID(), "user-defined-key", 3 * time.Second)
+		retrievedEvent, err := GetEvent[UserDefinedEventData](executor, setHandle.GetWorkflowID(), "user-defined-key", 3*time.Second)
 		require.NoError(t, err)
 
 		// Verify the retrieved data matches what we set
@@ -273,7 +273,7 @@ func sendUserDefinedTypeWorkflow(ctx DBOSContext, destinationID string) (string,
 
 func recvUserDefinedTypeWorkflow(ctx DBOSContext, input string) (UserDefinedEventData, error) {
 	// Receive the user-defined type message
-	result, err := Recv[UserDefinedEventData](ctx, "user-defined-topic", 3 * time.Second)
+	result, err := Recv[UserDefinedEventData](ctx, "user-defined-topic", 3*time.Second)
 	return result, err
 }
 

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1862,7 +1862,7 @@ type dequeuedWorkflow struct {
 }
 
 type dequeueWorkflowsInput struct {
-	queue              QueueOptions
+	queue              WorkflowQueue
 	executorID         string
 	applicationVersion string
 }

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1862,7 +1862,7 @@ type dequeuedWorkflow struct {
 }
 
 type dequeueWorkflowsInput struct {
-	queue              WorkflowQueue
+	queue              QueueOptions
 	executorID         string
 	applicationVersion string
 }

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -431,17 +431,17 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
 					 WHERE workflow_uuid = $2 AND status = $3`
 
 		_, err = input.tx.Exec(ctx, dlqQuery,
-			WorkflowStatusRetriesExceeded,
+			WorkflowStatusMaxRecoveryAttemptsExceeded,
 			input.status.ID,
 			WorkflowStatusPending)
 
 		if err != nil {
-			return nil, fmt.Errorf("failed to update workflow to %s: %w", WorkflowStatusRetriesExceeded, err)
+			return nil, fmt.Errorf("failed to update workflow to %s: %w", WorkflowStatusMaxRecoveryAttemptsExceeded, err)
 		}
 
 		// Commit the transaction before throwing the error
 		if err := input.tx.Commit(ctx); err != nil {
-			return nil, fmt.Errorf("failed to commit transaction after marking workflow as %s: %w", WorkflowStatusRetriesExceeded, err)
+			return nil, fmt.Errorf("failed to commit transaction after marking workflow as %s: %w", WorkflowStatusMaxRecoveryAttemptsExceeded, err)
 		}
 
 		return nil, newDeadLetterQueueError(input.status.ID, input.maxRetries)

--- a/dbos/utils_test.go
+++ b/dbos/utils_test.go
@@ -168,3 +168,22 @@ func queueEntriesAreCleanedUp(ctx DBOSContext) bool {
 
 	return success
 }
+
+func checkWfStatus(ctx DBOSContext, expectedStatus WorkflowStatusType) (bool, error) {
+	wfid, err := GetWorkflowID(ctx)
+	if err != nil {
+		return false, err
+	}
+	me, err := RetrieveWorkflow[string](ctx, wfid)
+	if err != nil {
+		return false, err
+	}
+	meStatus, err := me.GetStatus()
+	if err != nil {
+		return false, err
+	}
+	if meStatus.Status == expectedStatus {
+		return true, nil
+	}
+	return false, nil
+}

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1344,7 +1344,7 @@ func (c *dbosContext) RetrieveWorkflow(_ DBOSContext, workflowID string) (Workfl
 //	} else {
 //	    log.Printf("Result: %d", result)
 //	}
-func RetrieveWorkflow[R any](ctx DBOSContext, workflowID string) (*workflowPollingHandle[R], error) {
+func RetrieveWorkflow[R any](ctx DBOSContext, workflowID string) (WorkflowHandle[R], error) {
 	if ctx == nil {
 		return nil, errors.New("dbosCtx cannot be nil")
 	}

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -317,7 +317,7 @@ const (
 
 // WithMaxRetries sets the maximum number of retry attempts for workflow recovery.
 // If a workflow fails or is interrupted, it will be retried up to this many times.
-// After exceeding max retries, the workflow status becomes RETRIES_EXCEEDED.
+// After exceeding max retries, the workflow status becomes MAX_RECOVERY_ATTEMPTS_EXCEEDED.
 func WithMaxRetries(maxRetries int) WorkflowRegistrationOption {
 	return func(p *WorkflowRegistrationOptions) {
 		p.maxRetries = maxRetries

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -22,12 +22,12 @@ import (
 type WorkflowStatusType string
 
 const (
-	WorkflowStatusPending         WorkflowStatusType = "PENDING"                        // Workflow is running or ready to run
-	WorkflowStatusEnqueued        WorkflowStatusType = "ENQUEUED"                       // Workflow is queued and waiting for execution
-	WorkflowStatusSuccess         WorkflowStatusType = "SUCCESS"                        // Workflow completed successfully
-	WorkflowStatusError           WorkflowStatusType = "ERROR"                          // Workflow completed with an error
-	WorkflowStatusCancelled       WorkflowStatusType = "CANCELLED"                      // Workflow was cancelled (manually or due to timeout)
-	WorkflowStatusRetriesExceeded WorkflowStatusType = "MAX_RECOVERY_ATTEMPTS_EXCEEDED" // Workflow exceeded maximum retry attempts
+	WorkflowStatusPending                     WorkflowStatusType = "PENDING"                        // Workflow is running or ready to run
+	WorkflowStatusEnqueued                    WorkflowStatusType = "ENQUEUED"                       // Workflow is queued and waiting for execution
+	WorkflowStatusSuccess                     WorkflowStatusType = "SUCCESS"                        // Workflow completed successfully
+	WorkflowStatusError                       WorkflowStatusType = "ERROR"                          // Workflow completed with an error
+	WorkflowStatusCancelled                   WorkflowStatusType = "CANCELLED"                      // Workflow was cancelled (manually or due to timeout)
+	WorkflowStatusMaxRecoveryAttemptsExceeded WorkflowStatusType = "MAX_RECOVERY_ATTEMPTS_EXCEEDED" // Workflow exceeded maximum retry attempts
 )
 
 // WorkflowStatus contains comprehensive information about a workflow's current state and execution history.

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1009,57 +1009,148 @@ func TestWorkflowIdempotency(t *testing.T) {
 
 func TestWorkflowRecovery(t *testing.T) {
 	dbosCtx := setupDBOS(t, true, true)
-	RegisterWorkflow(dbosCtx, idempotencyWorkflowWithStep)
-	t.Run("RecoveryResumeWhereItLeftOff", func(t *testing.T) {
-		// Reset the global counter
-		idempotencyCounter = 0
 
-		// First execution - run the workflow once
-		input := "recovery-test"
-		idempotencyWorkflowWithStepEvent = NewEvent()
-		blockingStepStopEvent = NewEvent()
-		handle1, err := RunAsWorkflow(dbosCtx, idempotencyWorkflowWithStep, input)
-		require.NoError(t, err, "failed to execute workflow first time")
+	var (
+		recoveryCounters []int64
+		recoveryEvents   []*Event
+		blockingEvents   []*Event
+	)
 
-		idempotencyWorkflowWithStepEvent.Wait() // Wait for the first step to complete. The second spins forever.
+	recoveryWorkflow := func(dbosCtx DBOSContext, index int) (int64, error) {
+		// First step with custom name - increments the counter
+		_, err := RunAsStep(dbosCtx, func(ctx context.Context) (int64, error) {
+			recoveryCounters[index]++
+			return recoveryCounters[index], nil
+		}, WithStepName(fmt.Sprintf("IncrementStep-%d", index)))
+		if err != nil {
+			return 0, err
+		}
 
-		// Run recovery for pending workflows with "local" executor
+		// Signal that first step is complete
+		recoveryEvents[index].Set()
+
+		// Second step with custom name - blocks until signaled
+		_, err = RunAsStep(dbosCtx, func(ctx context.Context) (string, error) {
+			blockingEvents[index].Wait()
+			return fmt.Sprintf("completed-%d", index), nil
+		}, WithStepName(fmt.Sprintf("BlockingStep-%d", index)))
+		if err != nil {
+			return 0, err
+		}
+
+		return recoveryCounters[index], nil
+	}
+
+	RegisterWorkflow(dbosCtx, recoveryWorkflow)
+
+	t.Run("WorkflowRecovery", func(t *testing.T) {
+		const numWorkflows = 5
+
+		// Initialize slices for multiple workflows
+		recoveryCounters = make([]int64, numWorkflows)
+		recoveryEvents = make([]*Event, numWorkflows)
+		blockingEvents = make([]*Event, numWorkflows)
+
+		// Create events for each workflow
+		for i := range numWorkflows {
+			recoveryEvents[i] = NewEvent()
+			blockingEvents[i] = NewEvent()
+		}
+
+		// Start all workflows
+		handles := make([]WorkflowHandle[int64], numWorkflows)
+		for i := range numWorkflows {
+			handle, err := RunAsWorkflow(dbosCtx, recoveryWorkflow, i, WithWorkflowID(fmt.Sprintf("recovery-test-%d", i)))
+			require.NoError(t, err, "failed to start workflow %d", i)
+			handles[i] = handle
+		}
+
+		// Wait for all first steps to complete
+		for i := range numWorkflows {
+			recoveryEvents[i].Wait()
+		}
+
+		// Verify step states before recovery
+		for i := range numWorkflows {
+			steps, err := dbosCtx.(*dbosContext).systemDB.getWorkflowSteps(dbosCtx, handles[i].GetWorkflowID())
+			require.NoError(t, err, "failed to get steps for workflow %d", i)
+			require.Len(t, steps, 1, "expected 1 completed step for workflow %d before recovery", i)
+
+			// Verify first step has custom name and completed
+			assert.Equal(t, fmt.Sprintf("IncrementStep-%d", i), steps[0].StepName, "workflow %d first step name mismatch", i)
+			assert.Equal(t, 0, steps[0].StepID, "workflow %d first step ID should be 0", i)
+			assert.NotNil(t, steps[0].Output, "workflow %d first step should have output", i)
+			assert.Nil(t, steps[0].Error, "workflow %d first step should not have error", i)
+		}
+
+		// Verify counters are all 1 (executed once)
+		for i := range numWorkflows {
+			require.Equal(t, int64(1), recoveryCounters[i], "workflow %d counter should be 1 before recovery", i)
+		}
+
+		// Run recovery
 		recoveredHandles, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
 		require.NoError(t, err, "failed to recover pending workflows")
+		require.Len(t, recoveredHandles, numWorkflows, "expected %d recovered handles, got %d", numWorkflows, len(recoveredHandles))
 
-		// Check that we have a single handle in the return list
-		require.Len(t, recoveredHandles, 1, "expected 1 recovered handle, got %d", len(recoveredHandles))
+		// Create a map for easy lookup of recovered handles
+		recoveredMap := make(map[string]WorkflowHandle[any])
+		for _, h := range recoveredHandles {
+			recoveredMap[h.GetWorkflowID()] = h
+		}
 
-		// Check that the workflow ID from the handle is the same as the first handle
-		recoveredHandle := recoveredHandles[0]
-		_, ok := recoveredHandle.(*workflowPollingHandle[any])
-		require.True(t, ok, "expected handle to be of type workflowPollingHandle, got %T", recoveredHandle)
-		require.Equal(t, handle1.GetWorkflowID(), recoveredHandle.GetWorkflowID())
+		// Verify all original workflows were recovered
+		for i := range numWorkflows {
+			originalID := handles[i].GetWorkflowID()
+			recoveredHandle, found := recoveredMap[originalID]
+			require.True(t, found, "workflow %d with ID %s not found in recovered handles", i, originalID)
 
-		idempotencyWorkflowWithStepEvent.Clear()
-		idempotencyWorkflowWithStepEvent.Wait()
+			_, ok := recoveredHandle.(*workflowPollingHandle[any])
+			require.True(t, ok, "recovered handle %d should be of type workflowPollingHandle, got %T", i, recoveredHandle)
+		}
 
-		// Check that the first step was *not* re-executed (idempotency counter is still 1)
-		require.Equal(t, int64(1), idempotencyCounter, "expected counter to remain 1 after recovery (idempotent)")
+		// Verify first steps were NOT re-executed (counters should still be 1)
+		for i := range numWorkflows {
+			require.Equal(t, int64(1), recoveryCounters[i], "workflow %d counter should remain 1 after recovery (idempotent)", i)
+		}
 
-		// Using ListWorkflows, retrieve the status of the workflow
-		workflows, err := dbosCtx.(*dbosContext).systemDB.listWorkflows(context.Background(), listWorkflowsDBInput{
-			workflowIDs: []string{handle1.GetWorkflowID()},
-		})
-		require.NoError(t, err, "failed to list workflows")
+		// Verify workflow attempts increased to 2
+		for i := range numWorkflows {
+			workflows, err := dbosCtx.(*dbosContext).systemDB.listWorkflows(context.Background(), listWorkflowsDBInput{
+				workflowIDs: []string{handles[i].GetWorkflowID()},
+			})
+			require.NoError(t, err, "failed to list workflow %d", i)
+			require.Len(t, workflows, 1, "expected 1 workflow entry for workflow %d", i)
+			assert.Equal(t, 2, workflows[0].Attempts, "workflow %d should have 2 attempts after recovery", i)
+		}
 
-		require.Len(t, workflows, 1, "expected 1 workflow, got %d", len(workflows))
+		// Unblock all workflows and verify they complete
+		for i := range numWorkflows {
+			blockingEvents[i].Set()
+		}
 
-		workflow := workflows[0]
+		// Get results from all recovered workflows
+		for i := range numWorkflows {
+			recoveredHandle := recoveredMap[handles[i].GetWorkflowID()]
+			result, err := recoveredHandle.GetResult()
+			require.NoError(t, err, "failed to get result from recovered workflow %d", i)
 
-		// Ensure its number of attempts is 2
-		require.Equal(t, 2, workflow.Attempts)
+			// Result should be the counter value (1)
+			require.Equal(t, int64(1), result, "workflow %d result should be 1", i)
+		}
 
-		// unlock the workflow & wait for result
-		blockingStepStopEvent.Set() // This will allow the blocking step to complete
-		result, err := recoveredHandle.GetResult()
-		require.NoError(t, err, "failed to get result from recovered handle")
-		require.Equal(t, idempotencyCounter, result)
+		// Final verification of step states
+		for i := range numWorkflows {
+			steps, err := dbosCtx.(*dbosContext).systemDB.getWorkflowSteps(dbosCtx, handles[i].GetWorkflowID())
+			require.NoError(t, err, "failed to get final steps for workflow %d", i)
+			require.Len(t, steps, 2, "expected 2 steps for workflow %d", i)
+
+			// Both steps should now be completed
+			assert.NotNil(t, steps[0].Output, "workflow %d first step should have output", i)
+			assert.NotNil(t, steps[1].Output, "workflow %d second step should have output", i)
+			assert.Nil(t, steps[0].Error, "workflow %d first step should not have error", i)
+			assert.Nil(t, steps[1].Error, "workflow %d second step should not have error", i)
+		}
 	})
 }
 

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1213,7 +1213,7 @@ func TestWorkflowDeadLetterQueue(t *testing.T) {
 		require.True(t, ok, "expected DBOSError, got %T", err)
 		require.Equal(t, DeadLetterQueueError, dbosErr.Code)
 
-		// Verify workflow status is RETRIES_EXCEEDED
+		// Verify workflow status is MAX_RECOVERY_ATTEMPTS_EXCEEDED
 		status, err := handle.GetStatus()
 		require.NoError(t, err, "failed to get workflow status")
 		require.Equal(t, WorkflowStatusRetriesExceeded, status.Status)

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1308,15 +1308,15 @@ func sendWorkflow(ctx DBOSContext, input sendWorkflowInput) (string, error) {
 }
 
 func receiveWorkflow(ctx DBOSContext, topic string) (string, error) {
-	msg1, err := Recv[string](ctx, topic, 10 * time.Second)
+	msg1, err := Recv[string](ctx, topic, 10*time.Second)
 	if err != nil {
 		return "", err
 	}
-	msg2, err := Recv[string](ctx, topic, 10 * time.Second)
+	msg2, err := Recv[string](ctx, topic, 10*time.Second)
 	if err != nil {
 		return "", err
 	}
-	msg3, err := Recv[string](ctx, topic, 10 * time.Second)
+	msg3, err := Recv[string](ctx, topic, 10*time.Second)
 	if err != nil {
 		return "", err
 	}
@@ -1335,7 +1335,7 @@ func receiveWorkflowCoordinated(ctx DBOSContext, input struct {
 	concurrentRecvStartEvent.Wait()
 
 	// Do a single Recv call with timeout
-	msg, err := Recv[string](ctx, input.Topic, 3 * time.Second)
+	msg, err := Recv[string](ctx, input.Topic, 3*time.Second)
 	if err != nil {
 		return "", err
 	}
@@ -1349,7 +1349,7 @@ func sendStructWorkflow(ctx DBOSContext, input sendWorkflowInput) (string, error
 }
 
 func receiveStructWorkflow(ctx DBOSContext, topic string) (sendRecvType, error) {
-	return Recv[sendRecvType](ctx, topic, 3 * time.Second)
+	return Recv[sendRecvType](ctx, topic, 3*time.Second)
 }
 
 func sendIdempotencyWorkflow(ctx DBOSContext, input sendWorkflowInput) (string, error) {
@@ -1362,7 +1362,7 @@ func sendIdempotencyWorkflow(ctx DBOSContext, input sendWorkflowInput) (string, 
 }
 
 func receiveIdempotencyWorkflow(ctx DBOSContext, topic string) (string, error) {
-	msg, err := Recv[string](ctx, topic, 3 * time.Second)
+	msg, err := Recv[string](ctx, topic, 3*time.Second)
 	if err != nil {
 		// Unlock the test in this case
 		receiveIdempotencyStartEvent.Set()
@@ -1511,7 +1511,7 @@ func TestSendRecv(t *testing.T) {
 
 	t.Run("RecvMustRunInsideWorkflows", func(t *testing.T) {
 		// Attempt to run Recv outside of a workflow context
-		_, err := Recv[string](dbosCtx, "test-topic", 1 * time.Second)
+		_, err := Recv[string](dbosCtx, "test-topic", 1*time.Second)
 		require.Error(t, err, "expected error when running Recv outside of workflow context, but got none")
 
 		// Check the error type
@@ -1722,7 +1722,7 @@ func setEventWorkflow(ctx DBOSContext, input setEventWorkflowInput) (string, err
 }
 
 func getEventWorkflow(ctx DBOSContext, input setEventWorkflowInput) (string, error) {
-	result, err := GetEvent[string](ctx, input.Key, input.Message, 3 * time.Second)
+	result, err := GetEvent[string](ctx, input.Key, input.Message, 3*time.Second)
 	if err != nil {
 		return "", err
 	}
@@ -1759,7 +1759,7 @@ func setEventIdempotencyWorkflow(ctx DBOSContext, input setEventWorkflowInput) (
 }
 
 func getEventIdempotencyWorkflow(ctx DBOSContext, input setEventWorkflowInput) (string, error) {
-	result, err := GetEvent[string](ctx, input.Key, input.Message, 3 * time.Second)
+	result, err := GetEvent[string](ctx, input.Key, input.Message, 3*time.Second)
 	if err != nil {
 		return "", err
 	}
@@ -1969,7 +1969,7 @@ func TestSetGetEvent(t *testing.T) {
 		}
 
 		// Start a workflow that gets the event from outside the original workflow
-		message, err := GetEvent[string](dbosCtx, setHandle.GetWorkflowID(), "test-key", 3 * time.Second)
+		message, err := GetEvent[string](dbosCtx, setHandle.GetWorkflowID(), "test-key", 3*time.Second)
 		if err != nil {
 			t.Fatalf("failed to get event from outside workflow: %v", err)
 		}
@@ -1994,7 +1994,7 @@ func TestSetGetEvent(t *testing.T) {
 	t.Run("GetEventTimeout", func(t *testing.T) {
 		// Try to get an event from a non-existent workflow
 		nonExistentID := uuid.NewString()
-		message, err := GetEvent[string](dbosCtx, nonExistentID, "test-key", 3 * time.Second)
+		message, err := GetEvent[string](dbosCtx, nonExistentID, "test-key", 3*time.Second)
 		require.NoError(t, err, "failed to get event from non-existent workflow")
 		if message != "" {
 			t.Fatalf("expected empty result on timeout, got '%s'", message)
@@ -2008,7 +2008,7 @@ func TestSetGetEvent(t *testing.T) {
 		require.NoError(t, err, "failed to set event")
 		_, err = setHandle.GetResult()
 		require.NoError(t, err, "failed to get result from set event workflow")
-		message, err = GetEvent[string](dbosCtx, setHandle.GetWorkflowID(), "non-existent-key", 3 * time.Second)
+		message, err = GetEvent[string](dbosCtx, setHandle.GetWorkflowID(), "non-existent-key", 3*time.Second)
 		require.NoError(t, err, "failed to get event with non-existent key")
 		if message != "" {
 			t.Fatalf("expected empty result on timeout with non-existent key, got '%s'", message)
@@ -2155,7 +2155,7 @@ func TestSetGetEvent(t *testing.T) {
 		for range numGoroutines {
 			go func() {
 				defer wg.Done()
-				res, err := GetEvent[string](dbosCtx, setHandle.GetWorkflowID(), "concurrent-event-key", 10 * time.Second)
+				res, err := GetEvent[string](dbosCtx, setHandle.GetWorkflowID(), "concurrent-event-key", 10*time.Second)
 				if err != nil {
 					errors <- fmt.Errorf("failed to get event in goroutine: %v", err)
 					return
@@ -2260,6 +2260,18 @@ func TestWorkflowTimeout(t *testing.T) {
 		<-ctx.Done()
 		assert.True(t, errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded),
 			"workflow was cancelled, but context error is not context.Canceled nor context.DeadlineExceeded: %v", ctx.Err())
+		// The status of this workflow should transition to cancelled
+		maxtries := 10
+		for range maxtries {
+			isCancelled, err := checkWfStatus(ctx, WorkflowStatusCancelled)
+			if err != nil {
+				return "", err
+			}
+			if isCancelled {
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
 		return "", ctx.Err()
 	}
 	RegisterWorkflow(dbosCtx, waitForCancelWorkflow)
@@ -2326,6 +2338,62 @@ func TestWorkflowTimeout(t *testing.T) {
 		// Wait for the workflow to complete and get the result
 		result, err := handle.GetResult()
 		assert.True(t, errors.Is(err, context.DeadlineExceeded), "Expected deadline exceeded error, got: %v", err)
+		assert.Equal(t, "", result, "expected result to be an empty string")
+
+		// Check the workflow status: should be cancelled
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get workflow status")
+		assert.Equal(t, WorkflowStatusCancelled, status.Status, "expected workflow status to be WorkflowStatusCancelled")
+	})
+
+	waitForCancelWorkflowWithStepAfterCancel := func(ctx DBOSContext, _ string) (string, error) {
+		// Wait for cancellation
+		<-ctx.Done()
+		// Check that we have the correct cancellation error
+		if !errors.Is(ctx.Err(), context.Canceled) && !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return "", fmt.Errorf("workflow was cancelled, but context error is not context.Canceled nor context.DeadlineExceeded: %v", ctx.Err())
+		}
+		// The status of this workflow should transition to cancelled
+		maxtries := 10
+		for range maxtries {
+			isCancelled, err := checkWfStatus(ctx, WorkflowStatusCancelled)
+			if err != nil {
+				return "", err
+			}
+			if isCancelled {
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+
+		// After cancellation, try to run a simple step
+		// This should return a WorkflowCancelled error
+		return RunAsStep(ctx, simpleStep)
+	}
+	RegisterWorkflow(dbosCtx, waitForCancelWorkflowWithStepAfterCancel)
+
+	t.Run("WorkflowWithStepAfterTimeout", func(t *testing.T) {
+		// Start a workflow that waits for cancellation then tries to run a step
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, 1*time.Millisecond)
+		defer cancelFunc() // Ensure we clean up the context
+		handle, err := RunAsWorkflow(cancelCtx, waitForCancelWorkflowWithStepAfterCancel, "wf-with-step-after-timeout")
+		require.NoError(t, err, "failed to start workflow with step after timeout")
+
+		// Wait for the workflow to complete and get the result
+		result, err := handle.GetResult()
+		fmt.Println(result)
+		// The workflow should return a WorkflowCancelled error from the step
+		require.Error(t, err, "expected error from workflow")
+
+		// Check if the error is a DBOSError with WorkflowCancelled code
+		var dbosErr *DBOSError
+		if errors.As(err, &dbosErr) {
+			assert.Equal(t, WorkflowCancelled, dbosErr.Code, "expected WorkflowCancelled error code, got: %v", dbosErr.Code)
+		} else {
+			// If not a DBOSError, check if it's a context error
+			assert.True(t, errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded),
+				"expected context.Canceled or context.DeadlineExceeded error, got: %v", err)
+		}
 		assert.Equal(t, "", result, "expected result to be an empty string")
 
 		// Check the workflow status: should be cancelled
@@ -2519,7 +2587,7 @@ func TestWorkflowTimeout(t *testing.T) {
 }
 
 func notificationWaiterWorkflow(ctx DBOSContext, pairID int) (string, error) {
-	result, err := GetEvent[string](ctx, fmt.Sprintf("notification-setter-%d", pairID), "event-key", 10 * time.Second)
+	result, err := GetEvent[string](ctx, fmt.Sprintf("notification-setter-%d", pairID), "event-key", 10*time.Second)
 	if err != nil {
 		return "", err
 	}
@@ -2535,7 +2603,7 @@ func notificationSetterWorkflow(ctx DBOSContext, pairID int) (string, error) {
 }
 
 func sendRecvReceiverWorkflow(ctx DBOSContext, pairID int) (string, error) {
-	result, err := Recv[string](ctx, "send-recv-topic", 10 * time.Second)
+	result, err := Recv[string](ctx, "send-recv-topic", 10*time.Second)
 	if err != nil {
 		return "", err
 	}

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1216,7 +1216,7 @@ func TestWorkflowDeadLetterQueue(t *testing.T) {
 		// Verify workflow status is MAX_RECOVERY_ATTEMPTS_EXCEEDED
 		status, err := handle.GetStatus()
 		require.NoError(t, err, "failed to get workflow status")
-		require.Equal(t, WorkflowStatusRetriesExceeded, status.Status)
+		require.Equal(t, WorkflowStatusMaxRecoveryAttemptsExceeded, status.Status)
 
 		// Verify that attempting to start a workflow with the same ID throws a DLQ error
 		_, err = RunAsWorkflow(dbosCtx, deadLetterQueueWorkflow, "test", WithWorkflowID(wfID))

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -2472,7 +2472,6 @@ func TestWorkflowTimeout(t *testing.T) {
 
 		// Wait for the workflow to complete and get the result
 		result, err := handle.GetResult()
-		fmt.Println(result)
 		// The workflow should return a WorkflowCancelled error from the step
 		require.Error(t, err, "expected error from workflow")
 


### PR DESCRIPTION
- `QueueOptions` made public
- More comprehensive recovery test (recovers more workflows and check steps status)
- Check that steps return a cancelled error after the workflow was cancelled
- Admin server:
  - Always "stringify" non nil workflow output/input
  - Filter out queue tasks by status (pending/enqueued) on the list queues endpoint
- Have `RetrieveWorkflow` return a handle interface
  