### PR TITLE
Fix comms durable sleeps

### DIFF
--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1778,6 +1778,9 @@ func (s *sysDB) recv(ctx context.Context, input recvInput) (any, error) {
 			s.logger.Debug("Received notification on condition variable", "payload", payload)
 		case <-time.After(timeout):
 			s.logger.Warn("Recv() timeout reached", "payload", payload, "timeout", input.Timeout)
+		case <-ctx.Done():
+			s.logger.Warn("Recv() context cancelled", "payload", payload, "cause", context.Cause(ctx))
+			return nil, ctx.Err()
 		}
 	}
 

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1727,10 +1727,7 @@ func (s *sysDB) recv(ctx context.Context, input recvInput) (any, error) {
 		return nil, err
 	}
 	if recordedResult != nil {
-		if recordedResult.output != nil {
-			return recordedResult.output, nil
-		}
-		return nil, fmt.Errorf("no output recorded in the last recv")
+		return recordedResult.output, nil
 	}
 
 	// First check if there's already a receiver for this workflow/topic to avoid unnecessary database load

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1782,17 +1782,6 @@ func (s *sysDB) recv(ctx context.Context, input recvInput) (any, error) {
 			s.logger.Warn("Recv() context cancelled", "payload", payload, "cause", context.Cause(ctx))
 			return nil, ctx.Err()
 		}
-	} else {
-		// Do a "zero" sleep to record the sleep step in the workflow history
-		// This is to handle cases were consecutive Recv calls for the same key are made
-		// The key would exist and without this, the step IDs would be: 0 recv, 1 sleep, 2 recv, 4 recv, etc
-		_, err := s.sleep(ctx, sleepInput{
-			duration: 0,
-			stepID:   &sleepStepID,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to sleep before recv timeout: %w", err)
-		}
 	}
 
 	// Find the oldest message and delete it atomically

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1986,7 +1986,7 @@ func (s *sysDB) getEvent(ctx context.Context, input getEventInput) (any, error) 
 		return nil, fmt.Errorf("failed to query workflow event: %w", err)
 	}
 
-	if err == pgx.ErrNoRows { // valueString should never be `nil`
+	if err == pgx.ErrNoRows {
 		// Wait for notification with timeout using condition variable
 		done := make(chan struct{})
 		go func() {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1535,10 +1535,10 @@ func TestSendRecv(t *testing.T) {
 		// Verify step counting for receive workflow (receiveWorkflow calls Recv 3 times)
 		receiveSteps, err := GetWorkflowSteps(dbosCtx, receiveHandle.GetWorkflowID())
 		require.NoError(t, err, "failed to get workflow steps for receive workflow")
-		require.Len(t, receiveSteps, 4, "expected 4 steps in receive workflow (3 Recv calls + 1 sleep call during the first recv), got %d", len(receiveSteps))
+		require.Len(t, receiveSteps, 6, "expected 4 steps in receive workflow (3 Recv calls + 1 sleep call during the first recv), got %d", len(receiveSteps))
 		for i, step := range receiveSteps {
 			require.Equal(t, i, step.StepID, "expected step %d to have correct StepID", i)
-			if i == 1 {
+			if i%2 == 1 {
 				require.Equal(t, "DBOS.sleep", step.StepName, "expected step %d to have StepName 'DBOS.sleep'", i)
 			} else {
 				require.Equal(t, "DBOS.recv", step.StepName, "expected step %d to have StepName 'DBOS.recv'", i)
@@ -1654,10 +1654,10 @@ func TestSendRecv(t *testing.T) {
 		// Verify step counting for receive workflow (calls Recv 3 times, each with sleep)
 		receiveSteps, err := GetWorkflowSteps(dbosCtx, receiveHandle.GetWorkflowID())
 		require.NoError(t, err, "failed to get workflow steps for receive workflow")
-		require.Len(t, receiveSteps, 4, "expected 4 steps in receive workflow (3 Recv calls + 1 sleep calls), got %d", len(receiveSteps))
+		require.Len(t, receiveSteps, 6, "expected 4 steps in receive workflow (3 Recv calls + 1 sleep calls), got %d", len(receiveSteps))
 		for i, step := range receiveSteps {
 			require.Equal(t, i, step.StepID, "expected step %d to have correct StepID", i)
-			if i == 1 {
+			if i%2 == 1 {
 				require.Equal(t, "DBOS.sleep", step.StepName, "expected recv step %d to have StepName 'DBOS.sleep'", i)
 			} else {
 				require.Equal(t, "DBOS.recv", step.StepName, "expected recv step %d to have StepName 'DBOS.recv'", i)

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1535,15 +1535,12 @@ func TestSendRecv(t *testing.T) {
 		// Verify step counting for receive workflow (receiveWorkflow calls Recv 3 times)
 		receiveSteps, err := GetWorkflowSteps(dbosCtx, receiveHandle.GetWorkflowID())
 		require.NoError(t, err, "failed to get workflow steps for receive workflow")
-		require.Len(t, receiveSteps, 6, "expected 4 steps in receive workflow (3 Recv calls + 1 sleep call during the first recv), got %d", len(receiveSteps))
-		for i, step := range receiveSteps {
-			require.Equal(t, i, step.StepID, "expected step %d to have correct StepID", i)
-			if i%2 == 1 {
-				require.Equal(t, "DBOS.sleep", step.StepName, "expected step %d to have StepName 'DBOS.sleep'", i)
-			} else {
-				require.Equal(t, "DBOS.recv", step.StepName, "expected step %d to have StepName 'DBOS.recv'", i)
-			}
-		}
+		require.Len(t, receiveSteps, 4, "expected 4 steps in receive workflow (3 Recv calls + 1 sleep call during the first recv), got %d", len(receiveSteps))
+		// Steps 0, 2 and 4 are recv
+		require.Equal(t, "DBOS.recv", receiveSteps[0].StepName, "expected step 0 to have StepName 'DBOS.recv'")
+		require.Equal(t, "DBOS.sleep", receiveSteps[1].StepName, "expected step 1 to have StepName 'DBOS.sleep'")
+		require.Equal(t, "DBOS.recv", receiveSteps[2].StepName, "expected step 2 to have StepName 'DBOS.recv'")
+		require.Equal(t, "DBOS.recv", receiveSteps[3].StepName, "expected step 3 to have StepName 'DBOS.recv'")
 	})
 
 	t.Run("SendRecvCustomStruct", func(t *testing.T) {
@@ -1654,15 +1651,12 @@ func TestSendRecv(t *testing.T) {
 		// Verify step counting for receive workflow (calls Recv 3 times, each with sleep)
 		receiveSteps, err := GetWorkflowSteps(dbosCtx, receiveHandle.GetWorkflowID())
 		require.NoError(t, err, "failed to get workflow steps for receive workflow")
-		require.Len(t, receiveSteps, 6, "expected 4 steps in receive workflow (3 Recv calls + 1 sleep calls), got %d", len(receiveSteps))
-		for i, step := range receiveSteps {
-			require.Equal(t, i, step.StepID, "expected step %d to have correct StepID", i)
-			if i%2 == 1 {
-				require.Equal(t, "DBOS.sleep", step.StepName, "expected recv step %d to have StepName 'DBOS.sleep'", i)
-			} else {
-				require.Equal(t, "DBOS.recv", step.StepName, "expected recv step %d to have StepName 'DBOS.recv'", i)
-			}
-		}
+		require.Len(t, receiveSteps, 4, "expected 4 steps in receive workflow (3 Recv calls + 1 sleep calls), got %d", len(receiveSteps))
+		// Steps 0, 2 and 4 are recv
+		require.Equal(t, "DBOS.recv", receiveSteps[0].StepName, "expected step 0 to have StepName 'DBOS.recv'")
+		require.Equal(t, "DBOS.sleep", receiveSteps[1].StepName, "expected step 1 to have StepName 'DBOS.sleep'")
+		require.Equal(t, "DBOS.recv", receiveSteps[2].StepName, "expected step 2 to have StepName 'DBOS.recv'")
+		require.Equal(t, "DBOS.recv", receiveSteps[3].StepName, "expected step 3 to have StepName 'DBOS.recv'")
 	})
 	t.Run("SendRecvIdempotency", func(t *testing.T) {
 		// Start the receive workflow and wait for it to be ready


### PR DESCRIPTION
- Fix a bug where sleep steps ID were not always generated when `recv`/`getEvent` skipped sleeping (e.g., a value was already found, during recovery)
- Fix a bug were `recv` would return an error if it recorded a timeout value
- Handle context cancellation during `recv` (addresses #86)