### PR TITLE
Auth info from parent to child

### DIFF
--- a/dbos/recovery.go
+++ b/dbos/recovery.go
@@ -51,10 +51,15 @@ func recoverPendingWorkflows(ctx *dbosContext, executorIDs []string) ([]Workflow
 			continue
 		}
 
-		// Convert workflow parameters to options
+		// Convert workflow parameters to options.
+		// Auth identity is re-attached so child workflows spawned during
+		// recovery inherit the same identity as the original run.
 		opts := []WorkflowOption{
 			WithWorkflowID(workflow.ID),
 			withIsRecovery(),
+			WithAuthenticatedUser(workflow.AuthenticatedUser),
+			WithAssumedRole(workflow.AssumedRole),
+			WithAuthenticatedRoles(workflow.AuthenticatedRoles),
 		}
 		// Create a workflow context from the executor context
 		// Pass encoded input directly - decoding will happen in workflow wrapper when we know the target type

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -73,6 +73,10 @@ type workflowState struct {
 	stepID             int
 	isWithinStep       bool
 	isPortableWorkflow bool
+	// auth identity carried so child workflows can inherit it automatically
+	authenticatedUser  string
+	assumedRole        string
+	authenticatedRoles []string
 }
 
 // nextStepID returns the next step ID and increments the counter
@@ -1110,6 +1114,17 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 	if isChildWorkflow {
 		// Advance step ID if we are a child workflow
 		parentWorkflowState.nextStepID()
+
+		// Propagate parent auth identity to child unless caller explicitlyoverrode  it
+		if params.AuthenticatedUser == "" {
+			params.AuthenticatedUser = parentWorkflowState.authenticatedUser
+		}
+		if params.AssumedRole == "" {
+			params.AssumedRole = parentWorkflowState.assumedRole
+		}
+		if len(params.AuthenticatedRoles) == 0 {
+			params.AuthenticatedRoles = parentWorkflowState.authenticatedRoles
+		}
 	}
 
 	// Generate an ID for the workflow if not provided
@@ -1357,6 +1372,9 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 		workflowID:         workflowID,
 		stepID:             -1, // Steps are O-indexed
 		isPortableWorkflow: params.isPortableWorkflow,
+		authenticatedUser:  params.AuthenticatedUser,
+		assumedRole:        params.AssumedRole,
+		authenticatedRoles: params.AuthenticatedRoles,
 	}
 	workflowCtx := WithValue(c, workflowStateKey, wfState)
 

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -5154,6 +5154,160 @@ func TestWorkflowIdentity(t *testing.T) {
 	})
 }
 
+// authSnapshot holds identity fields read from a workflow's DB row.
+type authSnapshot struct {
+	User  string
+	Role  string
+	Roles []string
+}
+
+// captureAuthFromDB reads the calling workflow's own identity from workflow_status.
+func captureAuthFromDB(ctx DBOSContext) (authSnapshot, error) {
+	wfID, err := GetWorkflowID(ctx)
+	if err != nil {
+		return authSnapshot{}, err
+	}
+	rows, err := ctx.(*dbosContext).systemDB.listWorkflows(ctx, listWorkflowsDBInput{
+		workflowIDs: []string{wfID},
+	})
+	if err != nil || len(rows) == 0 {
+		return authSnapshot{}, err
+	}
+	return authSnapshot{
+		User:  rows[0].AuthenticatedUser,
+		Role:  rows[0].AssumedRole,
+		Roles: rows[0].AuthenticatedRoles,
+	}, nil
+}
+
+// authChildWorkflow returns its own auth snapshot as output.
+func authChildWorkflow(ctx DBOSContext, _ string) (authSnapshot, error) {
+	return captureAuthFromDB(ctx)
+}
+
+// authParentWorkflow spawns authChildWorkflow without passing any auth opts.
+// Propagation from workflowState should carry the parent's identity.
+func authParentWorkflow(ctx DBOSContext, _ string) (authSnapshot, error) {
+	handle, err := RunWorkflow(ctx, authChildWorkflow, "")
+	if err != nil {
+		return authSnapshot{}, err
+	}
+	return handle.GetResult()
+}
+
+// authGrandparentWorkflow tests three-level propagation.
+func authGrandparentWorkflow(ctx DBOSContext, _ string) (authSnapshot, error) {
+	handle, err := RunWorkflow(ctx, authParentWorkflow, "")
+	if err != nil {
+		return authSnapshot{}, err
+	}
+	return handle.GetResult()
+}
+
+// authParentWithOverrideWorkflow spawns a child that explicitly sets different auth.
+func authParentWithOverrideWorkflow(ctx DBOSContext, _ string) (authSnapshot, error) {
+	handle, err := RunWorkflow(ctx, authChildWorkflow, "",
+		WithAuthenticatedUser("service-account"),
+		WithAssumedRole("service"),
+		WithAuthenticatedRoles([]string{"internal"}),
+	)
+	if err != nil {
+		return authSnapshot{}, err
+	}
+	return handle.GetResult()
+}
+
+func TestAuthPropagation(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+	RegisterWorkflow(dbosCtx, authChildWorkflow)
+	RegisterWorkflow(dbosCtx, authParentWorkflow)
+	RegisterWorkflow(dbosCtx, authGrandparentWorkflow)
+	RegisterWorkflow(dbosCtx, authParentWithOverrideWorkflow)
+
+	t.Run("PropagatesFromParentToChild", func(t *testing.T) {
+		handle, err := RunWorkflow(dbosCtx, authParentWorkflow, "",
+			WithAuthenticatedUser("alice@example.com"),
+			WithAssumedRole("customer"),
+			WithAuthenticatedRoles([]string{"read", "write"}),
+		)
+		require.NoError(t, err)
+		childAuth, err := handle.GetResult()
+		require.NoError(t, err)
+		assert.Equal(t, "alice@example.com", childAuth.User)
+		assert.Equal(t, "customer", childAuth.Role)
+		assert.Equal(t, []string{"read", "write"}, childAuth.Roles)
+	})
+
+	t.Run("ChildExplicitOverridesParent", func(t *testing.T) {
+		handle, err := RunWorkflow(dbosCtx, authParentWithOverrideWorkflow, "",
+			WithAuthenticatedUser("alice@example.com"),
+			WithAssumedRole("customer"),
+			WithAuthenticatedRoles([]string{"read", "write"}),
+		)
+		require.NoError(t, err)
+		childAuth, err := handle.GetResult()
+		require.NoError(t, err)
+		assert.Equal(t, "service-account", childAuth.User)
+		assert.Equal(t, "service", childAuth.Role)
+		assert.Equal(t, []string{"internal"}, childAuth.Roles)
+	})
+
+	t.Run("EmptyParentDoesNotPropagateNoise", func(t *testing.T) {
+		handle, err := RunWorkflow(dbosCtx, authParentWorkflow, "")
+		require.NoError(t, err)
+		childAuth, err := handle.GetResult()
+		require.NoError(t, err)
+		assert.Empty(t, childAuth.User)
+		assert.Empty(t, childAuth.Role)
+		assert.Empty(t, childAuth.Roles)
+	})
+
+	t.Run("PropagatesMultipleLevels", func(t *testing.T) {
+		handle, err := RunWorkflow(dbosCtx, authGrandparentWorkflow, "",
+			WithAuthenticatedUser("alice@example.com"),
+			WithAssumedRole("customer"),
+			WithAuthenticatedRoles([]string{"read", "write"}),
+		)
+		require.NoError(t, err)
+		grandchildAuth, err := handle.GetResult()
+		require.NoError(t, err)
+		assert.Equal(t, "alice@example.com", grandchildAuth.User)
+		assert.Equal(t, "customer", grandchildAuth.Role)
+		assert.Equal(t, []string{"read", "write"}, grandchildAuth.Roles)
+	})
+
+	t.Run("PropagatesAfterRecovery", func(t *testing.T) {
+		const wfID = "auth-recovery-test-wf"
+
+		handle, err := RunWorkflow(dbosCtx, authParentWorkflow, "",
+			WithWorkflowID(wfID),
+			WithAuthenticatedUser("alice@example.com"),
+			WithAssumedRole("customer"),
+			WithAuthenticatedRoles([]string{"read", "write"}),
+		)
+		require.NoError(t, err)
+		_, err = handle.GetResult()
+		require.NoError(t, err)
+
+		// Simulate crash: reset parent to PENDING so recovery re-runs it.
+		setWorkflowStatusPending(t, dbosCtx, wfID)
+
+		recoveredHandles, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
+		require.NoError(t, err)
+		require.Len(t, recoveredHandles, 1)
+
+		// Use a typed handle so the JSON output decodes into authSnapshot.
+		typedHandle, err := RetrieveWorkflow[authSnapshot](dbosCtx, wfID)
+		require.NoError(t, err)
+		childAuth, err := typedHandle.GetResult()
+		require.NoError(t, err)
+
+		assert.Equal(t, "alice@example.com", childAuth.User)
+		assert.Equal(t, "customer", childAuth.Role)
+		assert.Equal(t, []string{"read", "write"}, childAuth.Roles)
+	})
+}
+
 func TestWorkflowHandles(t *testing.T) {
 	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
 	RegisterWorkflow(dbosCtx, slowWorkflow)


### PR DESCRIPTION
Changes

- When spawning a child workflow (`isChildWorkflow == true`), propagate the parent's auth fields into the child's `params` before `workflow_status` is inserted - only fills empty fields so explicit overrides are respected.
- Populate `wfState` with auth from `params` at workflow start so the running goroutine carries the identity for its own children.

Behaviour 
- Auth is set once at the initial `RunWorkflow` call site
- All child and grandchild workflows inherit it automatically with no changes to workflow business logic
- A child that passes its own `WithAuthenticatedUser(...) `opts uses those instead - parent auth does not override explicit values
- Recovery correctly restores the original identity so post-crash child spawns inherit the same auth as the first run.

Closes #331 