### PR TITLE
Admin server port

### DIFF
--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testAdminPort = 38081
+
 func TestAdminServer(t *testing.T) {
 	databaseURL := getDatabaseURL()
 
@@ -36,7 +38,7 @@ func TestAdminServer(t *testing.T) {
 
 		// Verify admin server is not running
 		client := &http.Client{Timeout: 1 * time.Second}
-		_, err = client.Get(fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_HEALTHCHECK_PATTERN, "GET /")))
+		_, err = client.Get(fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_HEALTHCHECK_PATTERN, "GET /")))
 		require.Error(t, err, "Expected request to fail when admin server is not started")
 
 		// Verify the DBOS executor doesn't have an admin server instance
@@ -54,6 +56,7 @@ func TestAdminServer(t *testing.T) {
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",
 			AdminServer: true,
+			AdminServerPort: testAdminPort,
 		})
 		require.NoError(t, err)
 
@@ -92,13 +95,13 @@ func TestAdminServer(t *testing.T) {
 			{
 				name:           "Health endpoint responds correctly",
 				method:         "GET",
-				endpoint:       fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_HEALTHCHECK_PATTERN, "GET /")),
+				endpoint:       fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_HEALTHCHECK_PATTERN, "GET /")),
 				expectedStatus: http.StatusOK,
 			},
 			{
 				name:           "Recovery endpoint responds correctly with valid JSON",
 				method:         "POST",
-				endpoint:       fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_WORKFLOW_RECOVERY_PATTERN, "POST /")),
+				endpoint:       fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOW_RECOVERY_PATTERN, "POST /")),
 				body:           bytes.NewBuffer(mustMarshal([]string{"executor1", "executor2"})),
 				contentType:    "application/json",
 				expectedStatus: http.StatusOK,
@@ -112,7 +115,7 @@ func TestAdminServer(t *testing.T) {
 			{
 				name:           "Recovery endpoint rejects invalid JSON",
 				method:         "POST",
-				endpoint:       fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_WORKFLOW_RECOVERY_PATTERN, "POST /")),
+				endpoint:       fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOW_RECOVERY_PATTERN, "POST /")),
 				body:           strings.NewReader(`{"invalid": json}`),
 				contentType:    "application/json",
 				expectedStatus: http.StatusBadRequest,
@@ -120,7 +123,7 @@ func TestAdminServer(t *testing.T) {
 			{
 				name:           "Queue metadata endpoint responds correctly",
 				method:         "GET",
-				endpoint:       fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_WORKFLOW_QUEUES_METADATA_PATTERN, "GET /")),
+				endpoint:       fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOW_QUEUES_METADATA_PATTERN, "GET /")),
 				expectedStatus: http.StatusOK,
 				validateResp: func(t *testing.T, resp *http.Response) {
 					var queueMetadata []WorkflowQueue
@@ -146,7 +149,7 @@ func TestAdminServer(t *testing.T) {
 			{
 				name:     "Workflows endpoint accepts all filters without error",
 				method:   "POST",
-				endpoint: fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /")),
+				endpoint: fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /")),
 				body: bytes.NewBuffer(mustMarshal(map[string]any{
 					"workflow_uuids":      []string{"test-id-1", "test-id-2"},
 					"authenticated_user":  "test-user",
@@ -177,7 +180,7 @@ func TestAdminServer(t *testing.T) {
 			{
 				name:           "Get single workflow returns 404 for non-existent workflow",
 				method:         "GET",
-				endpoint:       "http://localhost:3001/workflow/non-existent-workflow-id",
+				endpoint:       fmt.Sprintf("http://localhost:%d/workflow/non-existent-workflow-id", testAdminPort),
 				expectedStatus: http.StatusNotFound,
 			},
 		}
@@ -217,6 +220,7 @@ func TestAdminServer(t *testing.T) {
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",
 			AdminServer: true,
+			AdminServerPort: testAdminPort,
 		})
 		require.NoError(t, err)
 
@@ -258,7 +262,7 @@ func TestAdminServer(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		client := &http.Client{Timeout: 5 * time.Second}
-		endpoint := fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /"))
+		endpoint := fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /"))
 
 		// Create workflows with different input/output types
 		// 1. Integer workflow
@@ -363,6 +367,7 @@ func TestAdminServer(t *testing.T) {
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",
 			AdminServer: true,
+			AdminServerPort: testAdminPort,
 		})
 		require.NoError(t, err)
 
@@ -382,7 +387,7 @@ func TestAdminServer(t *testing.T) {
 		}()
 
 		client := &http.Client{Timeout: 5 * time.Second}
-		endpoint := fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /"))
+		endpoint := fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /"))
 
 		// Create first workflow
 		handle1, err := RunWorkflow(ctx, testWorkflow, "workflow1")
@@ -536,6 +541,7 @@ func TestAdminServer(t *testing.T) {
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",
 			AdminServer: true,
+			AdminServerPort: testAdminPort,
 		})
 		require.NoError(t, err)
 
@@ -570,7 +576,7 @@ func TestAdminServer(t *testing.T) {
 		}()
 
 		client := &http.Client{Timeout: 5 * time.Second}
-		endpoint := fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_QUEUED_WORKFLOWS_PATTERN, "POST /"))
+		endpoint := fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_QUEUED_WORKFLOWS_PATTERN, "POST /"))
 
 		/// Create a workflow that will not block the queue
 		h1, err := RunWorkflow(ctx, regularWorkflow, "regular", WithQueue(queue.Name))
@@ -721,6 +727,7 @@ func TestAdminServer(t *testing.T) {
 			DatabaseURL: databaseURL,
 			AppName:     "test-app",
 			AdminServer: true,
+			AdminServerPort: testAdminPort,
 		})
 		require.NoError(t, err)
 
@@ -754,7 +761,7 @@ func TestAdminServer(t *testing.T) {
 		}, 3*time.Second, 100*time.Millisecond, "Expected at least 2 scheduled workflow executions")
 
 		// Call deactivate endpoint
-		endpoint := fmt.Sprintf("http://localhost:3001/%s", strings.TrimPrefix(_DEACTIVATE_PATTERN, "GET /"))
+		endpoint := fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_DEACTIVATE_PATTERN, "GET /"))
 		req, err := http.NewRequest("GET", endpoint, nil)
 		require.NoError(t, err, "Failed to create deactivate request")
 

--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testAdminPort = 38081
-
 func TestAdminServer(t *testing.T) {
 	databaseURL := getDatabaseURL()
 
@@ -38,7 +36,7 @@ func TestAdminServer(t *testing.T) {
 
 		// Verify admin server is not running
 		client := &http.Client{Timeout: 1 * time.Second}
-		_, err = client.Get(fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_HEALTHCHECK_PATTERN, "GET /")))
+		_, err = client.Get(fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_HEALTHCHECK_PATTERN, "GET /")))
 		require.Error(t, err, "Expected request to fail when admin server is not started")
 
 		// Verify the DBOS executor doesn't have an admin server instance
@@ -53,10 +51,10 @@ func TestAdminServer(t *testing.T) {
 		resetTestDatabase(t, databaseURL)
 		// Launch DBOS with admin server once for all endpoint tests
 		ctx, err := NewDBOSContext(Config{
-			DatabaseURL: databaseURL,
-			AppName:     "test-app",
-			AdminServer: true,
-			AdminServerPort: testAdminPort,
+			DatabaseURL:     databaseURL,
+			AppName:         "test-app",
+			AdminServer:     true,
+			AdminServerPort: _DEFAULT_ADMIN_SERVER_PORT,
 		})
 		require.NoError(t, err)
 
@@ -95,13 +93,13 @@ func TestAdminServer(t *testing.T) {
 			{
 				name:           "Health endpoint responds correctly",
 				method:         "GET",
-				endpoint:       fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_HEALTHCHECK_PATTERN, "GET /")),
+				endpoint:       fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_HEALTHCHECK_PATTERN, "GET /")),
 				expectedStatus: http.StatusOK,
 			},
 			{
 				name:           "Recovery endpoint responds correctly with valid JSON",
 				method:         "POST",
-				endpoint:       fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOW_RECOVERY_PATTERN, "POST /")),
+				endpoint:       fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_WORKFLOW_RECOVERY_PATTERN, "POST /")),
 				body:           bytes.NewBuffer(mustMarshal([]string{"executor1", "executor2"})),
 				contentType:    "application/json",
 				expectedStatus: http.StatusOK,
@@ -115,7 +113,7 @@ func TestAdminServer(t *testing.T) {
 			{
 				name:           "Recovery endpoint rejects invalid JSON",
 				method:         "POST",
-				endpoint:       fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOW_RECOVERY_PATTERN, "POST /")),
+				endpoint:       fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_WORKFLOW_RECOVERY_PATTERN, "POST /")),
 				body:           strings.NewReader(`{"invalid": json}`),
 				contentType:    "application/json",
 				expectedStatus: http.StatusBadRequest,
@@ -123,7 +121,7 @@ func TestAdminServer(t *testing.T) {
 			{
 				name:           "Queue metadata endpoint responds correctly",
 				method:         "GET",
-				endpoint:       fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOW_QUEUES_METADATA_PATTERN, "GET /")),
+				endpoint:       fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_WORKFLOW_QUEUES_METADATA_PATTERN, "GET /")),
 				expectedStatus: http.StatusOK,
 				validateResp: func(t *testing.T, resp *http.Response) {
 					var queueMetadata []WorkflowQueue
@@ -149,7 +147,7 @@ func TestAdminServer(t *testing.T) {
 			{
 				name:     "Workflows endpoint accepts all filters without error",
 				method:   "POST",
-				endpoint: fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /")),
+				endpoint: fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /")),
 				body: bytes.NewBuffer(mustMarshal(map[string]any{
 					"workflow_uuids":      []string{"test-id-1", "test-id-2"},
 					"authenticated_user":  "test-user",
@@ -180,7 +178,7 @@ func TestAdminServer(t *testing.T) {
 			{
 				name:           "Get single workflow returns 404 for non-existent workflow",
 				method:         "GET",
-				endpoint:       fmt.Sprintf("http://localhost:%d/workflow/non-existent-workflow-id", testAdminPort),
+				endpoint:       fmt.Sprintf("http://localhost:%d/workflow/non-existent-workflow-id", _DEFAULT_ADMIN_SERVER_PORT),
 				expectedStatus: http.StatusNotFound,
 			},
 		}
@@ -217,10 +215,10 @@ func TestAdminServer(t *testing.T) {
 	t.Run("List workflows input/output values", func(t *testing.T) {
 		resetTestDatabase(t, databaseURL)
 		ctx, err := NewDBOSContext(Config{
-			DatabaseURL: databaseURL,
-			AppName:     "test-app",
-			AdminServer: true,
-			AdminServerPort: testAdminPort,
+			DatabaseURL:     databaseURL,
+			AppName:         "test-app",
+			AdminServer:     true,
+			AdminServerPort: _DEFAULT_ADMIN_SERVER_PORT,
 		})
 		require.NoError(t, err)
 
@@ -262,7 +260,7 @@ func TestAdminServer(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		client := &http.Client{Timeout: 5 * time.Second}
-		endpoint := fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /"))
+		endpoint := fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /"))
 
 		// Create workflows with different input/output types
 		// 1. Integer workflow
@@ -364,10 +362,10 @@ func TestAdminServer(t *testing.T) {
 	t.Run("List endpoints time filtering", func(t *testing.T) {
 		resetTestDatabase(t, databaseURL)
 		ctx, err := NewDBOSContext(Config{
-			DatabaseURL: databaseURL,
-			AppName:     "test-app",
-			AdminServer: true,
-			AdminServerPort: testAdminPort,
+			DatabaseURL:     databaseURL,
+			AppName:         "test-app",
+			AdminServer:     true,
+			AdminServerPort: _DEFAULT_ADMIN_SERVER_PORT,
 		})
 		require.NoError(t, err)
 
@@ -387,7 +385,7 @@ func TestAdminServer(t *testing.T) {
 		}()
 
 		client := &http.Client{Timeout: 5 * time.Second}
-		endpoint := fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /"))
+		endpoint := fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /"))
 
 		// Create first workflow
 		handle1, err := RunWorkflow(ctx, testWorkflow, "workflow1")
@@ -538,10 +536,10 @@ func TestAdminServer(t *testing.T) {
 	t.Run("ListQueuedWorkflows", func(t *testing.T) {
 		resetTestDatabase(t, databaseURL)
 		ctx, err := NewDBOSContext(Config{
-			DatabaseURL: databaseURL,
-			AppName:     "test-app",
-			AdminServer: true,
-			AdminServerPort: testAdminPort,
+			DatabaseURL:     databaseURL,
+			AppName:         "test-app",
+			AdminServer:     true,
+			AdminServerPort: _DEFAULT_ADMIN_SERVER_PORT,
 		})
 		require.NoError(t, err)
 
@@ -576,7 +574,7 @@ func TestAdminServer(t *testing.T) {
 		}()
 
 		client := &http.Client{Timeout: 5 * time.Second}
-		endpoint := fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_QUEUED_WORKFLOWS_PATTERN, "POST /"))
+		endpoint := fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_QUEUED_WORKFLOWS_PATTERN, "POST /"))
 
 		/// Create a workflow that will not block the queue
 		h1, err := RunWorkflow(ctx, regularWorkflow, "regular", WithQueue(queue.Name))
@@ -724,10 +722,10 @@ func TestAdminServer(t *testing.T) {
 	t.Run("TestDeactivate", func(t *testing.T) {
 		resetTestDatabase(t, databaseURL)
 		ctx, err := NewDBOSContext(Config{
-			DatabaseURL: databaseURL,
-			AppName:     "test-app",
-			AdminServer: true,
-			AdminServerPort: testAdminPort,
+			DatabaseURL:     databaseURL,
+			AppName:         "test-app",
+			AdminServer:     true,
+			AdminServerPort: _DEFAULT_ADMIN_SERVER_PORT,
 		})
 		require.NoError(t, err)
 
@@ -761,7 +759,7 @@ func TestAdminServer(t *testing.T) {
 		}, 3*time.Second, 100*time.Millisecond, "Expected at least 2 scheduled workflow executions")
 
 		// Call deactivate endpoint
-		endpoint := fmt.Sprintf("http://localhost:%d/%s", testAdminPort, strings.TrimPrefix(_DEACTIVATE_PATTERN, "GET /"))
+		endpoint := fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_DEACTIVATE_PATTERN, "GET /"))
 		req, err := http.NewRequest("GET", endpoint, nil)
 		require.NoError(t, err, "Failed to create deactivate request")
 

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -36,6 +36,7 @@ type Config struct {
 	AppName            string       // Application name for identification (required)
 	Logger             *slog.Logger // Custom logger instance (defaults to a new slog logger)
 	AdminServer        bool         // Enable Transact admin HTTP server (disabled by default)
+	AdminServerPort    int          // Port for the admin HTTP server (default: 3001)
 	ConductorURL       string       // DBOS conductor service URL (optional)
 	ConductorAPIKey    string       // DBOS conductor API key (optional)
 	ApplicationVersion string       // Application version (optional, overridden by DBOS__APPVERSION env var)
@@ -51,12 +52,16 @@ func processConfig(inputConfig *Config) (*Config, error) {
 	if len(inputConfig.AppName) == 0 {
 		return nil, fmt.Errorf("missing required config field: appName")
 	}
+	if inputConfig.AdminServerPort == 0 {
+	    inputConfig.AdminServerPort = _DEFAULT_ADMIN_SERVER_PORT
+	}
 
 	dbosConfig := &Config{
 		DatabaseURL:        inputConfig.DatabaseURL,
 		AppName:            inputConfig.AppName,
 		Logger:             inputConfig.Logger,
 		AdminServer:        inputConfig.AdminServer,
+		AdminServerPort:    inputConfig.AdminServerPort,
 		ConductorURL:       inputConfig.ConductorURL,
 		ConductorAPIKey:    inputConfig.ConductorAPIKey,
 		ApplicationVersion: inputConfig.ApplicationVersion,
@@ -372,13 +377,13 @@ func (c *dbosContext) Launch() error {
 
 	// Start the admin server if configured
 	if c.config.AdminServer {
-		adminServer := newAdminServer(c, _DEFAULT_ADMIN_SERVER_PORT)
+		adminServer := newAdminServer(c, c.config.AdminServerPort)
 		err := adminServer.Start()
 		if err != nil {
 			c.logger.Error("Failed to start admin server", "error", err)
 			return newInitializationError(fmt.Sprintf("failed to start admin server: %v", err))
 		}
-		c.logger.Info("Admin server started", "port", _DEFAULT_ADMIN_SERVER_PORT)
+		c.logger.Info("Admin server started", "port", c.config.AdminServerPort)
 		c.adminServer = adminServer
 	}
 


### PR DESCRIPTION

Replaced hard-coded port `3001` with a configurable `AdminServerPort` field in `Config`.  
Updated `dbos.go` to use the provided port (defaulting to 3001) and adjusted tests to use a custom port (`38081`).  

✅ All `TestAdminServer` cases now pass.
