### PR TITLE
Add DBOSContext.ReadStreamSnapshot method

### DIFF
--- a/dbos/client.go
+++ b/dbos/client.go
@@ -546,42 +546,56 @@ func ClientReadStreamAsync[R any](c Client, workflowID string, key string) (<-ch
 	}
 
 	typedCh := make(chan StreamValue[R], 1)
+	dbosCtx := c.(*client).dbosCtx
 
 	go func() {
 		defer close(typedCh)
 
-		customSer := c.(*client).dbosCtx.(*dbosContext).serializer
+		// send delivers v to ch, returning false if the client context is cancelled first.
+		// This prevents the goroutine from leaking even after the client is closed.
+		send := func(v StreamValue[R]) bool {
+			select {
+			case typedCh <- v:
+				return true
+			case <-dbosCtx.Done():
+				return false
+			}
+		}
+
+		customSer := dbosCtx.(*dbosContext).serializer
 
 		for streamValue := range anyCh {
 			if streamValue.Err != nil {
-				typedCh <- StreamValue[R]{Err: streamValue.Err}
+				send(StreamValue[R]{Err: streamValue.Err})
 				return
 			}
 
 			if streamValue.Closed {
-				typedCh <- StreamValue[R]{Closed: true}
+				send(StreamValue[R]{Closed: true})
 				return
 			}
 
 			entry, ok := streamValue.Value.(streamEntryWithSerialization)
 			if !ok {
-				typedCh <- StreamValue[R]{Err: fmt.Errorf("stream value is not streamEntryWithSerialization, got %T", streamValue.Value)}
+				send(StreamValue[R]{Err: fmt.Errorf("stream value is not streamEntryWithSerialization, got %T", streamValue.Value)})
 				return
 			}
 
 			decoder, resolveErr := resolveDecoder[R](entry.serialization, customSer)
 			if resolveErr != nil {
-				typedCh <- StreamValue[R]{Err: resolveErr}
+				send(StreamValue[R]{Err: resolveErr})
 				return
 			}
 
 			decodedValue, decodeErr := decoder.Decode(&entry.value)
 			if decodeErr != nil {
-				typedCh <- StreamValue[R]{Err: fmt.Errorf("decoding stream value to type %T: %w", *new(R), decodeErr)}
+				send(StreamValue[R]{Err: fmt.Errorf("decoding stream value to type %T: %w", *new(R), decodeErr)})
 				return
 			}
 
-			typedCh <- StreamValue[R]{Value: decodedValue}
+			if !send(StreamValue[R]{Value: decodedValue}) {
+				return
+			}
 		}
 	}()
 

--- a/dbos/client.go
+++ b/dbos/client.go
@@ -40,6 +40,7 @@ type Client interface {
 	GetWorkflowSteps(workflowID string) ([]StepInfo, error)
 	ClientReadStream(workflowID string, key string) ([]any, bool, error)
 	ClientReadStreamAsync(workflowID string, key string) (<-chan StreamValue[any], error)
+	ClientReadStreamSnapshot(workflowID string, key string, fromOffset int) ([]any, bool, error)
 
 	// Schedule management
 	CreateSchedule(input ClientScheduleInput) error
@@ -509,6 +510,52 @@ func ClientReadStream[R any](c Client, workflowID string, key string) ([]R, bool
 // Returns a channel that will receive StreamValue items as they're read.
 func (c *client) ClientReadStreamAsync(workflowID string, key string) (<-chan StreamValue[any], error) {
 	return c.dbosCtx.ReadStreamAsync(c.dbosCtx, workflowID, key)
+}
+
+// ClientReadStreamSnapshot reads currently available stream entries starting from fromOffset and returns immediately.
+func (c *client) ClientReadStreamSnapshot(workflowID string, key string, fromOffset int) ([]any, bool, error) {
+	return c.dbosCtx.ReadStreamSnapshot(c.dbosCtx, workflowID, key, fromOffset)
+}
+
+// ClientReadStreamSnapshot reads currently available stream entries from fromOffset with type safety.
+// Returns immediately without polling.
+//
+// Example:
+//
+//	values, closed, err := dbos.ClientReadStreamSnapshot[string](client, "workflow-id", "my-stream", 0)
+//	if err != nil {
+//	    return err
+//	}
+//	for _, value := range values {
+//	    log.Printf("Stream value: %s", value)
+//	}
+func ClientReadStreamSnapshot[R any](c Client, workflowID string, key string, fromOffset int) ([]R, bool, error) {
+	if c == nil {
+		return nil, false, errors.New("client cannot be nil")
+	}
+	values, closed, err := c.ClientReadStreamSnapshot(workflowID, key, fromOffset)
+	if err != nil {
+		return nil, false, err
+	}
+
+	customSer := c.(*client).dbosCtx.(*dbosContext).serializer
+	typedValues := make([]R, len(values))
+	for i, val := range values {
+		entry, ok := val.(streamEntryWithSerialization)
+		if !ok {
+			return nil, false, fmt.Errorf("stream value is not streamEntryWithSerialization, got %T", val)
+		}
+		decoder, resolveErr := resolveDecoder[R](entry.serialization, customSer)
+		if resolveErr != nil {
+			return nil, false, resolveErr
+		}
+		decodedValue, decodeErr := decoder.Decode(&entry.value)
+		if decodeErr != nil {
+			return nil, false, fmt.Errorf("decoding stream value to type %T: %w", *new(R), decodeErr)
+		}
+		typedValues[i] = decodedValue
+	}
+	return typedValues, closed, nil
 }
 
 // ClientReadStreamAsync reads values from a durable stream asynchronously with type safety.

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -1408,6 +1408,67 @@ func TestClientReadStream(t *testing.T) {
 	}
 }
 
+func TestClientReadStreamAsyncGoroutineLeak(t *testing.T) {
+	serverCtx := setupDBOS(t, setupDBOSOptions{dropDB: false, checkLeaks: true})
+
+	// Workflow that writes values then blocks waiting for a message, keeping it PENDING
+	blockingStreamWorkflow := func(ctx DBOSContext, streamKey string) (string, error) {
+		for _, v := range []string{"value1", "value2", "value3"} {
+			if err := WriteStream(ctx, streamKey, v); err != nil {
+				return "", err
+			}
+		}
+		// Block until a message arrives (long timeout keeps workflow PENDING)
+		Recv[string](ctx, "unblock", 10*time.Minute) //nolint:errcheck
+		return "done", nil
+	}
+	RegisterWorkflow(serverCtx, blockingStreamWorkflow, WithWorkflowName("BlockingStreamWorkflow"))
+	require.NoError(t, Launch(serverCtx))
+
+	databaseURL := getDatabaseURL()
+	client, err := NewClient(context.Background(), ClientConfig{DatabaseURL: databaseURL})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Shutdown(30 * time.Second) })
+
+	streamKey := "test-client-leak-stream"
+	handle, err := RunWorkflow(serverCtx, blockingStreamWorkflow, streamKey)
+	require.NoError(t, err)
+
+	// Wait until the workflow has written its 3 values by polling via ReadStreamAsync.
+	// ClientReadStream would block until the workflow finishes, so we use the async variant
+	// with a per-poll cancellable context instead.
+	require.Eventually(t, func() bool {
+		pollCtx, pollCancel := WithCancelCause(serverCtx)
+		defer pollCancel(nil)
+		ch, err := ReadStreamAsync[string](pollCtx, handle.GetWorkflowID(), streamKey)
+		if err != nil {
+			return false
+		}
+		var count int
+		for sv := range ch {
+			if sv.Err != nil || sv.Closed {
+				break
+			}
+			count++
+			if count >= 3 {
+				break
+			}
+		}
+		return count >= 3
+	}, 10*time.Second, 100*time.Millisecond)
+
+	ch, err := ClientReadStreamAsync[string](client, handle.GetWorkflowID(), streamKey)
+	require.NoError(t, err)
+
+	// Read one value then abandon the channel — goroutine must exit on client shutdown
+	streamValue := <-ch
+	require.NoError(t, streamValue.Err)
+	require.Equal(t, "value1", streamValue.Value)
+
+	// Cancel the workflow so it doesn't keep running after the test
+	require.NoError(t, CancelWorkflow(serverCtx, handle.GetWorkflowID()))
+}
+
 // TestDebouncerClient tests the DebouncerClient functionality using a Client interface
 func TestDebouncerClient(t *testing.T) {
 	// Setup server context - this will process tasks

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -144,6 +144,7 @@ type DBOSContext interface {
 	CloseStream(_ DBOSContext, key string) error                                                                // Close a durable stream
 	ReadStream(_ DBOSContext, workflowID string, key string) ([]any, bool, error)                               // Read values from a durable stream (blocks until workflow inactive or stream closed)
 	ReadStreamAsync(_ DBOSContext, workflowID string, key string) (<-chan StreamValue[any], error)              // Read values from a durable stream asynchronously
+	ReadStreamSnapshot(_ DBOSContext, workflowID string, key string, fromOffset int) ([]any, bool, error)      // Read currently available stream entries from fromOffset and return immediately
 	Sleep(_ DBOSContext, duration time.Duration) (time.Duration, error)                                         // Durable sleep that survives workflow recovery
 	Patch(_ DBOSContext, patchName string) (bool, error)                                                        // Check if workflow should use patched code
 	DeprecatePatch(_ DBOSContext, patchName string) error                                                       // Deprecate a patch

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1229,12 +1229,11 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 			_, loaded = c.activeWorkflowIDs.Load(workflowID)
 		}
 
-		shouldSkip :=
-			len(params.QueueName) > 0 || // We are enqueueing OR
-				insertStatusResult.status == WorkflowStatusSuccess || // workflow is in a terminal state (success) OR
-				insertStatusResult.status == WorkflowStatusError || // workflow is in a terminal state (error) OR
-				(!params.isDequeue && !params.isRecovery && insertStatusResult.ownerXID != ownerXID) || // another executor, not us dequeueing or being instructed to recover, is already owning the workflow OR
-				loaded // this executor is already running the workflow
+		shouldSkip := len(params.QueueName) > 0 || // We are enqueueing OR
+			insertStatusResult.status == WorkflowStatusSuccess || // workflow is in a terminal state (success) OR
+			insertStatusResult.status == WorkflowStatusError || // workflow is in a terminal state (error) OR
+			(!params.isDequeue && !params.isRecovery && insertStatusResult.ownerXID != ownerXID) || // another executor, not us dequeueing or being instructed to recover, is already owning the workflow OR
+			loaded // this executor is already running the workflow
 
 		if shouldSkip {
 			// Commit the transaction to update the number of attempts and/or enact the enqueue
@@ -2516,7 +2515,6 @@ func (c *dbosContext) readStream(workflowID string, key string) <-chan StreamVal
 				entries, closed, retryErr = c.systemDB.readStream(c, input)
 				return retryErr
 			}, withRetrierLogger(c.logger))
-
 			if err != nil {
 				send(StreamValue[any]{Err: err})
 				return
@@ -2551,7 +2549,6 @@ func (c *dbosContext) readStream(workflowID string, key string) <-chan StreamVal
 				}
 				return workflows[0].Status, nil
 			}, withRetrierLogger(c.logger))
-
 			if err != nil {
 				send(StreamValue[any]{Err: err})
 				return
@@ -2583,6 +2580,80 @@ func (c *dbosContext) readStream(workflowID string, key string) <-chan StreamVal
 type streamEntryWithSerialization struct {
 	value         string
 	serialization string
+}
+
+func (c *dbosContext) ReadStreamSnapshot(_ DBOSContext, workflowID string, key string, fromOffset int) ([]any, bool, error) {
+	input := readStreamDBInput{
+		WorkflowID: workflowID,
+		Key:        key,
+		FromOffset: fromOffset,
+	}
+	var entries []streamEntry
+	var closed bool
+	err := retry(c, func() error {
+		var retryErr error
+		entries, closed, retryErr = c.systemDB.readStream(c, input)
+		return retryErr
+	}, withRetrierLogger(c.logger))
+	if err != nil {
+		return nil, false, err
+	}
+	values := make([]any, len(entries))
+	for i, e := range entries {
+		values[i] = streamEntryWithSerialization{value: e.Value, serialization: e.Serialization}
+	}
+	return values, closed, nil
+}
+
+// ReadStreamSnapshot reads all stream entries currently available starting from fromOffset and returns immediately.
+// Unlike ReadStream, it does not poll or wait for the workflow to complete.
+//
+// Example:
+//
+//	values, closed, err := dbos.ReadStreamSnapshot[string](ctx, "workflow-id", "my-stream", 0)
+//	if err != nil {
+//	    return err
+//	}
+//	for _, value := range values {
+//	    log.Printf("Stream value: %s", value)
+//	}
+func ReadStreamSnapshot[R any](ctx DBOSContext, workflowID string, key string, fromOffset int) ([]R, bool, error) {
+	if ctx == nil {
+		return nil, false, errors.New("ctx cannot be nil")
+	}
+	values, closed, err := ctx.ReadStreamSnapshot(ctx, workflowID, key, fromOffset)
+	if err != nil {
+		return nil, false, err
+	}
+
+	typedValues := make([]R, len(values))
+	if _, ok := ctx.(*dbosContext); ok {
+		customSer := getCustomSerializerFromCtx(ctx)
+		for i, val := range values {
+			entry, ok := val.(streamEntryWithSerialization)
+			if !ok {
+				return nil, false, fmt.Errorf("stream value is not streamEntryWithSerialization, got %T", val)
+			}
+			decoder, resolveErr := resolveDecoder[R](entry.serialization, customSer)
+			if resolveErr != nil {
+				return nil, false, resolveErr
+			}
+			decodedValue, decodeErr := decoder.Decode(&entry.value)
+			if decodeErr != nil {
+				return nil, false, fmt.Errorf("decoding stream value to type %T: %w", *new(R), decodeErr)
+			}
+			typedValues[i] = decodedValue
+		}
+	} else {
+		for i, val := range values {
+			typedVal, ok := val.(R)
+			if !ok {
+				return nil, false, fmt.Errorf("stream value is not %T, got %T", *new(R), val)
+			}
+			typedValues[i] = typedVal
+		}
+	}
+	return typedValues, closed, nil
 }
 
 func (c *dbosContext) ReadStream(_ DBOSContext, workflowID string, key string) ([]any, bool, error) {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -2487,6 +2487,17 @@ func (c *dbosContext) readStream(workflowID string, key string) <-chan StreamVal
 	go func() {
 		defer close(ch)
 
+		// send delivers v to ch, returning false if the context is cancelled first.
+		// This prevents the goroutine from leaking when the consumer stops reading.
+		send := func(v StreamValue[any]) bool {
+			select {
+			case ch <- v:
+				return true
+			case <-c.Done():
+				return false
+			}
+		}
+
 		var currentOffset int
 		closed := false
 
@@ -2507,19 +2518,21 @@ func (c *dbosContext) readStream(workflowID string, key string) <-chan StreamVal
 			}, withRetrierLogger(c.logger))
 
 			if err != nil {
-				ch <- StreamValue[any]{Err: err}
+				send(StreamValue[any]{Err: err})
 				return
 			}
 
 			// Send each entry value to the channel
 			for _, entry := range entries {
-				ch <- StreamValue[any]{Value: streamEntryWithSerialization{value: entry.Value, serialization: entry.Serialization}}
+				if !send(StreamValue[any]{Value: streamEntryWithSerialization{value: entry.Value, serialization: entry.Serialization}}) {
+					return
+				}
 				currentOffset = entry.Offset + 1 // Next offset to read from
 			}
 
 			// If stream is closed (sentinel found), send final message and stop
 			if closed {
-				ch <- StreamValue[any]{Closed: true}
+				send(StreamValue[any]{Closed: true})
 				return
 			}
 
@@ -2540,13 +2553,13 @@ func (c *dbosContext) readStream(workflowID string, key string) <-chan StreamVal
 			}, withRetrierLogger(c.logger))
 
 			if err != nil {
-				ch <- StreamValue[any]{Err: err}
+				send(StreamValue[any]{Err: err})
 				return
 			}
 
 			// If workflow is inactive, send final message with Closed: true (BUG FIX)
 			if status != WorkflowStatusPending && status != WorkflowStatusEnqueued {
-				ch <- StreamValue[any]{Closed: true}
+				send(StreamValue[any]{Closed: true})
 				return
 			}
 
@@ -2554,7 +2567,7 @@ func (c *dbosContext) readStream(workflowID string, key string) <-chan StreamVal
 			if len(entries) == 0 {
 				select {
 				case <-c.Done():
-					ch <- StreamValue[any]{Err: c.Err()}
+					send(StreamValue[any]{Err: c.Err()})
 					return
 				case <-time.After(_DB_RETRY_INTERVAL):
 					// Continue loop to read again
@@ -2699,47 +2712,60 @@ func ReadStreamAsync[R any](ctx DBOSContext, workflowID string, key string) (<-c
 	go func() {
 		defer close(typedCh)
 
+		send := func(v StreamValue[R]) bool {
+			select {
+			case typedCh <- v:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+
 		customSer := getCustomSerializerFromCtx(ctx)
 
 		for streamValue := range anyCh {
 			if streamValue.Err != nil {
-				typedCh <- StreamValue[R]{Err: streamValue.Err}
+				send(StreamValue[R]{Err: streamValue.Err})
 				return
 			}
 
 			if streamValue.Closed {
-				typedCh <- StreamValue[R]{Closed: true}
+				send(StreamValue[R]{Closed: true})
 				return
 			}
 
 			if isReal {
 				entry, ok := streamValue.Value.(streamEntryWithSerialization)
 				if !ok {
-					typedCh <- StreamValue[R]{Err: fmt.Errorf("stream value is not streamEntryWithSerialization, got %T", streamValue.Value)}
+					send(StreamValue[R]{Err: fmt.Errorf("stream value is not streamEntryWithSerialization, got %T", streamValue.Value)})
 					return
 				}
 
 				asyncDecoder, resolveErr := resolveDecoder[R](entry.serialization, customSer)
 				if resolveErr != nil {
-					typedCh <- StreamValue[R]{Err: resolveErr}
+					send(StreamValue[R]{Err: resolveErr})
 					return
 				}
 
 				decodedValue, decodeErr := asyncDecoder.Decode(&entry.value)
 				if decodeErr != nil {
-					typedCh <- StreamValue[R]{Err: fmt.Errorf("decoding stream value to type %T: %w", *new(R), decodeErr)}
+					send(StreamValue[R]{Err: fmt.Errorf("decoding stream value to type %T: %w", *new(R), decodeErr)})
 					return
 				}
 
-				typedCh <- StreamValue[R]{Value: decodedValue}
+				if !send(StreamValue[R]{Value: decodedValue}) {
+					return
+				}
 			} else {
 				// Fallback for testing/mocking scenarios
 				typedVal, ok := streamValue.Value.(R)
 				if !ok {
-					typedCh <- StreamValue[R]{Err: fmt.Errorf("stream value is not %T, got %T", *new(R), streamValue.Value)}
+					send(StreamValue[R]{Err: fmt.Errorf("stream value is not %T, got %T", *new(R), streamValue.Value)})
 					return
 				}
-				typedCh <- StreamValue[R]{Value: typedVal}
+				if !send(StreamValue[R]{Value: typedVal}) {
+					return
+				}
 			}
 		}
 	}()

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -5862,6 +5862,55 @@ func TestStreams(t *testing.T) {
 		require.NoError(t, err, "failed to get result from forked workflow")
 	})
 
+	t.Run("GoroutineLeakOnContextCancel", func(t *testing.T) {
+		// Verifies that the readStream goroutine exits when the consumer's context is
+		// cancelled, even if the consumer stops reading from the channel.
+		// goleak (via checkLeaks:true on this test) will fail if the goroutine leaks.
+		streamBlockEvent = NewEvent()    // not set — workflow blocks after initial writes
+		streamStartedEvent = NewEvent() // signals that initial writes are done
+
+		streamKey := "test-stream-leak"
+		writerHandle, err := RunWorkflow(dbosCtx, writeStreamWorkflow, struct {
+			StreamKey string
+			Values    []string
+			Close     bool
+		}{
+			StreamKey: streamKey,
+			Values:    []string{"value1", "value2", "value3"},
+			Close:     false,
+		})
+		require.NoError(t, err)
+
+		// Wait until the workflow has written its values and is blocked
+		streamStartedEvent.Wait()
+
+		cancelCtx, cancel := WithCancelCause(dbosCtx)
+		defer cancel(nil)
+
+		ch, err := ReadStreamAsync[string](cancelCtx, writerHandle.GetWorkflowID(), streamKey)
+		require.NoError(t, err)
+
+		// Read one value to confirm the stream is working
+		streamValue := <-ch
+		require.NoError(t, streamValue.Err)
+		require.Equal(t, "value1", streamValue.Value)
+
+		// Cancel the context and abandon the channel — the goroutine must exit on its own
+		cancel(nil)
+
+		// Verify the channel closes within a reasonable time (goroutine unblocked)
+		select {
+		case <-ch:
+		case <-time.After(5 * time.Second):
+			t.Fatal("readStream goroutine did not exit after context cancellation")
+		}
+
+		// Unblock and complete the workflow for clean test teardown
+		streamBlockEvent.Set()
+		_, err = writerHandle.GetResult()
+		require.NoError(t, err)
+	})
+
 	t.Run("AsyncErrorHandling", func(t *testing.T) {
 		// Test reading from non-existent workflow
 		nonExistentWorkflowID := uuid.NewString()

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -5911,6 +5911,88 @@ func TestStreams(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("ReadStreamSnapshot", func(t *testing.T) {
+		streamBlockEvent = NewEvent()    // not set — workflow blocks after initial writes
+		streamStartedEvent = NewEvent()
+
+		streamKey := "test-stream-snapshot"
+		writerHandle, err := RunWorkflow(dbosCtx, writeStreamWorkflow, struct {
+			StreamKey string
+			Values    []string
+			Close     bool
+		}{
+			StreamKey: streamKey,
+			Values:    []string{"value1", "value2", "value3"},
+			Close:     false,
+		})
+		require.NoError(t, err)
+
+		// Wait until the workflow has written its values and is blocked
+		streamStartedEvent.Wait()
+
+		// Snapshot at offset 0 — returns all written entries immediately
+		values, closed, err := ReadStreamSnapshot[string](dbosCtx, writerHandle.GetWorkflowID(), streamKey, 0)
+		require.NoError(t, err)
+		require.False(t, closed, "stream should not be closed while workflow is blocked")
+		require.Equal(t, []string{"value1", "value2", "value3"}, values)
+
+		// Snapshot at offset 1 — returns only the tail
+		values, closed, err = ReadStreamSnapshot[string](dbosCtx, writerHandle.GetWorkflowID(), streamKey, 1)
+		require.NoError(t, err)
+		require.False(t, closed)
+		require.Equal(t, []string{"value2", "value3"}, values)
+
+		// Snapshot past the end — returns empty, not closed
+		values, closed, err = ReadStreamSnapshot[string](dbosCtx, writerHandle.GetWorkflowID(), streamKey, 99)
+		require.NoError(t, err)
+		require.False(t, closed)
+		require.Empty(t, values)
+
+		// Unblock workflow and let it complete (no close)
+		streamBlockEvent.Set()
+		_, err = writerHandle.GetResult()
+		require.NoError(t, err)
+
+		// Snapshot after workflow completes — still returns entries, closed: false (no sentinel written)
+		values, closed, err = ReadStreamSnapshot[string](dbosCtx, writerHandle.GetWorkflowID(), streamKey, 0)
+		require.NoError(t, err)
+		require.False(t, closed)
+		// step-value was written inside RunAsStep before workflow finished
+		require.Equal(t, []string{"value1", "value2", "value3", "step-value"}, values)
+	})
+
+	t.Run("ReadStreamSnapshotClosed", func(t *testing.T) {
+		streamBlockEvent = NewEvent()
+		streamBlockEvent.Set() // unblocked — workflow runs to completion and closes the stream
+		streamStartedEvent = nil
+
+		streamKey := "test-stream-snapshot-closed"
+		writerHandle, err := RunWorkflow(dbosCtx, writeStreamWorkflow, struct {
+			StreamKey string
+			Values    []string
+			Close     bool
+		}{
+			StreamKey: streamKey,
+			Values:    []string{"a", "b"},
+			Close:     true,
+		})
+		require.NoError(t, err)
+		_, err = writerHandle.GetResult()
+		require.Error(t, err) // write-after-close error expected
+
+		// Snapshot returns entries and closed: true when sentinel is present
+		values, closed, err := ReadStreamSnapshot[string](dbosCtx, writerHandle.GetWorkflowID(), streamKey, 0)
+		require.NoError(t, err)
+		require.True(t, closed)
+		require.Equal(t, []string{"a", "b", "step-value"}, values)
+
+		// Snapshot at offset 2 still shows closed
+		values, closed, err = ReadStreamSnapshot[string](dbosCtx, writerHandle.GetWorkflowID(), streamKey, 2)
+		require.NoError(t, err)
+		require.True(t, closed)
+		require.Equal(t, []string{"step-value"}, values)
+	})
+
 	t.Run("AsyncErrorHandling", func(t *testing.T) {
 		// Test reading from non-existent workflow
 		nonExistentWorkflowID := uuid.NewString()


### PR DESCRIPTION
Right now there is no way to read workflow events without either blocking forever or a creating a Goroutine the writes to a channel until the stream is closed. 

For some scenarios it would be useful to have a way to retrieve only the events that have already been written to a stream without blocking. `ReadStreamSnapshot` allows this and also adds the ability to only read events after a certain offset.

Not sure if this is the right approach. An alternative would be to repurpose `ReadStream` for this and accept options like `dbos.WithWait(false)` and `dbos.WithOffset` 🤔 

Based on #318