### PR TITLE
Add typed admin client and stabilize time filter test

### DIFF
--- a/dbos/admin_client.go
+++ b/dbos/admin_client.go
@@ -1,0 +1,256 @@
+package dbos
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const defaultAdminClientTimeout = 5 * time.Second
+
+type AdminClient struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+}
+
+type AdminClientError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *AdminClientError) Error() string {
+	return fmt.Sprintf("admin API returned HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+type AdminEpochMillis int64
+
+func (m *AdminEpochMillis) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, []byte("null")) {
+		*m = 0
+		return nil
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("admin epoch milliseconds must be a JSON string or null: %w", err)
+	}
+	millis, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid admin epoch milliseconds %q: %w", value, err)
+	}
+	*m = AdminEpochMillis(millis)
+	return nil
+}
+
+func (m AdminEpochMillis) Time() time.Time {
+	return time.UnixMilli(int64(m))
+}
+
+type AdminHealthResponse struct {
+	Status string `json:"status"`
+}
+
+type AdminListWorkflowsRequest struct {
+	WorkflowUUIDs      []string           `json:"workflow_uuids,omitempty"`
+	AuthenticatedUser  *string            `json:"authenticated_user,omitempty"`
+	StartTime          *time.Time         `json:"start_time,omitempty"`
+	EndTime            *time.Time         `json:"end_time,omitempty"`
+	Status             WorkflowStatusType `json:"status,omitempty"`
+	ApplicationVersion *string            `json:"application_version,omitempty"`
+	WorkflowName       *string            `json:"workflow_name,omitempty"`
+	Limit              *int               `json:"limit,omitempty"`
+	Offset             *int               `json:"offset,omitempty"`
+	SortDesc           *bool              `json:"sort_desc,omitempty"`
+	WorkflowIDPrefix   *string            `json:"workflow_id_prefix,omitempty"`
+	LoadInput          *bool              `json:"load_input,omitempty"`
+	LoadOutput         *bool              `json:"load_output,omitempty"`
+	QueueName          *string            `json:"queue_name,omitempty"`
+}
+
+type AdminWorkflow struct {
+	WorkflowUUID            string             `json:"WorkflowUUID"`
+	Status                  WorkflowStatusType `json:"Status"`
+	WorkflowName            string             `json:"WorkflowName"`
+	AuthenticatedUser       string             `json:"AuthenticatedUser"`
+	AssumedRole             string             `json:"AssumedRole"`
+	AuthenticatedRoles      []string           `json:"AuthenticatedRoles"`
+	Output                  string             `json:"Output"`
+	Error                   string             `json:"Error"`
+	ExecutorID              string             `json:"ExecutorID"`
+	ApplicationVersion      string             `json:"ApplicationVersion"`
+	ApplicationID           string             `json:"ApplicationID"`
+	Attempts                int                `json:"Attempts"`
+	QueueName               string             `json:"QueueName"`
+	Timeout                 time.Duration      `json:"Timeout"`
+	DeduplicationID         string             `json:"DeduplicationID"`
+	Priority                int                `json:"Priority"`
+	QueuePartitionKey       string             `json:"QueuePartitionKey"`
+	Input                   string             `json:"Input"`
+	CreatedAt               AdminEpochMillis   `json:"CreatedAt"`
+	UpdatedAt               AdminEpochMillis   `json:"UpdatedAt"`
+	WorkflowDeadlineEpochMS AdminEpochMillis   `json:"WorkflowDeadlineEpochMS"`
+	StartedAt               AdminEpochMillis   `json:"StartedAt"`
+}
+
+type AdminWorkflowStep struct {
+	FunctionID         int    `json:"function_id"`
+	FunctionName       string `json:"function_name"`
+	ChildWorkflowID    string `json:"child_workflow_id"`
+	StartedAtEpochMS   int64  `json:"started_at_epoch_ms"`
+	CompletedAtEpochMS int64  `json:"completed_at_epoch_ms"`
+	Output             string `json:"output"`
+	Error              string `json:"error"`
+}
+
+type AdminForkWorkflowRequest struct {
+	StartStep          *uint   `json:"start_step,omitempty"`
+	NewWorkflowID      *string `json:"new_workflow_id,omitempty"`
+	ApplicationVersion *string `json:"application_version,omitempty"`
+}
+
+type AdminForkWorkflowResponse struct {
+	WorkflowID string `json:"workflow_id"`
+}
+
+type AdminGarbageCollectRequest struct {
+	CutoffEpochTimestampMS *int64 `json:"cutoff_epoch_timestamp_ms,omitempty"`
+	RowsThreshold          *int   `json:"rows_threshold,omitempty"`
+}
+
+type AdminGlobalTimeoutRequest struct {
+	CutoffEpochTimestampMS int64 `json:"cutoff_epoch_timestamp_ms"`
+}
+
+func NewAdminClient(rawBaseURL string) (*AdminClient, error) {
+	if rawBaseURL == "" {
+		return nil, errors.New("admin client base URL is required")
+	}
+	baseURL, err := url.Parse(rawBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid admin client base URL: %w", err)
+	}
+	if baseURL.Scheme == "" || baseURL.Host == "" {
+		return nil, errors.New("admin client base URL must include scheme and host")
+	}
+
+	return &AdminClient{
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: defaultAdminClientTimeout},
+	}, nil
+}
+
+func (c *AdminClient) Health(ctx context.Context) (AdminHealthResponse, error) {
+	return doAdminRequest[AdminHealthResponse](c, ctx, http.MethodGet, "/dbos-healthz", nil)
+}
+
+func (c *AdminClient) RecoverWorkflows(ctx context.Context, executorIDs []string) ([]string, error) {
+	return doAdminRequest[[]string](c, ctx, http.MethodPost, "/dbos-workflow-recovery", executorIDs)
+}
+
+func (c *AdminClient) ListQueues(ctx context.Context) ([]WorkflowQueue, error) {
+	return doAdminRequest[[]WorkflowQueue](c, ctx, http.MethodGet, "/dbos-workflow-queues-metadata", nil)
+}
+
+func (c *AdminClient) GarbageCollect(ctx context.Context, request AdminGarbageCollectRequest) error {
+	return doAdminRequestWithoutResponse(c, ctx, http.MethodPost, "/dbos-garbage-collect", request)
+}
+
+func (c *AdminClient) GlobalTimeout(ctx context.Context, cutoffTime time.Time) error {
+	return doAdminRequestWithoutResponse(c, ctx, http.MethodPost, "/dbos-global-timeout", AdminGlobalTimeoutRequest{
+		CutoffEpochTimestampMS: cutoffTime.UnixMilli(),
+	})
+}
+
+func (c *AdminClient) ListWorkflows(ctx context.Context, request AdminListWorkflowsRequest) ([]AdminWorkflow, error) {
+	return doAdminRequest[[]AdminWorkflow](c, ctx, http.MethodPost, "/workflows", request)
+}
+
+func (c *AdminClient) ListQueuedWorkflows(ctx context.Context, request AdminListWorkflowsRequest) ([]AdminWorkflow, error) {
+	return doAdminRequest[[]AdminWorkflow](c, ctx, http.MethodPost, "/queues", request)
+}
+
+func (c *AdminClient) GetWorkflow(ctx context.Context, workflowID string) (AdminWorkflow, error) {
+	return doAdminRequest[AdminWorkflow](c, ctx, http.MethodGet, "/workflows/"+url.PathEscape(workflowID), nil)
+}
+
+func (c *AdminClient) GetWorkflowSteps(ctx context.Context, workflowID string) ([]AdminWorkflowStep, error) {
+	return doAdminRequest[[]AdminWorkflowStep](c, ctx, http.MethodGet, "/workflows/"+url.PathEscape(workflowID)+"/steps", nil)
+}
+
+func (c *AdminClient) CancelWorkflow(ctx context.Context, workflowID string) error {
+	return doAdminRequestWithoutResponse(c, ctx, http.MethodPost, "/workflows/"+url.PathEscape(workflowID)+"/cancel", nil)
+}
+
+func (c *AdminClient) ResumeWorkflow(ctx context.Context, workflowID string) error {
+	return doAdminRequestWithoutResponse(c, ctx, http.MethodPost, "/workflows/"+url.PathEscape(workflowID)+"/resume", nil)
+}
+
+func (c *AdminClient) ForkWorkflow(ctx context.Context, workflowID string, request AdminForkWorkflowRequest) (AdminForkWorkflowResponse, error) {
+	return doAdminRequest[AdminForkWorkflowResponse](c, ctx, http.MethodPost, "/workflows/"+url.PathEscape(workflowID)+"/fork", request)
+}
+
+func (c *AdminClient) Deactivate(ctx context.Context) error {
+	return doAdminRequestWithoutResponse(c, ctx, http.MethodGet, "/deactivate", nil)
+}
+
+func doAdminRequest[T any](client *AdminClient, ctx context.Context, method, path string, body any) (T, error) {
+	var result T
+	response, err := client.do(ctx, method, path, body)
+	if err != nil {
+		return result, err
+	}
+	defer response.Body.Close()
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		return result, fmt.Errorf("decoding admin API response: %w", err)
+	}
+	return result, nil
+}
+
+func doAdminRequestWithoutResponse(client *AdminClient, ctx context.Context, method, path string, body any) error {
+	response, err := client.do(ctx, method, path, body)
+	if err != nil {
+		return err
+	}
+	return response.Body.Close()
+}
+
+func (c *AdminClient) do(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	var requestBody io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("encoding admin API request: %w", err)
+		}
+		requestBody = bytes.NewReader(encoded)
+	}
+
+	requestURL := c.baseURL.JoinPath(strings.TrimPrefix(path, "/"))
+	request, err := http.NewRequestWithContext(ctx, method, requestURL.String(), requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("creating admin API request: %w", err)
+	}
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("calling admin API: %w", err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		defer response.Body.Close()
+		responseBody, readErr := io.ReadAll(response.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("reading admin API error response: %w", readErr)
+		}
+		return nil, &AdminClientError{StatusCode: response.StatusCode, Body: strings.TrimSpace(string(responseBody))}
+	}
+	return response, nil
+}

--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -403,159 +402,55 @@ func TestAdminServer(t *testing.T) {
 			}
 		}()
 
-		client := &http.Client{Timeout: 5 * time.Second}
-		endpoint := fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_WORKFLOWS_PATTERN, "POST /"))
+		client, err := NewAdminClient(fmt.Sprintf("http://localhost:%d", _DEFAULT_ADMIN_SERVER_PORT))
+		require.NoError(t, err)
 
-		// Create first workflow
-		handle1, err := RunWorkflow(ctx, testWorkflow, "workflow1")
-		require.NoError(t, err, "Failed to create first workflow")
-		workflowID1 := handle1.GetWorkflowID()
-
-		// Wait for first workflow to complete
-		result1, err := handle1.GetResult()
-		require.NoError(t, err, "Failed to get first workflow result")
-		assert.Equal(t, "result-workflow1", result1)
-
-		// Record time between workflows
-		timeBetween := time.Now()
-		time.Sleep(500 * time.Millisecond)
-
-		// Create second workflow
-		handle2, err := RunWorkflow(ctx, testWorkflow, "workflow2")
-		require.NoError(t, err, "Failed to create second workflow")
-		result2, err := handle2.GetResult()
-		require.NoError(t, err, "Failed to get second workflow result")
-		assert.Equal(t, "result-workflow2", result2)
-		workflowID2 := handle2.GetWorkflowID()
-
-		// Test 1: Query with start_time before timeBetween (should get both workflows)
-		reqBody1 := map[string]any{
-			"start_time": timeBetween.Add(-2 * time.Second).Format(time.RFC3339Nano),
-			"limit":      10,
+		workflowIDs := make([]string, 5)
+		for i := range workflowIDs {
+			input := fmt.Sprintf("workflow-%d", i)
+			handle, err := RunWorkflow(ctx, testWorkflow, input)
+			require.NoError(t, err)
+			result, err := handle.GetResult()
+			require.NoError(t, err)
+			assert.Equal(t, "result-"+input, result)
+			workflowIDs[i] = handle.GetWorkflowID()
+			if i < len(workflowIDs)-1 {
+				time.Sleep(2 * time.Millisecond)
+			}
 		}
-		req1, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(mustMarshal(reqBody1)))
-		require.NoError(t, err, "Failed to create request 1")
-		req1.Header.Set("Content-Type", "application/json")
 
-		resp1, err := client.Do(req1)
-		require.NoError(t, err, "Failed to make request 1")
-		defer resp1.Body.Close()
+		allWorkflows, err := client.ListWorkflows(context.Background(), AdminListWorkflowsRequest{
+			WorkflowUUIDs: workflowIDs,
+		})
+		require.NoError(t, err)
+		require.Len(t, allWorkflows, len(workflowIDs))
 
-		assert.Equal(t, http.StatusOK, resp1.StatusCode)
-
-		var workflows1 []map[string]any
-		err = json.NewDecoder(resp1.Body).Decode(&workflows1)
-		require.NoError(t, err, "Failed to decode workflows response 1")
-
-		// Should have exactly 2 workflows that we just created
-		assert.Equal(t, 2, len(workflows1), "Expected exactly 2 workflows with start_time before timeBetween")
-
-		// Verify timestamps are epoch-millisecond strings (matches the DBOS console schema)
-		timeBetweenMillis := timeBetween.UnixMilli()
-		parseCreatedAt := func(wf map[string]any) int64 {
-			s, ok := wf["CreatedAt"].(string)
-			require.True(t, ok, "CreatedAt should be a string, got %T", wf["CreatedAt"])
-			ms, err := strconv.ParseInt(s, 10, 64)
-			require.NoError(t, err, "CreatedAt should parse as int64")
-			return ms
+		for i := 1; i < len(allWorkflows); i++ {
+			require.Less(t, allWorkflows[i-1].CreatedAt, allWorkflows[i].CreatedAt)
 		}
-		for _, wf := range workflows1 {
-			parseCreatedAt(wf)
+
+		thirdCreatedAt := allWorkflows[2].CreatedAt.Time()
+		afterThird := thirdCreatedAt.Add(time.Millisecond)
+
+		firstThree, err := client.ListWorkflows(context.Background(), AdminListWorkflowsRequest{
+			WorkflowUUIDs: workflowIDs,
+			EndTime:       &thirdCreatedAt,
+		})
+		require.NoError(t, err)
+		require.Len(t, firstThree, 3)
+
+		lastTwo, err := client.ListWorkflows(context.Background(), AdminListWorkflowsRequest{
+			WorkflowUUIDs: workflowIDs,
+			StartTime:     &afterThird,
+		})
+		require.NoError(t, err)
+		require.Len(t, lastTwo, 2)
+
+		filteredIDs := make([]string, 0, len(workflowIDs))
+		for _, workflow := range append(firstThree, lastTwo...) {
+			filteredIDs = append(filteredIDs, workflow.WorkflowUUID)
 		}
-		// Verify the timestamp is around timeBetween (within 2 seconds before or after)
-		assert.Less(t, parseCreatedAt(workflows1[0]), timeBetweenMillis, "first workflow CreatedAt should be before timeBetween")
-		assert.Greater(t, parseCreatedAt(workflows1[1]), timeBetweenMillis, "second workflow CreatedAt should be before timeBetween")
-
-		// Verify both workflow IDs are present
-		foundIDs1 := make(map[string]bool)
-		for _, wf := range workflows1 {
-			id, ok := wf["WorkflowUUID"].(string)
-			require.True(t, ok, "WorkflowUUID should be a string")
-			foundIDs1[id] = true
-		}
-		assert.True(t, foundIDs1[workflowID1], "Expected to find first workflow ID in results")
-		assert.True(t, foundIDs1[workflowID2], "Expected to find second workflow ID in results")
-
-		// Test 2: Query with start_time after timeBetween (should get only second workflow)
-		reqBody2 := map[string]any{
-			"start_time": timeBetween.Format(time.RFC3339Nano),
-			"limit":      10,
-		}
-		req2, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(mustMarshal(reqBody2)))
-		require.NoError(t, err, "Failed to create request 2")
-		req2.Header.Set("Content-Type", "application/json")
-
-		resp2, err := client.Do(req2)
-		require.NoError(t, err, "Failed to make request 2")
-		defer resp2.Body.Close()
-
-		assert.Equal(t, http.StatusOK, resp2.StatusCode)
-
-		var workflows2 []map[string]any
-		err = json.NewDecoder(resp2.Body).Decode(&workflows2)
-		require.NoError(t, err, "Failed to decode workflows response 2")
-
-		// Should have exactly 1 workflow (the second one)
-		assert.Equal(t, 1, len(workflows2), "Expected exactly 1 workflow with start_time after timeBetween")
-
-		// Verify it's the second workflow
-		id2, ok := workflows2[0]["WorkflowUUID"].(string)
-		require.True(t, ok, "WorkflowUUID should be a string")
-		assert.Equal(t, workflowID2, id2, "Expected second workflow ID in results")
-
-		// Also test end_time filter
-		reqBody3 := map[string]any{
-			"end_time": timeBetween.Format(time.RFC3339Nano),
-			"limit":    10,
-		}
-		req3, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(mustMarshal(reqBody3)))
-		require.NoError(t, err, "Failed to create request 3")
-		req3.Header.Set("Content-Type", "application/json")
-
-		resp3, err := client.Do(req3)
-		require.NoError(t, err, "Failed to make request 3")
-		defer resp3.Body.Close()
-
-		assert.Equal(t, http.StatusOK, resp3.StatusCode)
-
-		var workflows3 []map[string]any
-		err = json.NewDecoder(resp3.Body).Decode(&workflows3)
-		require.NoError(t, err, "Failed to decode workflows response 3")
-
-		// Should have exactly 1 workflow (the first one)
-		assert.Equal(t, 1, len(workflows3), "Expected exactly 1 workflow with end_time before timeBetween")
-
-		// Verify it's the first workflow
-		id3, ok := workflows3[0]["WorkflowUUID"].(string)
-		require.True(t, ok, "WorkflowUUID should be a string")
-		assert.Equal(t, workflowID1, id3, "Expected first workflow ID in results")
-
-		// Test 4: Query with empty body (should return all workflows)
-		req4, err := http.NewRequest(http.MethodPost, endpoint, nil)
-		require.NoError(t, err, "Failed to create request 4")
-
-		resp4, err := client.Do(req4)
-		require.NoError(t, err, "Failed to make request 4")
-		defer resp4.Body.Close()
-
-		assert.Equal(t, http.StatusOK, resp4.StatusCode)
-
-		var workflows4 []map[string]any
-		err = json.NewDecoder(resp4.Body).Decode(&workflows4)
-		require.NoError(t, err, "Failed to decode workflows response 4")
-
-		// Should have exactly 2 workflows (both that we created)
-		assert.Equal(t, 2, len(workflows4), "Expected exactly 2 workflows with empty body")
-
-		// Verify both workflow IDs are present
-		foundIDs4 := make(map[string]bool)
-		for _, wf := range workflows4 {
-			id, ok := wf["WorkflowUUID"].(string)
-			require.True(t, ok, "WorkflowUUID should be a string")
-			foundIDs4[id] = true
-		}
-		assert.True(t, foundIDs4[workflowID1], "Expected to find first workflow ID in empty body results")
-		assert.True(t, foundIDs4[workflowID2], "Expected to find second workflow ID in empty body results")
+		assert.ElementsMatch(t, workflowIDs, filteredIDs)
 	})
 
 	t.Run("ListQueuedWorkflows", func(t *testing.T) {


### PR DESCRIPTION
## Summary

  - Add typed AdminClient.
  - Replace manual HTTP requests in the time-filtering test.
  - Fix flaky list endpoint time-filtering test.

  ## Flakiness

  Previous test used time.Now() between workflow creations.

  Workflow created_at uses millisecond precision. Fast executions could place the workflow and boundary in the same millisecond. Inclusive filters then returned unexpected workflows.

  New test:

  - Creates five workflows with distinct timestamps.
  - Uses persisted third workflow timestamp as boundary.
  - Verifies 3 + 2 = 5 workflows.

  ## Testing

```sh
DBOS_TEST_BACKEND=sqlite go test ./dbos \
    -run '^TestAdminServer/List_endpoints_time_filtering$' -count=30
```

```sh
DBOS_TEST_BACKEND=sqlite go test ./dbos \
    -run '^TestAdminServer$' -count=1
```