### PR TITLE
init exp backoff + jitter for system_database.go

### DIFF
--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -2324,7 +2324,7 @@ func (qb *queryBuilder) addWhereLessEqual(column string, value any) {
 	qb.args = append(qb.args, value)
 }
 
-func backoffWithJitter(retryAttempt int) (time.Duration) {
+func backoffWithJitter(retryAttempt int) time.Duration {
 	// cap backoff to max number of retries, then do a fixed time delay
 	// expected retryAttempt to initially be 0, so >= used
 	if retryAttempt >= _DB_CONNECTION_RETRY_MAX_RETRIES {
@@ -2336,6 +2336,7 @@ func backoffWithJitter(retryAttempt int) (time.Duration) {
 		exp = float64(_DB_CONNECTION_MAX_DELAY)
 	}
 
-	jitter := 0.5 + rand.Float64()
-	return time.Duration(exp + jitter)
+	// want randomization between +-25% of exp
+	jitter := 0.75 + rand.Float64()*0.5
+	return time.Duration(exp * jitter)
 }


### PR DESCRIPTION
Fixes #95 

Added exponential backoff delay + jitter to replace fixed delay being used in `shutdown` and `notificationListenerLoop`.

Replaced delay interval constant by constants

```go
    _DB_CONNECTION_RETRY_BASE_DELAY = 500 * time.Millisecond
    _DB_CONNECTION_RETRY_FACTOR = 2
    _DB_CONNECTION_RETRY_MAX_RETRIES = 3
    _DB_CONNECTION_MAX_DELAY = 10 * time.Second
```

### How this works
Func `backoffWithJitter` takes an argument attempt - attempts of backoff delay done yet.
Calculates the delay as 

`baseDelay * math.Pow(retryFactor, attempts) + jitter`

Jitter being calculated as a random value between 0.3 and 1.3 (constants of no particular significance, can change - repo has varying implementations of backoff with jitter).

If the delay calculate exceeds a cap defined in constants - take the constant instead.

If the number of retries get too large -> return an error saying so (optional, maybe want to timeout if takes too long).


