### PR TITLE
Remove temp install

### DIFF
--- a/cmd/dbos/cli_integration_test.go
+++ b/cmd/dbos/cli_integration_test.go
@@ -159,11 +159,6 @@ func testProjectInitialization(t *testing.T, cliPath string) {
 	modCmd := exec.Command("go", "mod", "tidy")
 	modOutput, err := modCmd.CombinedOutput()
 	require.NoError(t, err, "go mod tidy failed: %s", string(modOutput))
-
-	// TEMPORARY: go get github.com/dbos-inc/dbos-transact-golang/cmd/dbos@dbos-migration
-	tmpCmd := exec.Command("go", "get", "github.com/dbos-inc/dbos-transact-golang/cmd/dbos@dbos-migration")
-	tmpOutput, err := tmpCmd.CombinedOutput()
-	require.NoError(t, err, "Failed to get dbos-migration: %s", string(tmpOutput))
 }
 
 // testApplicationLifecycle starts the application and triggers workflows

--- a/cmd/dbos/postgres.go
+++ b/cmd/dbos/postgres.go
@@ -174,7 +174,7 @@ func startDockerPostgres() error {
 		return err
 	}
 
-	logger.Info("Postgres available", "url", fmt.Sprintf("postgresql://postgres:%s@localhost:5432", password))
+	logger.Info("Postgres available", "url", fmt.Sprintf("postgres://postgres:%s@localhost:5432", password))
 	return nil
 }
 


### PR DESCRIPTION
- The CLI test can now use the latest golang SDK (had to specifically get a version with the new migration scheme before)
- Update a log info telling users to use `postgresql` instead of `postgres` as the db driver