### PR TITLE
Run as step inside go routines

### DIFF
--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -107,7 +107,7 @@ type DBOSContext interface {
 
 	// Workflow operations
 	RunAsStep(_ DBOSContext, fn StepFunc, opts ...StepOption) (any, error)                                      // Execute a function as a durable step within a workflow
-	Go(_ DBOSContext, fn StepFunc, StepID int, opts ...StepOption) (any, error)                                 // Execute a function as a durable step within a Go routine
+	Go(_ DBOSContext, fn StepFunc, opts ...StepOption) (any, error)                                             // Execute a function as a durable step within a Go routine
 	RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opts ...WorkflowOption) (WorkflowHandle[any], error) // Start a new workflow execution
 	Send(_ DBOSContext, destinationID string, message any, topic string) error                                  // Send a message to another workflow
 	Recv(_ DBOSContext, topic string, timeout time.Duration) (any, error)                                       // Receive a message sent to this workflow

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -53,7 +53,7 @@ func processConfig(inputConfig *Config) (*Config, error) {
 		return nil, fmt.Errorf("missing required config field: appName")
 	}
 	if inputConfig.AdminServerPort == 0 {
-	    inputConfig.AdminServerPort = _DEFAULT_ADMIN_SERVER_PORT
+		inputConfig.AdminServerPort = _DEFAULT_ADMIN_SERVER_PORT
 	}
 
 	dbosConfig := &Config{
@@ -106,15 +106,16 @@ type DBOSContext interface {
 	Shutdown(timeout time.Duration) // Gracefully shutdown all DBOS runtime components with ordered cleanup sequence
 
 	// Workflow operations
-	RunAsStep(_ DBOSContext, fn StepFunc, opts ...StepOption) (any, error)                                        // Execute a function as a durable step within a workflow
+	RunAsStep(_ DBOSContext, fn StepFunc, opts ...StepOption) (any, error)                                      // Execute a function as a durable step within a workflow
+	Go(_ DBOSContext, fn StepFunc, StepID int, opts ...StepOption) (any, error)                                 // Execute a function as a durable step within a Go routine
 	RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opts ...WorkflowOption) (WorkflowHandle[any], error) // Start a new workflow execution
-	Send(_ DBOSContext, destinationID string, message any, topic string) error                                    // Send a message to another workflow
-	Recv(_ DBOSContext, topic string, timeout time.Duration) (any, error)                                         // Receive a message sent to this workflow
-	SetEvent(_ DBOSContext, key string, message any) error                                                        // Set a key-value event for this workflow
-	GetEvent(_ DBOSContext, targetWorkflowID string, key string, timeout time.Duration) (any, error)              // Get a key-value event from a target workflow
-	Sleep(_ DBOSContext, duration time.Duration) (time.Duration, error)                                           // Durable sleep that survives workflow recovery
-	GetWorkflowID() (string, error)                                                                               // Get the current workflow ID (only available within workflows)
-	GetStepID() (int, error)                                                                                      // Get the current step ID (only available within workflows)
+	Send(_ DBOSContext, destinationID string, message any, topic string) error                                  // Send a message to another workflow
+	Recv(_ DBOSContext, topic string, timeout time.Duration) (any, error)                                       // Receive a message sent to this workflow
+	SetEvent(_ DBOSContext, key string, message any) error                                                      // Set a key-value event for this workflow
+	GetEvent(_ DBOSContext, targetWorkflowID string, key string, timeout time.Duration) (any, error)            // Get a key-value event from a target workflow
+	Sleep(_ DBOSContext, duration time.Duration) (time.Duration, error)                                         // Durable sleep that survives workflow recovery
+	GetWorkflowID() (string, error)                                                                             // Get the current workflow ID (only available within workflows)
+	GetStepID() (int, error)                                                                                    // Get the current step ID (only available within workflows)
 
 	// Workflow management
 	RetrieveWorkflow(_ DBOSContext, workflowID string) (WorkflowHandle[any], error)                                       // Get a handle to an existing workflow

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"reflect"
 	"runtime"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -1142,36 +1141,18 @@ type stepResultChan struct {
 // Private interface
 // Add docs
 func (c *dbosContext) Go(ctx DBOSContext, fn StepFunc, stepID int, opts ...StepOption) (any, error) {
-	var wg sync.WaitGroup
-	stepResult := make(chan stepResultChan, 1)
-
-	wg.Add(1)
-
+	result := make(chan stepResultChan, 1)
 	go func() {
-		defer wg.Done()
 		res, err := c.RunAsStep(ctx, fn, c.WithNextStepID(stepID))
-		if err != nil {
-			stepRes := stepResultChan{
-				result: nil,
-				err:    err,
-			}
-			stepResult <- stepRes
-			return
-		}
-
-		stepRes := stepResultChan{
+		result <- stepResultChan{
 			result: res,
-			err:    nil,
+			err:    err,
 		}
-		stepResult <- stepRes
 	}()
 
-	wg.Wait()
-	close(stepResult)
-
-	res := <-stepResult
-
-	return res.result, res.err
+	resultChan := <-result
+	close(result)
+	return resultChan.result, resultChan.err
 }
 
 /****************************************/

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1091,11 +1091,7 @@ func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, opts ...StepOption) 
 	return stepOutput, stepError
 }
 
-// how can I setup the sdk in a way to test it locally with other files?
-
-// Package level
-// Run step function using Go routines
-// Add odocs
+// TODO: Add docs --- will add once I get the implementation right
 func Go[R any](ctx DBOSContext, fn Step[R], opts ...StepOption) (R, error) {
 	if ctx == nil {
 		return *new(R), newStepExecutionError("", "", "ctx cannot be nil")
@@ -1133,13 +1129,13 @@ func Go[R any](ctx DBOSContext, fn Step[R], opts ...StepOption) (R, error) {
 	return typedResult, err
 }
 
+// TODO: move type above -- keeping it here for in case I need to modify quickly
 type stepResultChan struct {
 	result any
 	err    error
 }
 
-// Private interface
-// Add docs
+// TODO: Add docs --- will add once I get the implementation right
 func (c *dbosContext) Go(ctx DBOSContext, fn StepFunc, stepID int, opts ...StepOption) (any, error) {
 	result := make(chan stepResultChan, 1)
 	go func() {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1117,11 +1117,10 @@ func Go[R any](ctx DBOSContext, fn Step[R], opts ...StepOption) (R, error) {
 	opts = append(opts, WithNextStepID(stepID))
 
 	// Type-erase the function
-
 	typeErasedFn := StepFunc(func(ctx context.Context) (any, error) { return fn(ctx) })
 
 	// run step inside a Go routine by passing stepID
-	result, err := ctx.Go(ctx, typeErasedFn, stepID, opts...)
+	result, err := ctx.Go(ctx, typeErasedFn, opts...)
 
 	// Step function could return a nil result
 	if result == nil {
@@ -1142,7 +1141,7 @@ type stepResultChan struct {
 }
 
 // TODO: Add docs --- will add once I get the implementation right
-func (c *dbosContext) Go(ctx DBOSContext, fn StepFunc, stepID int, opts ...StepOption) (any, error) {
+func (c *dbosContext) Go(ctx DBOSContext, fn StepFunc, opts ...StepOption) (any, error) {
 	result := make(chan stepResultChan, 1)
 	go func() {
 		res, err := c.RunAsStep(ctx, fn, opts...)

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"reflect"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -838,6 +839,7 @@ type StepOptions struct {
 	baseInterval  time.Duration // Initial delay between retries (default: 100ms)
 	maxInterval   time.Duration // Maximum delay between retries (default: 5s)
 	stepName      string        // Custom name for the step (defaults to function name)
+	stepID        int
 }
 
 // setDefaults applies default values to stepOptions
@@ -897,6 +899,12 @@ func WithBaseInterval(interval time.Duration) StepOption {
 func WithMaxInterval(interval time.Duration) StepOption {
 	return func(opts *StepOptions) {
 		opts.maxInterval = interval
+	}
+}
+
+func (c *dbosContext) WithNextStepID(stepID int) StepOption {
+	return func(opts *StepOptions) {
+		opts.stepID = stepID
 	}
 }
 
@@ -995,9 +1003,14 @@ func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, opts ...StepOption) 
 
 	// Setup step state
 	stepState := workflowState{
-		workflowID:   wfState.workflowID,
-		stepID:       wfState.NextStepID(), // crucially, this increments the step ID on the *workflow* state
+		workflowID: wfState.workflowID,
+		//	stepID:       wfState.NextStepID(), // crucially, this increments the step ID on the *workflow* state
 		isWithinStep: true,
+	}
+
+	// this logic needs to be looked at
+	if stepOpts.stepID >= 0 {
+		stepState.stepID = stepOpts.stepID
 	}
 
 	// Uncancellable context for DBOS operations
@@ -1077,6 +1090,88 @@ func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, opts ...StepOption) 
 	}
 
 	return stepOutput, stepError
+}
+
+// how can I setup the sdk in a way to test it locally with other files?
+
+// Package level
+// Run step function using Go routines
+// Add odocs
+func Go[R any](ctx DBOSContext, fn Step[R], opts ...StepOption) (R, error) {
+	if ctx == nil {
+		return *new(R), newStepExecutionError("", "", "ctx cannot be nil")
+	}
+
+	if fn == nil {
+		return *new(R), newStepExecutionError("", "", "step function cannot be nil")
+	}
+
+	// Append WithStepName option to ensure the step name is set. This will not erase a user-provided step name
+	stepName := runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+	opts = append(opts, WithStepName(stepName))
+
+	// create a determistic step ID
+	wfState, ok := ctx.Value(workflowStateKey).(*workflowState)
+	if !ok || wfState == nil {
+		return *new(R), newStepExecutionError("", stepName, "workflow state not found in context: are you running this step within a workflow?")
+	}
+	stepID := wfState.NextStepID()
+
+	typeErasedFn := StepFunc(func(ctx context.Context) (any, error) { return fn(ctx) })
+
+	// run step inside a Go routine by passing stepID
+	result, err := ctx.Go(ctx, typeErasedFn, stepID, opts...)
+
+	// Step function could return a nil result
+	if result == nil {
+		return *new(R), err
+	}
+	// Otherwise type-check and cast the result
+	typedResult, ok := result.(R)
+	if !ok {
+		return *new(R), fmt.Errorf("unexpected result type: expected %T, got %T", *new(R), result)
+	}
+	return typedResult, err
+}
+
+type stepResultChan struct {
+	result any
+	err    error
+}
+
+// Private interface
+// Add docs
+func (c *dbosContext) Go(ctx DBOSContext, fn StepFunc, stepID int, opts ...StepOption) (any, error) {
+	var wg sync.WaitGroup
+	stepResult := make(chan stepResultChan, 1)
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		res, err := c.RunAsStep(ctx, fn, c.WithNextStepID(stepID))
+		if err != nil {
+			stepRes := stepResultChan{
+				result: nil,
+				err:    err,
+			}
+			stepResult <- stepRes
+			return
+		}
+
+		stepRes := stepResultChan{
+			result: res,
+			err:    nil,
+		}
+		stepResult <- stepRes
+	}()
+
+	wg.Wait()
+	close(stepResult)
+
+	res := <-stepResult
+
+	return res.result, res.err
 }
 
 /****************************************/

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -901,7 +901,7 @@ func WithMaxInterval(interval time.Duration) StepOption {
 	}
 }
 
-func (c *dbosContext) WithNextStepID(stepID int) StepOption {
+func WithNextStepID(stepID int) StepOption {
 	return func(opts *StepOptions) {
 		opts.stepID = stepID
 	}
@@ -1111,6 +1111,9 @@ func Go[R any](ctx DBOSContext, fn Step[R], opts ...StepOption) (R, error) {
 		return *new(R), newStepExecutionError("", stepName, "workflow state not found in context: are you running this step within a workflow?")
 	}
 	stepID := wfState.NextStepID()
+	opts = append(opts, WithNextStepID(stepID))
+
+	// Type-erase the function
 
 	typeErasedFn := StepFunc(func(ctx context.Context) (any, error) { return fn(ctx) })
 
@@ -1129,7 +1132,7 @@ func Go[R any](ctx DBOSContext, fn Step[R], opts ...StepOption) (R, error) {
 	return typedResult, err
 }
 
-// TODO: move type above -- keeping it here for in case I need to modify quickly
+// TODO: move type above -- keeping it here for in case I need to modify it quickly
 type stepResultChan struct {
 	result any
 	err    error
@@ -1139,7 +1142,7 @@ type stepResultChan struct {
 func (c *dbosContext) Go(ctx DBOSContext, fn StepFunc, stepID int, opts ...StepOption) (any, error) {
 	result := make(chan stepResultChan, 1)
 	go func() {
-		res, err := c.RunAsStep(ctx, fn, c.WithNextStepID(stepID))
+		res, err := c.RunAsStep(ctx, fn, opts...)
 		result <- stepResultChan{
 			result: res,
 			err:    err,

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -833,12 +833,12 @@ type Step[R any] func(ctx context.Context) (R, error)
 
 // StepOptions holds the configuration for step execution using functional options pattern.
 type StepOptions struct {
-	maxRetries    int           // Maximum number of retry attempts (0 = no retries)
-	backoffFactor float64       // Exponential backoff multiplier between retries (default: 2.0)
-	baseInterval  time.Duration // Initial delay between retries (default: 100ms)
-	maxInterval   time.Duration // Maximum delay between retries (default: 5s)
-	stepName      string        // Custom name for the step (defaults to function name)
-	stepID        int
+	maxRetries         int           // Maximum number of retry attempts (0 = no retries)
+	backoffFactor      float64       // Exponential backoff multiplier between retries (default: 2.0)
+	baseInterval       time.Duration // Initial delay between retries (default: 100ms)
+	maxInterval        time.Duration // Maximum delay between retries (default: 5s)
+	stepName           string        // Custom name for the step (defaults to function name)
+	preGeneratedStepID *int          // Pre generated stepID in case we want to run the function in a Go routine
 }
 
 // setDefaults applies default values to stepOptions
@@ -903,7 +903,7 @@ func WithMaxInterval(interval time.Duration) StepOption {
 
 func WithNextStepID(stepID int) StepOption {
 	return func(opts *StepOptions) {
-		opts.stepID = stepID
+		opts.preGeneratedStepID = &stepID
 	}
 }
 
@@ -1000,16 +1000,19 @@ func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, opts ...StepOption) 
 		return fn(c)
 	}
 
-	// Setup step state
-	stepState := workflowState{
-		workflowID: wfState.workflowID,
-		//	stepID:       wfState.NextStepID(), // crucially, this increments the step ID on the *workflow* state
-		isWithinStep: true,
+	// Get stepID if it has been pre generated
+	var stepID int
+	if stepOpts.preGeneratedStepID != nil {
+		stepID = *stepOpts.preGeneratedStepID
+	} else {
+		stepID = wfState.NextStepID() // crucially, this increments the step ID on the *workflow* state
 	}
 
-	// this logic needs to be looked at
-	if stepOpts.stepID >= 0 {
-		stepState.stepID = stepOpts.stepID
+	// Setup step state
+	stepState := workflowState{
+		workflowID:   wfState.workflowID,
+		stepID:       stepID,
+		isWithinStep: true,
 	}
 
 	// Uncancellable context for DBOS operations


### PR DESCRIPTION
## Summary
Adds support for running steps inside goroutines with deterministic step ID generation.

This is by no means the final solution, it's a PR to get feedback.

## Problem
Currently, running steps inside goroutines causes non-deterministic step ID generation due to race conditions:


## Solution

Pre-generate step IDs before launching goroutines:

- Added Go() function that pre-generates step IDs and runs steps in goroutines
- Added WithNextStepID option to pass pre-generated IDs to RunAsStep
- Modified RunAsStep to use pre-generated IDs when provided

## Open Questions

- Does this satisfy the UX you had in mind @maxdml ? I am a bit unsure as to what you had in mind but gave it a go anyway. 
- Might be worth giving me fuller example of how you think the UX would work inside the workflow

## ToDos
- I still need to add some docs
- Still need to write tests for it as well