### PR TITLE
Add missing enqueue options

### DIFF
--- a/dbos/client.go
+++ b/dbos/client.go
@@ -176,6 +176,27 @@ func WithEnqueueDelay(delay time.Duration) EnqueueOption {
 	}
 }
 
+// WithEnqueueAuthenticatedUser sets the authenticated user for the enqueued workflow.
+func WithEnqueueAuthenticatedUser(user string) EnqueueOption {
+	return func(opts *enqueueOptions) {
+		opts.authenticatedUser = user
+	}
+}
+
+// WithEnqueueAssumedRole sets the assumed role for the enqueued workflow.
+func WithEnqueueAssumedRole(role string) EnqueueOption {
+	return func(opts *enqueueOptions) {
+		opts.assumedRole = role
+	}
+}
+
+// WithEnqueueAuthenticatedRoles sets the authenticated roles for the enqueued workflow.
+func WithEnqueueAuthenticatedRoles(roles []string) EnqueueOption {
+	return func(opts *enqueueOptions) {
+		opts.authenticatedRoles = roles
+	}
+}
+
 type enqueueOptions struct {
 	workflowName       string
 	workflowID         string
@@ -188,6 +209,9 @@ type enqueueOptions struct {
 	className          string
 	configName         *string
 	delayDuration      time.Duration
+	authenticatedUser  string
+	assumedRole        string
+	authenticatedRoles []string
 }
 
 // EnqueueWorkflow enqueues a workflow to a named queue for deferred execution.
@@ -282,6 +306,9 @@ func (c *client) Enqueue(queueName, workflowName string, input any, opts ...Enqu
 		ConfigName:         params.configName,
 		Serialization:      serialization,
 		DelayUntil:         delayUntil,
+		AuthenticatedUser:  params.authenticatedUser,
+		AssumedRole:        params.assumedRole,
+		AuthenticatedRoles: params.authenticatedRoles,
 	}
 
 	uncancellableCtx := WithoutCancel(dbosCtx)

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -344,6 +344,27 @@ func TestClientEnqueue(t *testing.T) {
 		assert.Contains(t, err.Error(), "workflow name is required", "expected error message to contain 'workflow name is required'")
 	})
 
+	t.Run("EnqueueWithAuthOptions", func(t *testing.T) {
+		wfID := "client-auth-options-wf"
+		handle, err := Enqueue[wfInput, string](client, queue.Name, "ServerWorkflow", wfInput{Input: "test-input"},
+			WithEnqueueWorkflowID(wfID),
+			WithEnqueueAuthenticatedUser("test-user"),
+			WithEnqueueAssumedRole("test-role"),
+			WithEnqueueAuthenticatedRoles([]string{"role1", "role2"}),
+			WithEnqueueApplicationVersion(serverCtx.GetApplicationVersion()))
+		require.NoError(t, err)
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err)
+
+		assert.Equal(t, "test-user", status.AuthenticatedUser)
+		assert.Equal(t, "test-role", status.AssumedRole)
+		assert.Equal(t, []string{"role1", "role2"}, status.AuthenticatedRoles)
+
+		_, err = handle.GetResult()
+		require.NoError(t, err)
+	})
+
 	// Verify all queue entries are cleaned up
 	require.True(t, queueEntriesAreCleanedUp(serverCtx), "expected queue entries to be cleaned up after client tests")
 }


### PR DESCRIPTION
Adds missing options for `AuthenticatedUser`, `AssumedRole` and `AuthenticatedRoles` to `dbos.Enqueue`. While these fields aren't used anywhere in DBOS I was planning to utilize them myself to attach some metadata to a workflow.

The options are already available on `RunWorkflow` so this PR just closes the gap.