### PR TITLE
Add package-level Launch and Shutdown wrapper functions

### DIFF
--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -579,3 +579,40 @@ func getDBOSVersion() string {
 	}
 	return "unknown"
 }
+
+// Launch launches the DBOS runtime using the provided DBOSContext.
+// This is a package-level wrapper for the DBOSContext.Launch() method.
+//
+// Example:
+//
+//	ctx, err := dbos.NewDBOSContext(context.Background(), config)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	if err := dbos.Launch(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
+func Launch(ctx DBOSContext) error {
+	if ctx == nil {
+		return fmt.Errorf("ctx cannot be nil")
+	}
+	return ctx.Launch()
+}
+
+// Shutdown gracefully shuts down the DBOS runtime using the provided DBOSContext and timeout.
+// This is a package-level wrapper for the DBOSContext.Shutdown() method.
+//
+// Example:
+//
+//	ctx, err := dbos.NewDBOSContext(context.Background(), config)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer dbos.Shutdown(ctx, 30*time.Second)
+func Shutdown(ctx DBOSContext, timeout time.Duration) {
+	if ctx == nil {
+		return
+	}
+	ctx.Shutdown(timeout)
+}


### PR DESCRIPTION
## Description
This PR adds two new package-level wrapper functions `Launch()` and `Shutdown()` to maintain 1:1 parity between `DBOSContext` interface methods and package-level functions.