### PR TITLE
Add queue option

### DIFF
--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -14,6 +14,9 @@ import (
 const (
 	_DBOS_INTERNAL_QUEUE_NAME        = "_dbos_internal_queue"
 	_DEFAULT_MAX_TASKS_PER_ITERATION = 100
+	_DEFAULT_BASE_INTERVAL           = 1.0
+	_DEFAULT_MAX_INTERVAL            = 120.0
+	_DEFAULT_MIN_INTERVAL            = 1.0
 )
 
 // RateLimiter configures rate limiting for workflow queue execution.
@@ -159,11 +162,21 @@ type queueRunner struct {
 	completionChan chan struct{}
 }
 
-func newQueueRunner(logger *slog.Logger) *queueRunner {
+func newQueueRunner(logger *slog.Logger, config QueueConfig) *queueRunner {
+	if config.BaseInterval == 0 {
+		config.BaseInterval = _DEFAULT_BASE_INTERVAL
+	}
+	if config.MinInterval == 0 {
+		config.MinInterval = _DEFAULT_MIN_INTERVAL
+	}
+	if config.MaxInterval == 0 {
+		config.MaxInterval = _DEFAULT_MAX_INTERVAL
+	}
+
 	return &queueRunner{
-		baseInterval:          1.0,
-		minInterval:           1.0,
-		maxInterval:           120.0,
+		baseInterval:          config.BaseInterval,
+		minInterval:           config.MinInterval,
+		maxInterval:           config.MaxInterval,
 		backoffFactor:         2.0,
 		scalebackFactor:       0.9,
 		jitterMin:             0.95,

--- a/dbos/queues_test.go
+++ b/dbos/queues_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"reflect"
 	"runtime"
@@ -1577,5 +1578,26 @@ func TestPartitionedQueues(t *testing.T) {
 		// Now unblock partition 1 blocking workflow
 		partition1BlockEvent.Set()
 		require.True(t, queueEntriesAreCleanedUp(dbosCtx), "expected queue entries to be cleaned up after partitioned queue test")
+	})
+}
+
+func TestNewQueueRunner(t *testing.T) {
+	t.Run("init queue with default interval", func(t *testing.T) {
+		runner := newQueueRunner(slog.New(slog.NewTextHandler(os.Stdout, nil)), QueueConfig{})
+		require.Equal(t, _DEFAULT_BASE_INTERVAL, runner.baseInterval)
+		require.Equal(t, _DEFAULT_MAX_INTERVAL, runner.maxInterval)
+		require.Equal(t, _DEFAULT_MIN_INTERVAL, runner.minInterval)
+	})
+
+	t.Run("init queue with custom interval", func(t *testing.T) {
+		runner := newQueueRunner(slog.New(slog.NewTextHandler(os.Stdout, nil)), QueueConfig{
+			BaseInterval: 1,
+			MinInterval:  2,
+			MaxInterval:  3,
+		})
+		require.Equal(t, float64(1), runner.baseInterval)
+		require.Equal(t, float64(2), runner.minInterval)
+		require.Equal(t, float64(3), runner.maxInterval)
+
 	})
 }


### PR DESCRIPTION
# Description
Currently queue interval is fixed value. This PR add option to custom these values  when initialize DbOS

