### PR TITLE
read the body of the HTTP response from conductor when Dial fails

### DIFF
--- a/dbos/conductor.go
+++ b/dbos/conductor.go
@@ -246,7 +246,9 @@ func (c *conductor) connect() error {
 			body := ""
 			if resp.Body != nil {
 				bodyBytes, readErr := io.ReadAll(resp.Body)
-				resp.Body.Close()
+				if closeErr := resp.Body.Close(); closeErr != nil {
+					c.logger.Debug("Failed to close response body", "error", closeErr)
+				}
 				if readErr == nil && len(bodyBytes) > 0 {
 					body = string(bodyBytes)
 				}


### PR DESCRIPTION
fix #227 

<img width="1766" height="46" alt="Screenshot 2026-01-20 at 08 58 28" src="https://github.com/user-attachments/assets/6463bec6-898b-44ae-98ed-282385567ec2" />

