### PR TITLE
Getevent recv durable sleep

### DIFF
--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -264,7 +264,7 @@ func (qr *queueRunner) run(ctx *dbosContext) {
 		// Sleep with jittered interval, but allow early exit on context cancellation
 		select {
 		case <-ctx.Done():
-			qr.logger.Info("Queue runner stopping due to context cancellation", "cause", context.Cause(ctx))
+			qr.logger.Debug("Queue runner stopping due to context cancellation", "cause", context.Cause(ctx))
 			qr.completionChan <- struct{}{}
 			return
 		case <-time.After(sleepDuration):

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -111,7 +111,7 @@ func createDatabaseIfNotExists(ctx context.Context, databaseURL string, logger *
 		if err != nil {
 			return newInitializationError(fmt.Sprintf("failed to create database %s: %v", dbName, err))
 		}
-		logger.Info("Database created", "name", dbName)
+		logger.Debug("Database created", "name", dbName)
 	}
 
 	return nil
@@ -304,7 +304,7 @@ func (s *sysDB) launch(ctx context.Context) {
 }
 
 func (s *sysDB) shutdown(ctx context.Context, timeout time.Duration) {
-	s.logger.Info("DBOS: Closing system database connection pool")
+	s.logger.Debug("DBOS: Closing system database connection pool")
 	if s.pool != nil {
 		s.pool.Close()
 	}
@@ -319,7 +319,7 @@ func (s *sysDB) shutdown(ctx context.Context, timeout time.Duration) {
 
 	if s.launched {
 		// Wait for the notification loop to exit
-		s.logger.Info("DBOS: Waiting for notification listener loop to finish")
+		s.logger.Debug("DBOS: Waiting for notification listener loop to finish")
 		select {
 		case <-s.notificationLoopDone:
 		case <-time.After(timeout):
@@ -1530,7 +1530,7 @@ func (s *sysDB) notificationListenerLoop(ctx context.Context) {
 		s.notificationLoopDone <- struct{}{}
 	}()
 
-	s.logger.Info("DBOS: Starting notification listener loop")
+	s.logger.Debug("DBOS: Starting notification listener loop")
 	mrr := s.notificationListenerConnection.Exec(ctx, fmt.Sprintf("LISTEN %s; LISTEN %s", _DBOS_NOTIFICATIONS_CHANNEL, _DBOS_WORKFLOW_EVENTS_CHANNEL))
 	results, err := mrr.ReadAll()
 	if err != nil {
@@ -1558,7 +1558,7 @@ func (s *sysDB) notificationListenerLoop(ctx context.Context) {
 		if err != nil {
 			// Context cancellation
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				s.logger.Info("Notification listener loop exiting due to context cancellation", "cause", context.Cause(ctx), "error", err)
+				s.logger.Debug("Notification listener loop exiting due to context cancellation", "cause", context.Cause(ctx), "error", err)
 				return
 			}
 

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1241,7 +1241,7 @@ func GetEvent[R any](ctx DBOSContext, targetWorkflowID, key string, timeout time
 }
 
 func (c *dbosContext) Sleep(_ DBOSContext, duration time.Duration) (time.Duration, error) {
-	return c.systemDB.sleep(c, duration)
+	return c.systemDB.sleep(c, duration, -1)
 }
 
 // Sleep pauses workflow execution for the specified duration.

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1241,7 +1241,7 @@ func GetEvent[R any](ctx DBOSContext, targetWorkflowID, key string, timeout time
 }
 
 func (c *dbosContext) Sleep(_ DBOSContext, duration time.Duration) (time.Duration, error) {
-	return c.systemDB.sleep(c, duration, -1)
+	return c.systemDB.sleep(c, sleepInput{duration: duration, stepID: -1, skipSleep: false})
 }
 
 // Sleep pauses workflow execution for the specified duration.

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -2009,19 +2009,27 @@ func TestSetGetEvent(t *testing.T) {
 			assert.Equal(t, "DBOS.setEvent", step.StepName, "expected step %d to have StepName 'DBOS.setEvent'", i)
 		}
 
-		// Verify step counting for getFirstEventHandle (calls GetEvent 1 time)
+		// Verify step counting for the first get event workflow
 		getFirstSteps, err := GetWorkflowSteps(dbosCtx, getFirstEventHandle.GetWorkflowID())
 		require.NoError(t, err, "failed to get workflow steps for get first event workflow")
-		require.Len(t, getFirstSteps, 1, "expected 1 step in get first event workflow (1 GetEvent call), got %d", len(getFirstSteps))
-		assert.Equal(t, 0, getFirstSteps[0].StepID, "expected step to have StepID 0")
-		assert.Equal(t, "DBOS.getEvent", getFirstSteps[0].StepName, "expected step to have StepName 'DBOS.getEvent'")
+		require.Len(t, getFirstSteps, 2, "expected 2 steps in get first event workflow (getEvent + durable sleep), got %d", len(getFirstSteps))
+		// First step should be the getEvent step with stepID 0
+		assert.Equal(t, 0, getFirstSteps[0].StepID, "expected first step to have StepID 0")
+		assert.Equal(t, "DBOS.getEvent", getFirstSteps[0].StepName, "expected first step to have StepName 'DBOS.getEvent'")
+		// Second step should be the sleep step with stepID 1
+		assert.Equal(t, 1, getFirstSteps[1].StepID, "expected second step to have StepID 1")
+		assert.Equal(t, "DBOS.sleep", getFirstSteps[1].StepName, "expected second step to have StepName 'DBOS.sleep'")
 
-		// Verify step counting for getSecondEventHandle (calls GetEvent 1 time)
+		// Verify step counting for the second get event workflow
 		getSecondSteps, err := GetWorkflowSteps(dbosCtx, getSecondEventHandle.GetWorkflowID())
 		require.NoError(t, err, "failed to get workflow steps for get second event workflow")
-		require.Len(t, getSecondSteps, 1, "expected 1 step in get second event workflow (1 GetEvent call), got %d", len(getSecondSteps))
-		assert.Equal(t, 0, getSecondSteps[0].StepID, "expected step to have StepID 0")
-		assert.Equal(t, "DBOS.getEvent", getSecondSteps[0].StepName, "expected step to have StepName 'DBOS.getEvent'")
+		require.Len(t, getSecondSteps, 2, "expected 2 steps in get second event workflow (getEvent + durable sleep), got %d", len(getSecondSteps))
+		// First step should be the getEvent step with stepID 0
+		assert.Equal(t, 0, getSecondSteps[0].StepID, "expected first step to have StepID 0")
+		assert.Equal(t, "DBOS.getEvent", getSecondSteps[0].StepName, "expected first step to have StepName 'DBOS.getEvent'")
+		// Second step should be the sleep step with stepID 1
+		assert.Equal(t, 1, getSecondSteps[1].StepID, "expected second step to have StepID 1")
+		assert.Equal(t, "DBOS.sleep", getSecondSteps[1].StepName, "expected second step to have StepName 'DBOS.sleep'")
 	})
 
 	t.Run("GetEventFromOutsideWorkflow", func(t *testing.T) {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1790,6 +1790,66 @@ func TestSendRecv(t *testing.T) {
 		// Ensure total results match expected
 		assert.Equal(t, numReceivers, timeoutCount+errorCount, "expected total results to equal number of receivers")
 	})
+
+	t.Run("durableSleep", func(t *testing.T) {
+		// Clear events before starting
+		receiveIdempotencyStartEvent.Clear()
+		receiveIdempotencyStopEvent.Clear()
+
+		// First execution: Start workflow that will timeout after 3 seconds and then block
+		workflowID := uuid.NewString()
+		startTime := time.Now()
+
+		handle1, err := RunWorkflow(dbosCtx, receiveIdempotencyWorkflow, "durable-sleep-topic", WithWorkflowID(workflowID))
+		require.NoError(t, err, "failed to start first receive workflow")
+
+		// Wait for the workflow to signal it has completed the Recv call (which includes the sleep)
+		receiveIdempotencyStartEvent.Wait()
+		receiveIdempotencyStartEvent.Clear()
+
+		// Verify it took at least close to 3 seconds to reach this point (the Recv timeout)
+		elapsed := time.Since(startTime)
+		require.GreaterOrEqual(t, elapsed, 2900*time.Millisecond, "expected workflow to sleep for close to 3 seconds, but elapsed time was %v", elapsed)
+
+		// Now the workflow is blocked on receiveIdempotencyStopEvent.Wait()
+		// Let's recover it to test that the sleep is not repeated
+		recoveredHandles, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
+		require.NoError(t, err, "failed to recover pending workflows")
+		require.Len(t, recoveredHandles, 1, "expected 1 recovered handle, got %d", len(recoveredHandles))
+
+		// The recovered workflow should proceed quickly since it already completed the sleep
+		receiveIdempotencyStartEvent.Wait()
+
+		// Verify that the recovery was fast (no additional 3-second sleep)
+		secondElapsed := time.Since(startTime)
+		additionalTime := secondElapsed - elapsed
+		require.Less(t, additionalTime, 500*time.Millisecond, "expected recovery to be fast (additional time less than 500ms), but additional time was %v", additionalTime)
+
+		// Complete the workflow
+		receiveIdempotencyStopEvent.Set()
+
+		// Get results from both handles - they should be the same (empty string due to timeout)
+		result1, err := handle1.GetResult()
+		require.NoError(t, err, "failed to get result from first workflow")
+		require.Equal(t, "", result1, "expected empty result from first workflow due to timeout")
+
+		result2, err := recoveredHandles[0].GetResult()
+		require.NoError(t, err, "failed to get result from recovered workflow")
+		require.Equal(t, result1, result2, "expected both workflow results to be the same")
+
+		// Verify that there are exactly 2 steps: recv and sleep
+		steps, err := GetWorkflowSteps(dbosCtx, workflowID)
+		require.NoError(t, err, "failed to get workflow steps")
+		require.Len(t, steps, 2, "expected 2 steps (recv + sleep), got %d", len(steps))
+
+		// First step should be recv
+		require.Equal(t, 0, steps[0].StepID, "expected first step ID to be 0")
+		require.Equal(t, "DBOS.recv", steps[0].StepName, "expected first step to be recv")
+
+		// Second step should be sleep
+		require.Equal(t, 1, steps[1].StepID, "expected second step ID to be 1")
+		require.Equal(t, "DBOS.sleep", steps[1].StepName, "expected second step to be sleep")
+	})
 }
 
 var (
@@ -2340,6 +2400,7 @@ func TestSetGetEvent(t *testing.T) {
 
 		// Wait for the workflow to signal it has completed the GetEvent call (which includes the sleep)
 		getEventStartIdempotencyEvent.Wait()
+		getEventStartIdempotencyEvent.Clear()
 
 		// Verify it took at least close to 3 seconds to reach this point (the GetEvent timeout)
 		elapsed := time.Since(startTime)


### PR DESCRIPTION
- Support durable sleep for GetEvent and Recv (this essentially records a sleep step when sleep is needed)
- Be less verbose in the DBOS logs