### PR TITLE
Fix goroutine leak when ReadStreamAsync consumer stops reading

### DIFF
--- a/dbos/client.go
+++ b/dbos/client.go
@@ -546,42 +546,56 @@ func ClientReadStreamAsync[R any](c Client, workflowID string, key string) (<-ch
 	}
 
 	typedCh := make(chan StreamValue[R], 1)
+	dbosCtx := c.(*client).dbosCtx
 
 	go func() {
 		defer close(typedCh)
 
-		customSer := c.(*client).dbosCtx.(*dbosContext).serializer
+		// send delivers v to ch, returning false if the client context is cancelled first.
+		// This prevents the goroutine from leaking even after the client is closed.
+		send := func(v StreamValue[R]) bool {
+			select {
+			case typedCh <- v:
+				return true
+			case <-dbosCtx.Done():
+				return false
+			}
+		}
+
+		customSer := dbosCtx.(*dbosContext).serializer
 
 		for streamValue := range anyCh {
 			if streamValue.Err != nil {
-				typedCh <- StreamValue[R]{Err: streamValue.Err}
+				send(StreamValue[R]{Err: streamValue.Err})
 				return
 			}
 
 			if streamValue.Closed {
-				typedCh <- StreamValue[R]{Closed: true}
+				send(StreamValue[R]{Closed: true})
 				return
 			}
 
 			entry, ok := streamValue.Value.(streamEntryWithSerialization)
 			if !ok {
-				typedCh <- StreamValue[R]{Err: fmt.Errorf("stream value is not streamEntryWithSerialization, got %T", streamValue.Value)}
+				send(StreamValue[R]{Err: fmt.Errorf("stream value is not streamEntryWithSerialization, got %T", streamValue.Value)})
 				return
 			}
 
 			decoder, resolveErr := resolveDecoder[R](entry.serialization, customSer)
 			if resolveErr != nil {
-				typedCh <- StreamValue[R]{Err: resolveErr}
+				send(StreamValue[R]{Err: resolveErr})
 				return
 			}
 
 			decodedValue, decodeErr := decoder.Decode(&entry.value)
 			if decodeErr != nil {
-				typedCh <- StreamValue[R]{Err: fmt.Errorf("decoding stream value to type %T: %w", *new(R), decodeErr)}
+				send(StreamValue[R]{Err: fmt.Errorf("decoding stream value to type %T: %w", *new(R), decodeErr)})
 				return
 			}
 
-			typedCh <- StreamValue[R]{Value: decodedValue}
+			if !send(StreamValue[R]{Value: decodedValue}) {
+				return
+			}
 		}
 	}()
 

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -1408,6 +1408,67 @@ func TestClientReadStream(t *testing.T) {
 	}
 }
 
+func TestClientReadStreamAsyncGoroutineLeak(t *testing.T) {
+	serverCtx := setupDBOS(t, setupDBOSOptions{dropDB: false, checkLeaks: true})
+
+	// Workflow that writes values then blocks waiting for a message, keeping it PENDING
+	blockingStreamWorkflow := func(ctx DBOSContext, streamKey string) (string, error) {
+		for _, v := range []string{"value1", "value2", "value3"} {
+			if err := WriteStream(ctx, streamKey, v); err != nil {
+				return "", err
+			}
+		}
+		// Block until a message arrives (long timeout keeps workflow PENDING)
+		Recv[string](ctx, "unblock", 10*time.Minute) //nolint:errcheck
+		return "done", nil
+	}
+	RegisterWorkflow(serverCtx, blockingStreamWorkflow, WithWorkflowName("BlockingStreamWorkflow"))
+	require.NoError(t, Launch(serverCtx))
+
+	databaseURL := getDatabaseURL()
+	client, err := NewClient(context.Background(), ClientConfig{DatabaseURL: databaseURL})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Shutdown(30 * time.Second) })
+
+	streamKey := "test-client-leak-stream"
+	handle, err := RunWorkflow(serverCtx, blockingStreamWorkflow, streamKey)
+	require.NoError(t, err)
+
+	// Wait until the workflow has written its 3 values by polling via ReadStreamAsync.
+	// ClientReadStream would block until the workflow finishes, so we use the async variant
+	// with a per-poll cancellable context instead.
+	require.Eventually(t, func() bool {
+		pollCtx, pollCancel := WithCancelCause(serverCtx)
+		defer pollCancel(nil)
+		ch, err := ReadStreamAsync[string](pollCtx, handle.GetWorkflowID(), streamKey)
+		if err != nil {
+			return false
+		}
+		var count int
+		for sv := range ch {
+			if sv.Err != nil || sv.Closed {
+				break
+			}
+			count++
+			if count >= 3 {
+				break
+			}
+		}
+		return count >= 3
+	}, 10*time.Second, 100*time.Millisecond)
+
+	ch, err := ClientReadStreamAsync[string](client, handle.GetWorkflowID(), streamKey)
+	require.NoError(t, err)
+
+	// Read one value then abandon the channel — goroutine must exit on client shutdown
+	streamValue := <-ch
+	require.NoError(t, streamValue.Err)
+	require.Equal(t, "value1", streamValue.Value)
+
+	// Cancel the workflow so it doesn't keep running after the test
+	require.NoError(t, CancelWorkflow(serverCtx, handle.GetWorkflowID()))
+}
+
 // TestDebouncerClient tests the DebouncerClient functionality using a Client interface
 func TestDebouncerClient(t *testing.T) {
 	// Setup server context - this will process tasks

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -1434,29 +1434,6 @@ func TestClientReadStreamAsyncGoroutineLeak(t *testing.T) {
 	handle, err := RunWorkflow(serverCtx, blockingStreamWorkflow, streamKey)
 	require.NoError(t, err)
 
-	// Wait until the workflow has written its 3 values by polling via ReadStreamAsync.
-	// ClientReadStream would block until the workflow finishes, so we use the async variant
-	// with a per-poll cancellable context instead.
-	require.Eventually(t, func() bool {
-		pollCtx, pollCancel := WithCancelCause(serverCtx)
-		defer pollCancel(nil)
-		ch, err := ReadStreamAsync[string](pollCtx, handle.GetWorkflowID(), streamKey)
-		if err != nil {
-			return false
-		}
-		var count int
-		for sv := range ch {
-			if sv.Err != nil || sv.Closed {
-				break
-			}
-			count++
-			if count >= 3 {
-				break
-			}
-		}
-		return count >= 3
-	}, 10*time.Second, 100*time.Millisecond)
-
 	ch, err := ClientReadStreamAsync[string](client, handle.GetWorkflowID(), streamKey)
 	require.NoError(t, err)
 

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -2487,6 +2487,17 @@ func (c *dbosContext) readStream(workflowID string, key string) <-chan StreamVal
 	go func() {
 		defer close(ch)
 
+		// send delivers v to ch, returning false if the context is cancelled first.
+		// This prevents the goroutine from leaking when the consumer stops reading.
+		send := func(v StreamValue[any]) bool {
+			select {
+			case ch <- v:
+				return true
+			case <-c.Done():
+				return false
+			}
+		}
+
 		var currentOffset int
 		closed := false
 
@@ -2507,19 +2518,21 @@ func (c *dbosContext) readStream(workflowID string, key string) <-chan StreamVal
 			}, withRetrierLogger(c.logger))
 
 			if err != nil {
-				ch <- StreamValue[any]{Err: err}
+				send(StreamValue[any]{Err: err})
 				return
 			}
 
 			// Send each entry value to the channel
 			for _, entry := range entries {
-				ch <- StreamValue[any]{Value: streamEntryWithSerialization{value: entry.Value, serialization: entry.Serialization}}
+				if !send(StreamValue[any]{Value: streamEntryWithSerialization{value: entry.Value, serialization: entry.Serialization}}) {
+					return
+				}
 				currentOffset = entry.Offset + 1 // Next offset to read from
 			}
 
 			// If stream is closed (sentinel found), send final message and stop
 			if closed {
-				ch <- StreamValue[any]{Closed: true}
+				send(StreamValue[any]{Closed: true})
 				return
 			}
 
@@ -2540,13 +2553,13 @@ func (c *dbosContext) readStream(workflowID string, key string) <-chan StreamVal
 			}, withRetrierLogger(c.logger))
 
 			if err != nil {
-				ch <- StreamValue[any]{Err: err}
+				send(StreamValue[any]{Err: err})
 				return
 			}
 
 			// If workflow is inactive, send final message with Closed: true (BUG FIX)
 			if status != WorkflowStatusPending && status != WorkflowStatusEnqueued {
-				ch <- StreamValue[any]{Closed: true}
+				send(StreamValue[any]{Closed: true})
 				return
 			}
 
@@ -2554,7 +2567,7 @@ func (c *dbosContext) readStream(workflowID string, key string) <-chan StreamVal
 			if len(entries) == 0 {
 				select {
 				case <-c.Done():
-					ch <- StreamValue[any]{Err: c.Err()}
+					send(StreamValue[any]{Err: c.Err()})
 					return
 				case <-time.After(_DB_RETRY_INTERVAL):
 					// Continue loop to read again
@@ -2699,47 +2712,60 @@ func ReadStreamAsync[R any](ctx DBOSContext, workflowID string, key string) (<-c
 	go func() {
 		defer close(typedCh)
 
+		send := func(v StreamValue[R]) bool {
+			select {
+			case typedCh <- v:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+
 		customSer := getCustomSerializerFromCtx(ctx)
 
 		for streamValue := range anyCh {
 			if streamValue.Err != nil {
-				typedCh <- StreamValue[R]{Err: streamValue.Err}
+				send(StreamValue[R]{Err: streamValue.Err})
 				return
 			}
 
 			if streamValue.Closed {
-				typedCh <- StreamValue[R]{Closed: true}
+				send(StreamValue[R]{Closed: true})
 				return
 			}
 
 			if isReal {
 				entry, ok := streamValue.Value.(streamEntryWithSerialization)
 				if !ok {
-					typedCh <- StreamValue[R]{Err: fmt.Errorf("stream value is not streamEntryWithSerialization, got %T", streamValue.Value)}
+					send(StreamValue[R]{Err: fmt.Errorf("stream value is not streamEntryWithSerialization, got %T", streamValue.Value)})
 					return
 				}
 
 				asyncDecoder, resolveErr := resolveDecoder[R](entry.serialization, customSer)
 				if resolveErr != nil {
-					typedCh <- StreamValue[R]{Err: resolveErr}
+					send(StreamValue[R]{Err: resolveErr})
 					return
 				}
 
 				decodedValue, decodeErr := asyncDecoder.Decode(&entry.value)
 				if decodeErr != nil {
-					typedCh <- StreamValue[R]{Err: fmt.Errorf("decoding stream value to type %T: %w", *new(R), decodeErr)}
+					send(StreamValue[R]{Err: fmt.Errorf("decoding stream value to type %T: %w", *new(R), decodeErr)})
 					return
 				}
 
-				typedCh <- StreamValue[R]{Value: decodedValue}
+				if !send(StreamValue[R]{Value: decodedValue}) {
+					return
+				}
 			} else {
 				// Fallback for testing/mocking scenarios
 				typedVal, ok := streamValue.Value.(R)
 				if !ok {
-					typedCh <- StreamValue[R]{Err: fmt.Errorf("stream value is not %T, got %T", *new(R), streamValue.Value)}
+					send(StreamValue[R]{Err: fmt.Errorf("stream value is not %T, got %T", *new(R), streamValue.Value)})
 					return
 				}
-				typedCh <- StreamValue[R]{Value: typedVal}
+				if !send(StreamValue[R]{Value: typedVal}) {
+					return
+				}
 			}
 		}
 	}()

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -5862,6 +5862,55 @@ func TestStreams(t *testing.T) {
 		require.NoError(t, err, "failed to get result from forked workflow")
 	})
 
+	t.Run("GoroutineLeakOnContextCancel", func(t *testing.T) {
+		// Verifies that the readStream goroutine exits when the consumer's context is
+		// cancelled, even if the consumer stops reading from the channel.
+		// goleak (via checkLeaks:true on this test) will fail if the goroutine leaks.
+		streamBlockEvent = NewEvent()    // not set — workflow blocks after initial writes
+		streamStartedEvent = NewEvent() // signals that initial writes are done
+
+		streamKey := "test-stream-leak"
+		writerHandle, err := RunWorkflow(dbosCtx, writeStreamWorkflow, struct {
+			StreamKey string
+			Values    []string
+			Close     bool
+		}{
+			StreamKey: streamKey,
+			Values:    []string{"value1", "value2", "value3"},
+			Close:     false,
+		})
+		require.NoError(t, err)
+
+		// Wait until the workflow has written its values and is blocked
+		streamStartedEvent.Wait()
+
+		cancelCtx, cancel := WithCancelCause(dbosCtx)
+		defer cancel(nil)
+
+		ch, err := ReadStreamAsync[string](cancelCtx, writerHandle.GetWorkflowID(), streamKey)
+		require.NoError(t, err)
+
+		// Read one value to confirm the stream is working
+		streamValue := <-ch
+		require.NoError(t, streamValue.Err)
+		require.Equal(t, "value1", streamValue.Value)
+
+		// Cancel the context and abandon the channel — the goroutine must exit on its own
+		cancel(nil)
+
+		// Verify the channel closes within a reasonable time (goroutine unblocked)
+		select {
+		case <-ch:
+		case <-time.After(5 * time.Second):
+			t.Fatal("readStream goroutine did not exit after context cancellation")
+		}
+
+		// Unblock and complete the workflow for clean test teardown
+		streamBlockEvent.Set()
+		_, err = writerHandle.GetResult()
+		require.NoError(t, err)
+	})
+
 	t.Run("AsyncErrorHandling", func(t *testing.T) {
 		// Test reading from non-existent workflow
 		nonExistentWorkflowID := uuid.NewString()


### PR DESCRIPTION
When `ReadStreamAsync` is called but the consumer stops reading from the channel before the stream is closed, the goroutine currently blocks forever on `ch <- v` without respecting context cancellation. 

You can verify that this bug exists by running the `GoroutineLeakOnContextCancel` test on `main`.

This PR introduces a small `send` wrapper that selects between `ch <- v` and `<-c.Done()` and immediately exits the loop when the context is done.