### PR TITLE
use custom pool for everything in systemp db

### DIFF
--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -506,7 +506,7 @@ func TestCustomPool(t *testing.T) {
 		return receivedMsg, nil
 	}
 
-	t.Run("NewSystemDatabaseWithCustomPool", func(t *testing.T) {
+	t.Run("CustomPool", func(t *testing.T) {
 		// Custom Pool
 		databaseURL := getDatabaseURL()
 		poolConfig, err := pgxpool.ParseConfig(databaseURL)

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -3,6 +3,7 @@ package dbos
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -463,6 +464,48 @@ func TestCustomSystemDBSchema(t *testing.T) {
 }
 
 func TestCustomPool(t *testing.T) {
+	// Test workflows for custom pool testing
+	type customPoolWorkflowInput struct {
+		PartnerWorkflowID string
+		Message           string
+	}
+
+	// Workflow A: Uses Send() and GetEvent() - waits for workflow B
+	sendGetEventWorkflowCustom := func(ctx DBOSContext, input customPoolWorkflowInput) (string, error) {
+		// Send a message to the partner workflow
+		err := Send(ctx, input.PartnerWorkflowID, input.Message, "custom-pool-topic")
+		if err != nil {
+			return "", err
+		}
+
+		// Wait for an event from the partner workflow
+		result, err := GetEvent[string](ctx, input.PartnerWorkflowID, "custom-response-key", 5*time.Hour)
+		if err != nil {
+			return "", err
+		}
+
+		return result, nil
+	}
+
+	// Workflow B: Uses Recv() and SetEvent() - waits for workflow A
+	recvSetEventWorkflowCustom := func(ctx DBOSContext, input customPoolWorkflowInput) (string, error) {
+		// Receive a message from the partner workflow
+		receivedMsg, err := Recv[string](ctx, "custom-pool-topic", 5*time.Hour)
+		if err != nil {
+			return "", err
+		}
+
+		time.Sleep(1 * time.Second)
+
+		// Set an event for the partner workflow
+		err = SetEvent(ctx, "custom-response-key", "response-from-custom-pool-workflow")
+		if err != nil {
+			return "", err
+		}
+
+		return receivedMsg, nil
+	}
+
 	t.Run("NewSystemDatabaseWithCustomPool", func(t *testing.T) {
 		// Custom Pool
 		databaseURL := getDatabaseURL()
@@ -506,6 +549,60 @@ func TestCustomPool(t *testing.T) {
 		assert.Equal(t, 2*time.Hour, sysdbConfig.MaxConnLifetime)
 		assert.Equal(t, 2*time.Minute, sysdbConfig.MaxConnIdleTime)
 		assert.Equal(t, 10*time.Second, sysdbConfig.ConnConfig.ConnectTimeout)
+
+		// Register the test workflows
+		RegisterWorkflow(customdbosContext, sendGetEventWorkflowCustom)
+		RegisterWorkflow(customdbosContext, recvSetEventWorkflowCustom)
+
+		// Launch the DBOS context
+		err = customdbosContext.Launch()
+		require.NoError(t, err)
+		defer dbosCtx.Shutdown(1 * time.Minute)
+
+		// Test RunWorkflow - start both workflows that will communicate with each other
+		workflowAID := uuid.NewString()
+		workflowBID := uuid.NewString()
+
+		// Start workflow B first (receiver)
+		handleB, err := RunWorkflow(customdbosContext, recvSetEventWorkflowCustom, customPoolWorkflowInput{
+			PartnerWorkflowID: workflowAID,
+			Message:           "custom-pool-message-from-b",
+		}, WithWorkflowID(workflowBID))
+		require.NoError(t, err, "failed to start recvSetEventWorkflowCustom")
+
+		// Small delay to ensure workflow B is ready to receive
+		time.Sleep(100 * time.Millisecond)
+
+		// Start workflow A (sender)
+		handleA, err := RunWorkflow(customdbosContext, sendGetEventWorkflowCustom, customPoolWorkflowInput{
+			PartnerWorkflowID: workflowBID,
+			Message:           "custom-pool-message-from-a",
+		}, WithWorkflowID(workflowAID))
+		require.NoError(t, err, "failed to start sendGetEventWorkflowCustom")
+
+		// Wait for both workflows to complete
+		resultA, err := handleA.GetResult()
+		require.NoError(t, err, "failed to get result from workflow A")
+		assert.Equal(t, "response-from-custom-pool-workflow", resultA, "workflow A should receive response from workflow B")
+
+		resultB, err := handleB.GetResult()
+		require.NoError(t, err, "failed to get result from workflow B")
+		assert.Equal(t, "custom-pool-message-from-a", resultB, "workflow B should receive message from workflow A")
+
+		// Test GetWorkflowSteps
+		stepsA, err := GetWorkflowSteps(customdbosContext, workflowAID)
+		require.NoError(t, err, "failed to get workflow A steps")
+		require.Len(t, stepsA, 3, "workflow A should have 3 steps (Send + GetEvent + Sleep)")
+		assert.Equal(t, "DBOS.send", stepsA[0].StepName, "first step should be Send")
+		assert.Equal(t, "DBOS.getEvent", stepsA[1].StepName, "second step should be GetEvent")
+		assert.Equal(t, "DBOS.sleep", stepsA[2].StepName, "third step should be Sleep")
+
+		stepsB, err := GetWorkflowSteps(customdbosContext, workflowBID)
+		require.NoError(t, err, "failed to get workflow B steps")
+		require.Len(t, stepsB, 3, "workflow B should have 3 steps (Recv + Sleep + SetEvent)")
+		assert.Equal(t, "DBOS.recv", stepsB[0].StepName, "first step should be Recv")
+		assert.Equal(t, "DBOS.sleep", stepsB[1].StepName, "second step should be Sleep")
+		assert.Equal(t, "DBOS.setEvent", stepsB[2].StepName, "third step should be SetEvent")
 	})
 
 	wf := func(ctx DBOSContext, input string) (string, error) {
@@ -538,5 +635,72 @@ func TestCustomPool(t *testing.T) {
 		// Run a workflow
 		_, err = RunWorkflow(dbosCtx, wf, "test-input")
 		require.NoError(t, err)
+	})
+
+	t.Run("InvalidCustomPool", func(t *testing.T) {
+		databaseURL := getDatabaseURL()
+		poolConfig, err := pgxpool.ParseConfig(databaseURL)
+		require.NoError(t, err)
+		poolConfig.ConnConfig.Host = "invalid-host"
+		pool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
+		require.NoError(t, err)
+
+		config := Config{
+			DatabaseURL:  databaseURL,
+			AppName:      "test-invalid-custom-pool",
+			SystemDBPool: pool,
+		}
+		_, err = NewDBOSContext(context.Background(), config)
+		require.Error(t, err)
+		dbosErr, ok := err.(*DBOSError)
+		require.True(t, ok, "expected DBOSError, got %T", err)
+		assert.Equal(t, InitializationError, dbosErr.Code)
+		expectedMsg := "Error initializing DBOS Transact: failed to create system database"
+		assert.Contains(t, dbosErr.Message, expectedMsg)
+	})
+
+	t.Run("DirectSystemDatabase", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		databaseURL := getDatabaseURL()
+		logger := slog.Default()
+
+		// Create custom pool
+		poolConfig, err := pgxpool.ParseConfig(databaseURL)
+		require.NoError(t, err)
+		poolConfig.MaxConns = 15
+		poolConfig.MinConns = 3
+		customPool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+		require.NoError(t, err)
+		defer customPool.Close()
+
+		// Create system database with custom pool
+		sysDBInput := newSystemDatabaseInput{
+			databaseURL:    databaseURL,
+			databaseSchema: "dbos_test_custom_direct",
+			customPool:     customPool,
+			logger:         logger,
+		}
+
+		systemDB, err := newSystemDatabase(ctx, sysDBInput)
+		require.NoError(t, err, "failed to create system database with custom pool")
+		require.NotNil(t, systemDB)
+
+		// Launch the system database
+		systemDB.launch(ctx)
+
+		require.Eventually(t, func() bool {
+			conn, err := systemDB.(*sysDB).pool.Acquire(ctx)
+			require.NoError(t, err)
+			defer conn.Release()
+			err = conn.Ping(ctx)
+			require.NoError(t, err)
+			return true
+		}, 5*time.Second, 100*time.Millisecond, "system database should be reachable")
+
+		// Shutdown the system database
+		cancel() // Cancel context
+		shutdownTimeout := 2 * time.Second
+		systemDB.shutdown(ctx, shutdownTimeout)
+		assert.False(t, systemDB.(*sysDB).launched)
 	})
 }

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -243,14 +243,6 @@ func newSystemDatabase(ctx context.Context, inputs newSystemDatabaseInput) (syst
 	customPool := inputs.customPool
 	logger := inputs.logger
 
-	// Displaying Masked Database URL
-	maskedDatabaseURL, err := maskPassword(databaseURL)
-	if err != nil {
-		logger.Warn("Failed to parse database URL", "error", err)
-	} else {
-		logger.Info("Masked Database URL", "url", maskedDatabaseURL)
-	}
-
 	// Validate that schema is provided
 	if databaseSchema == "" {
 		return nil, fmt.Errorf("database schema cannot be empty")
@@ -293,6 +285,14 @@ func newSystemDatabase(ctx context.Context, inputs newSystemDatabaseInput) (syst
 			return nil, fmt.Errorf("failed to create connection pool: %v", err)
 		}
 		pool = newPool
+	}
+
+	// Displaying Masked Database URL
+	maskedDatabaseURL, err := maskPassword(pool.Config().ConnString())
+	if err != nil {
+		logger.Warn("Failed to parse database URL", "error", err)
+	} else {
+		logger.Info("Masked Database URL", "url", maskedDatabaseURL)
 	}
 
 	if customPool == nil {
@@ -2520,7 +2520,6 @@ func backoffWithJitter(retryAttempt int) time.Duration {
 // maskPassword replaces the password in a database URL with asterisks
 func maskPassword(dbURL string) (string, error) {
 	parsedURL, err := url.Parse(dbURL)
-
 	if err != nil {
 		return "", err
 	}

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1646,8 +1646,8 @@ func (s *sysDB) notificationListenerLoop(ctx context.Context) {
 				s.logger.Error("Notification listener connection closed. re-acquiring")
 				poolConn.Release()
 				for {
-					if ctx.Err() != nil || strings.Contains(err.Error(), "pool closed") {
-						s.logger.Debug("Notification listener exiting (context canceled or pool closed)", "cause", context.Cause(ctx), "error", err)
+					if ctx.Err() != nil {
+						s.logger.Debug("Notification listener exiting (context canceled)", "cause", context.Cause(ctx), "error", err)
 						return
 					}
 					poolConn, err = acquire(ctx)

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -342,6 +342,7 @@ func (s *sysDB) shutdown(ctx context.Context, timeout time.Duration) {
 
 	if s.launched {
 		// Wait for the notification loop to exit
+		// The context should be cancelled prior to calling shutdown
 		select {
 		case <-s.notificationLoopDone:
 		case <-time.After(timeout):

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -363,10 +363,6 @@ func (s *sysDB) shutdown(ctx context.Context, timeout time.Duration) {
 	}
 
 	s.notificationsMap.Clear()
-	// Allow pgx health checks to complete
-	// https://github.com/jackc/pgx/blob/15bca4a4e14e0049777c1245dba4c16300fe4fd0/pgxpool/pool.go#L417
-	// These trigger go-leak alerts
-	time.Sleep(500 * time.Millisecond)
 
 	s.launched = false
 }

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -290,7 +290,8 @@ func newSystemDatabase(ctx context.Context, inputs newSystemDatabaseInput) (syst
 	// Displaying Masked Database URL
 	maskedDatabaseURL, err := maskPassword(pool.Config().ConnString())
 	if err != nil {
-		logger.Warn("Failed to parse database URL", "error", err)
+		logger.Error("Failed to parse database URL", "error", err)
+		return nil, fmt.Errorf("failed to parse database URL: %v", err)
 	}
 	logger.Info("Connecting to system database", "database_url", maskedDatabaseURL, "schema", databaseSchema)
 

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -291,9 +291,8 @@ func newSystemDatabase(ctx context.Context, inputs newSystemDatabaseInput) (syst
 	maskedDatabaseURL, err := maskPassword(pool.Config().ConnString())
 	if err != nil {
 		logger.Warn("Failed to parse database URL", "error", err)
-	} else {
-		logger.Info("Masked Database URL", "url", maskedDatabaseURL)
 	}
+	logger.Info("Connecting to system database", "database_url", maskedDatabaseURL, "schema", databaseSchema)
 
 	if customPool == nil {
 		// Create the database if it doesn't exist
@@ -2530,7 +2529,7 @@ func maskPassword(dbURL string) (string, error) {
 		_, hasPassword := parsedURL.User.Password()
 		if hasPassword {
 			// Manually construct the URL with masked password to avoid encoding
-			maskedURL := parsedURL.Scheme + "://" + username + ":********@" + parsedURL.Host + parsedURL.Path
+			maskedURL := parsedURL.Scheme + "://" + username + ":***@" + parsedURL.Host + parsedURL.Path
 			if parsedURL.RawQuery != "" {
 				maskedURL += "?" + parsedURL.RawQuery
 			}

--- a/dbos/utils_test.go
+++ b/dbos/utils_test.go
@@ -67,7 +67,6 @@ func setupDBOS(t *testing.T, dropDB bool, checkLeaks bool) DBOSContext {
 
 	// Register cleanup to run after test completes
 	t.Cleanup(func() {
-		fmt.Println("Cleaning up DBOS instance...")
 		dbosCtx.(*dbosContext).logger.Info("Cleaning up DBOS instance...")
 		if dbosCtx != nil {
 			dbosCtx.Shutdown(30 * time.Second) // Wait for workflows to finish and shutdown admin server and system database
@@ -77,8 +76,9 @@ func setupDBOS(t *testing.T, dropDB bool, checkLeaks bool) DBOSContext {
 			goleak.VerifyNone(t,
 				// Ignore pgx health checks
 				// https://github.com/jackc/pgx/blob/15bca4a4e14e0049777c1245dba4c16300fe4fd0/pgxpool/pool.go#L417
-				goleak.IgnoreTopFunction("github.com/jackc/pgx/v5/pgxpool.(*Pool).backgroundHealthCheck"),
-				goleak.IgnoreTopFunction("github.com/jackc/pgx/v5/pgxpool.(*Pool).triggerHealthCheck"),
+				goleak.IgnoreAnyFunction("github.com/jackc/pgx/v5/pgxpool.(*Pool).backgroundHealthCheck"),
+				goleak.IgnoreAnyFunction("github.com/jackc/pgx/v5/pgxpool.(*Pool).triggerHealthCheck"),
+				goleak.IgnoreAnyFunction("github.com/jackc/pgx/v5/pgxpool.(*Pool).triggerHealthCheck.func1"),
 			)
 		}
 	})

--- a/dbos/utils_test.go
+++ b/dbos/utils_test.go
@@ -74,7 +74,12 @@ func setupDBOS(t *testing.T, dropDB bool, checkLeaks bool) DBOSContext {
 		}
 		dbosCtx = nil
 		if checkLeaks {
-			goleak.VerifyNone(t)
+			goleak.VerifyNone(t,
+				// Ignore pgx health checks
+				// https://github.com/jackc/pgx/blob/15bca4a4e14e0049777c1245dba4c16300fe4fd0/pgxpool/pool.go#L417
+				goleak.IgnoreTopFunction("github.com/jackc/pgx/v5/pgxpool.(*Pool).backgroundHealthCheck"),
+				goleak.IgnoreTopFunction("github.com/jackc/pgx/v5/pgxpool.(*Pool).triggerHealthCheck"),
+			)
 		}
 	})
 


### PR DESCRIPTION
This PR:
- Ensure we use the user pgxpool for every interaction with the system DB, if provided
- Moves the notification listener to using a connection from from said pool, rather than using a standalone connection
- Make the notification listener loop resilient to connection failures (addresses #94)

Note that `OnNotification` has to be set before a connection is started (which is too late once Acquired from the pool), which is why the logic to handle notifications is now inlined in the listener.