### PR TITLE
Return the correct DLQ error + test getResult returns a DLQ error

### DIFF
--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1346,7 +1346,7 @@ func (s *sysDB) awaitWorkflowResult(ctx context.Context, workflowID string, poll
 		case WorkflowStatusCancelled:
 			return outputString, newAwaitedWorkflowCancelledError(workflowID)
 		case WorkflowStatusMaxRecoveryAttemptsExceeded:
-			return outputString, newDeadLetterQueueError(workflowID, attempts-1)
+			return outputString, newDeadLetterQueueError(workflowID, attempts-2)
 		default:
 			time.Sleep(pollInterval)
 		}

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1695,7 +1695,7 @@ func TestWorkflowDeadLetterQueue(t *testing.T) {
 		require.NoError(t, err, "failed to retrieve workflow")
 		_, err = retrievedHandle.GetResult()
 		require.Error(t, err, "expected dead letter queue error but got none")
-		expectedDLQMsg := fmt.Sprintf("Workflow %s has been moved to the dead-letter queue after exceeding the maximum of %d retries", wfID, maxRecoveryAttempts+1)
+		expectedDLQMsg := fmt.Sprintf("Workflow %s has been moved to the dead-letter queue after exceeding the maximum of %d retries", wfID, maxRecoveryAttempts)
 		require.Contains(t, err.Error(), expectedDLQMsg, "expected error to mention dead-letter queue, got: %v", err)
 
 		// Verify that attempting to start a workflow with the same ID throws a DLQ error


### PR DESCRIPTION
Fix the error returned by `getResult()` and accurately test.