### PR TITLE
Feat : Custom retry conditions in steps

### DIFF
--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1521,13 +1521,14 @@ type txn[R any] func(ctx context.Context, tx Tx) (R, error)
 
 // stepOptions holds the configuration for step execution using functional options pattern.
 type stepOptions struct {
-	maxRetries         int           // Maximum number of retry attempts (0 = no retries)
-	backoffFactor      float64       // Exponential backoff multiplier between retries (default: 2.0)
-	baseInterval       time.Duration // Initial delay between retries (default: 100ms)
-	maxInterval        time.Duration // Maximum delay between retries (default: 5s)
-	stepName           string        // Custom name for the step (defaults to function name)
-	preGeneratedStepID *int          // Pre generated stepID
-	txIsoLevel         *IsoLevel     // Transaction isolation level for runAsTxn (nil = ReadCommitted)
+	maxRetries         int              // Maximum number of retry attempts (0 = no retries)
+	backoffFactor      float64          // Exponential backoff multiplier between retries (default: 2.0)
+	baseInterval       time.Duration    // Initial delay between retries (default: 100ms)
+	maxInterval        time.Duration    // Maximum delay between retries (default: 5s)
+	stepName           string           // Custom name for the step (defaults to function name)
+	preGeneratedStepID *int             // Pre generated stepID
+	txIsoLevel         *IsoLevel        // Transaction isolation level for runAsTxn (nil = ReadCommitted)
+	retryPredicate     func(error) bool // Optional predicate: nil = retry all errors up to maxRetries
 }
 
 // setDefaults applies default values to stepOptions
@@ -1586,6 +1587,32 @@ func WithBaseInterval(interval time.Duration) StepOption {
 func WithMaxInterval(interval time.Duration) StepOption {
 	return func(opts *stepOptions) {
 		opts.maxInterval = interval
+	}
+}
+
+// WithRetryPredicate sets a function to decide whether a step error is retryable.
+// If the predicate returns false for an error, the step stops retrying immediately
+// and returns that error even if maxRetries has not been reached.
+// If not set (nil), all errors are retried up to maxRetries (default behaviour).
+//
+// The predicate is evaluated before the backoff delay, so a non-retryable error
+// exits immediately without waiting.
+//
+// Example : only retry HTTP 5xx errors, not 4xx client errors:
+//
+//	dbos.RunAsStep(ctx, callPaymentAPI,
+//	    dbos.WithStepMaxRetries(3),
+//	    dbos.WithRetryPredicate(func(err error) bool {
+//	        var apiErr *APIError
+//	        if errors.As(err, &apiErr) {
+//	            return apiErr.StatusCode >= 500
+//	        }
+//	        return true
+//	    }),
+//	)
+func WithRetryPredicate(fn func(error) bool) StepOption {
+	return func(opts *stepOptions) {
+		opts.retryPredicate = fn
 	}
 }
 
@@ -1706,6 +1733,10 @@ func executeStepWithRetry(c *dbosContext, workflowID string, stepOpts *stepOptio
 	var joinedErrors error
 	joinedErrors = errors.Join(joinedErrors, stepError)
 	for retry := 1; retry <= stepOpts.maxRetries; retry++ {
+		// Check predicate before sleeping, exit immediately on non-retryable errors.
+		if stepOpts.retryPredicate != nil && !stepOpts.retryPredicate(stepError) {
+			return stepOutput, stepError
+		}
 		delay := stepOpts.baseInterval
 		if retry > 1 {
 			exponentialDelay := float64(stepOpts.baseInterval) * math.Pow(stepOpts.backoffFactor, float64(retry-1))
@@ -1747,6 +1778,9 @@ func executeStepWithRetry(c *dbosContext, workflowID string, stepOpts *stepOptio
 //   - WithBackoffFactor: Exponential backoff multiplier (default: 2.0)
 //   - WithBaseInterval: Initial delay between retries (default: 100ms)
 //   - WithMaxInterval: Maximum delay between retries (default: 5s)
+//   - WithRetryPredicate: Function called before each retry to decide whether the error is retryable.
+//     If it returns false the step stops retrying immediately, even if maxRetries has not been reached.
+//     If not set, all errors are retried up to maxRetries (default behaviour).
 //
 // Example:
 //

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -426,32 +426,6 @@ func retryPredicateWorkflow(ctx DBOSContext, _ string) (string, error) {
 	)
 }
 
-var retryPredicateAllowAllCount int
-
-// retryPredicateAllowAllWorkflow: predicate always returns true same as no predicate.
-func retryPredicateAllowAllWorkflow(ctx DBOSContext, _ string) (string, error) {
-	return RunAsStep(ctx, func(_ context.Context) (string, error) {
-		retryPredicateAllowAllCount++
-		return "", fmt.Errorf("always transient")
-	},
-		WithStepMaxRetries(3),
-		WithBaseInterval(1*time.Millisecond),
-		WithRetryPredicate(func(err error) bool { return true }),
-	)
-}
-
-var retryPredicateNilCount int
-
-// retryPredicateNilWorkflow: no predicate set - all errors retried up to maxRetries.
-func retryPredicateNilWorkflow(ctx DBOSContext, _ string) (string, error) {
-	return RunAsStep(ctx, func(_ context.Context) (string, error) {
-		retryPredicateNilCount++
-		return "", fmt.Errorf("always fails")
-	},
-		WithStepMaxRetries(2),
-		WithBaseInterval(1*time.Millisecond),
-	)
-}
 
 func stepIdempotencyTest(_ context.Context) (string, error) {
 	stepIdempotencyCounter++
@@ -521,8 +495,6 @@ func TestSteps(t *testing.T) {
 	RegisterWorkflow(dbosCtx, testStepWf2)
 	RegisterWorkflow(dbosCtx, genericStepWorkflow)
 	RegisterWorkflow(dbosCtx, retryPredicateWorkflow)
-	RegisterWorkflow(dbosCtx, retryPredicateAllowAllWorkflow)
-	RegisterWorkflow(dbosCtx, retryPredicateNilWorkflow)
 	// Create a workflow that uses custom step names
 	customNameWorkflow := func(dbosCtx DBOSContext, input string) (string, error) {
 		// Run a step with a custom name
@@ -712,27 +684,6 @@ func TestSteps(t *testing.T) {
 		assert.Contains(t, err.Error(), "permanent failure")
 	})
 
-	t.Run("RetryPredicateAllowsRetryableErrors", func(t *testing.T) {
-		retryPredicateAllowAllCount = 0
-		handle, err := RunWorkflow(dbosCtx, retryPredicateAllowAllWorkflow, "")
-		require.NoError(t, err)
-
-		_, err = handle.GetResult()
-		require.Error(t, err)
-		// 1 initial + 3 retries = 4 total (predicate always returns true = no early exit)
-		assert.Equal(t, 4, retryPredicateAllowAllCount, "expected all retries to run when predicate always returns true")
-	})
-
-	t.Run("RetryPredicateNilBehavesLikeNoOption", func(t *testing.T) {
-		retryPredicateNilCount = 0
-		handle, err := RunWorkflow(dbosCtx, retryPredicateNilWorkflow, "")
-		require.NoError(t, err)
-
-		_, err = handle.GetResult()
-		require.Error(t, err)
-		// 1 initial + 2 retries = 3 total (nil predicate = existing behaviour unchanged)
-		assert.Equal(t, 3, retryPredicateNilCount, "expected all retries when no predicate set")
-	})
 
 	t.Run("checkStepName", func(t *testing.T) {
 		// Run first workflow with custom step name

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -405,6 +405,54 @@ func stepRetryAlwaysFailsStep(_ context.Context) (string, error) {
 
 var stepIdempotencyCounter int
 
+// --- retry predicate test helpers ---
+
+var retryPredicateAttemptCount int
+
+// retryPredicateWorkflow: stops on "permanent" errors, retries transient ones.
+func retryPredicateWorkflow(ctx DBOSContext, _ string) (string, error) {
+	return RunAsStep(ctx, func(_ context.Context) (string, error) {
+		retryPredicateAttemptCount++
+		if retryPredicateAttemptCount == 2 {
+			return "", fmt.Errorf("permanent failure")
+		}
+		return "", fmt.Errorf("transient failure")
+	},
+		WithStepMaxRetries(5),
+		WithBaseInterval(1*time.Millisecond),
+		WithRetryPredicate(func(err error) bool {
+			return !strings.Contains(err.Error(), "permanent")
+		}),
+	)
+}
+
+var retryPredicateAllowAllCount int
+
+// retryPredicateAllowAllWorkflow: predicate always returns true same as no predicate.
+func retryPredicateAllowAllWorkflow(ctx DBOSContext, _ string) (string, error) {
+	return RunAsStep(ctx, func(_ context.Context) (string, error) {
+		retryPredicateAllowAllCount++
+		return "", fmt.Errorf("always transient")
+	},
+		WithStepMaxRetries(3),
+		WithBaseInterval(1*time.Millisecond),
+		WithRetryPredicate(func(err error) bool { return true }),
+	)
+}
+
+var retryPredicateNilCount int
+
+// retryPredicateNilWorkflow: no predicate set - all errors retried up to maxRetries.
+func retryPredicateNilWorkflow(ctx DBOSContext, _ string) (string, error) {
+	return RunAsStep(ctx, func(_ context.Context) (string, error) {
+		retryPredicateNilCount++
+		return "", fmt.Errorf("always fails")
+	},
+		WithStepMaxRetries(2),
+		WithBaseInterval(1*time.Millisecond),
+	)
+}
+
 func stepIdempotencyTest(_ context.Context) (string, error) {
 	stepIdempotencyCounter++
 	return "", nil
@@ -472,6 +520,9 @@ func TestSteps(t *testing.T) {
 	RegisterWorkflow(dbosCtx, testStepWf1)
 	RegisterWorkflow(dbosCtx, testStepWf2)
 	RegisterWorkflow(dbosCtx, genericStepWorkflow)
+	RegisterWorkflow(dbosCtx, retryPredicateWorkflow)
+	RegisterWorkflow(dbosCtx, retryPredicateAllowAllWorkflow)
+	RegisterWorkflow(dbosCtx, retryPredicateNilWorkflow)
 	// Create a workflow that uses custom step names
 	customNameWorkflow := func(dbosCtx DBOSContext, input string) (string, error) {
 		// Run a step with a custom name
@@ -647,6 +698,40 @@ func TestSteps(t *testing.T) {
 
 		// Verify the idempotency step was executed only once
 		assert.Equal(t, 1, stepIdempotencyCounter, "expected idempotency step to be executed only once")
+	})
+
+	t.Run("RetryPredicateStopsOnNonRetryableError", func(t *testing.T) {
+		retryPredicateAttemptCount = 0
+		handle, err := RunWorkflow(dbosCtx, retryPredicateWorkflow, "")
+		require.NoError(t, err)
+
+		_, err = handle.GetResult()
+		require.Error(t, err, "expected error from non-retryable failure")
+		// attempt 1 = transient (retried), attempt 2 = permanent (predicate returns false - stop)
+		assert.Equal(t, 2, retryPredicateAttemptCount, "expected exactly 2 attempts before predicate stopped retrying")
+		assert.Contains(t, err.Error(), "permanent failure")
+	})
+
+	t.Run("RetryPredicateAllowsRetryableErrors", func(t *testing.T) {
+		retryPredicateAllowAllCount = 0
+		handle, err := RunWorkflow(dbosCtx, retryPredicateAllowAllWorkflow, "")
+		require.NoError(t, err)
+
+		_, err = handle.GetResult()
+		require.Error(t, err)
+		// 1 initial + 3 retries = 4 total (predicate always returns true = no early exit)
+		assert.Equal(t, 4, retryPredicateAllowAllCount, "expected all retries to run when predicate always returns true")
+	})
+
+	t.Run("RetryPredicateNilBehavesLikeNoOption", func(t *testing.T) {
+		retryPredicateNilCount = 0
+		handle, err := RunWorkflow(dbosCtx, retryPredicateNilWorkflow, "")
+		require.NoError(t, err)
+
+		_, err = handle.GetResult()
+		require.Error(t, err)
+		// 1 initial + 2 retries = 3 total (nil predicate = existing behaviour unchanged)
+		assert.Equal(t, 3, retryPredicateNilCount, "expected all retries when no predicate set")
 	})
 
 	t.Run("checkStepName", func(t *testing.T) {
@@ -6084,7 +6169,7 @@ func TestStreams(t *testing.T) {
 		// Verifies that the readStream goroutine exits when the consumer's context is
 		// cancelled, even if the consumer stops reading from the channel.
 		// goleak (via checkLeaks:true on this test) will fail if the goroutine leaks.
-		streamBlockEvent = NewEvent()    // not set — workflow blocks after initial writes
+		streamBlockEvent = NewEvent()   // not set — workflow blocks after initial writes
 		streamStartedEvent = NewEvent() // signals that initial writes are done
 
 		streamKey := "test-stream-leak"


### PR DESCRIPTION
Adds a `WithRetryPredicate(func(error) bool)` option to `RunAsStep` that lets callers decide per-error whether a retry should happen. If the predicate returns false, the step stops immediately without waiting through the remaining backoff - even if maxRetries has not been reached. When not set, all errors are retried as before with no behaviour change.

Closes #302 