### PR TITLE
Remove log noise for unknown schedule workflows

### DIFF
--- a/dbos/scheduler.go
+++ b/dbos/scheduler.go
@@ -214,7 +214,7 @@ func (c *dbosContext) buildDBScheduleFunc(schedule WorkflowSchedule) (ScheduledW
 func (c *dbosContext) addDBScheduleToScheduler(schedule WorkflowSchedule) {
 	fn, err := c.buildDBScheduleFunc(schedule)
 	if err != nil {
-		c.logger.Error("failed to get workflow for schedule", "schedule", schedule.ScheduleName, "error", err)
+		c.logger.Debug("failed to get workflow for schedule", "schedule", schedule.ScheduleName, "error", err)
 		return
 	}
 


### PR DESCRIPTION
I was planning to run multiple workers with different workflows all connected to the same DBOS database + schema. This works great but as soon as I create schedules, each worker starts logging `failed to get workflow for schedule` for any workflow they don't know about.

Maybe the proper fix would be for each worker to only look at the schedules for queues and workflows they have registered? For now I just lowered the log level to debug because I wasn't sure about the intended design.