### PR TITLE
Support configured instance + fix collision execution

### DIFF
--- a/.github/workflows/tests-crdb.yml
+++ b/.github/workflows/tests-crdb.yml
@@ -64,14 +64,14 @@ jobs:
       working-directory: ./integration
 
     - name: Run integration tests
-      run: go vet ./... && gotestsum --format github-action -- -race -v -count=1 -timeout 30m ./...
+      run: go vet ./... && gotestsum --format github-action -- -race -v -count=1 -timeout 45m ./...
       working-directory: ./integration
       env:
         DBOS_SYSTEM_DATABASE_URL: postgresql://root@localhost:26257/dbos?sslmode=disable
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run CLI tests
-      run: go vet ./... && gotestsum --format github-action -- -race -v -count=1 -timeout 30m ./...
+      run: go vet ./... && gotestsum --format github-action -- -race -v -count=1 -timeout 45m ./...
       working-directory: ./cmd/dbos
       env:
         ISCRDB: true
@@ -82,7 +82,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run tests
-      run: go vet ./... && gotestsum --format github-action -- -race -v -count=1 -timeout 30m ./...
+      run: go vet ./... && gotestsum --format github-action -- -race -v -count=1 -timeout 45m ./...
       working-directory: ./dbos
       env:
         DBOS_SYSTEM_DATABASE_URL: postgresql://root@localhost:26257/dbos?sslmode=disable

--- a/dbos/client.go
+++ b/dbos/client.go
@@ -167,8 +167,9 @@ func WithEnqueueClassName(className string) EnqueueOption {
 }
 
 // WithEnqueueConfigName sets the config/instance name for the enqueued workflow.
-// This is required when enqueueing to Python, TypeScript, or Java targets that
-// register workflows on class instances (e.g. DBOSConfiguredInstance / ConfiguredInstance).
+// This is required when enqueueing to a workflow registered on a configured instance:
+// a Go workflow registered with WithInstance, or a Python/TypeScript/Java class
+// instance workflow (e.g. DBOSConfiguredInstance / ConfiguredInstance).
 // Pass an empty string ("") to target the default (unnamed) instance.
 func WithEnqueueConfigName(configName string) EnqueueOption {
 	return func(opts *enqueueOptions) {

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -1807,6 +1807,54 @@ func TestDebouncerClient(t *testing.T) {
 	})
 }
 
+// TestDebouncerClientConfiguredInstance verifies that a client-side debouncer targets the
+// workflow registration bound to a specific configured instance via WithDebouncerConfigName.
+func TestDebouncerClientConfiguredInstance(t *testing.T) {
+	serverCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+
+	// Set internal queue polling interval to 10ms for faster tests
+	internalQueue := serverCtx.(*dbosContext).queueRunner.workflowQueueRegistry[_DBOS_INTERNAL_QUEUE_NAME]
+	internalQueue.basePollingInterval = 10 * time.Millisecond
+	serverCtx.(*dbosContext).queueRunner.workflowQueueRegistry[_DBOS_INTERNAL_QUEUE_NAME] = internalQueue
+
+	// Two configured instances of the same workflow method, sharing a custom name
+	slackNotifier := &configuredNotifier{channel: "slack"}
+	emailNotifier := &configuredNotifier{channel: "email"}
+	RegisterWorkflow(serverCtx, slackNotifier.Send, WithWorkflowName("NotifierWorkflow"), WithInstance(slackNotifier))
+	RegisterWorkflow(serverCtx, emailNotifier.Send, WithWorkflowName("NotifierWorkflow"), WithInstance(emailNotifier))
+
+	err := Launch(serverCtx)
+	require.NoError(t, err)
+
+	client, err := NewClient(context.Background(), ClientConfig{DatabaseURL: backendDatabaseURL(t)})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if client != nil {
+			client.Shutdown(30 * time.Second)
+		}
+	})
+
+	// The config name routes the debounced workflow to the matching registered instance
+	for _, inst := range []*configuredNotifier{slackNotifier, emailNotifier} {
+		debouncer := NewDebouncerClient[string, string]("NotifierWorkflow", client,
+			WithDebouncerTimeout(10*time.Second),
+			WithDebouncerConfigName(inst.channel))
+
+		handle, err := debouncer.Debounce("instance-key-"+inst.channel, 100*time.Millisecond, "hi")
+		require.NoError(t, err, "failed to debounce on instance %q", inst.channel)
+
+		result, err := handle.GetResult()
+		require.NoError(t, err, "failed to get result for instance %q", inst.channel)
+		assert.Equal(t, inst.channel+": hi", result, "debounced workflow ran on the wrong instance")
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err)
+		assert.Equal(t, "NotifierWorkflow", status.Name)
+		require.NotNil(t, status.ConfigName, "config name not recorded")
+		assert.Equal(t, inst.channel, *status.ConfigName)
+	}
+}
+
 func TestDebouncerClientWorkflowOptions(t *testing.T) {
 	// Setup server context
 	serverCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -75,6 +75,12 @@ func TestClientEnqueue(t *testing.T) {
 	}
 	RegisterWorkflow(serverCtx, partitionedWorkflow, WithWorkflowName("PartitionedWorkflow"))
 
+	// Two configured instances of the same workflow method, sharing a custom name (for the config name test)
+	slackNotifier := &configuredNotifier{channel: "slack"}
+	emailNotifier := &configuredNotifier{channel: "email"}
+	RegisterWorkflow(serverCtx, slackNotifier.Send, WithWorkflowName("NotifierWorkflow"), WithInstance(slackNotifier))
+	RegisterWorkflow(serverCtx, emailNotifier.Send, WithWorkflowName("NotifierWorkflow"), WithInstance(emailNotifier))
+
 	// Launch the server context to start processing tasks
 	err := Launch(serverCtx)
 	require.NoError(t, err)
@@ -90,6 +96,27 @@ func TestClientEnqueue(t *testing.T) {
 		if client != nil {
 			client.Shutdown(30 * time.Second)
 		}
+	})
+
+	t.Run("EnqueueToConfiguredInstance", func(t *testing.T) {
+		// The config name routes the workflow to the matching registered instance
+		for _, inst := range []*configuredNotifier{slackNotifier, emailNotifier} {
+			handle, err := Enqueue[string, string](client, queue.Name, "NotifierWorkflow", "hi",
+				WithEnqueueConfigName(inst.channel),
+				WithEnqueueApplicationVersion(serverCtx.GetApplicationVersion()))
+			require.NoError(t, err)
+
+			result, err := handle.GetResult()
+			require.NoError(t, err)
+			assert.Equal(t, inst.channel+": hi", result, "workflow ran on the wrong instance")
+
+			status, err := handle.GetStatus()
+			require.NoError(t, err)
+			assert.Equal(t, "NotifierWorkflow", status.Name)
+			require.NotNil(t, status.ConfigName, "config name not recorded")
+			assert.Equal(t, inst.channel, *status.ConfigName)
+		}
+		assert.True(t, queueEntriesAreCleanedUp(serverCtx), "expected queue entries to be cleaned up")
 	})
 
 	t.Run("EnqueueAndGetResult", func(t *testing.T) {

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -103,6 +103,7 @@ func TestClientEnqueue(t *testing.T) {
 		for _, inst := range []*configuredNotifier{slackNotifier, emailNotifier} {
 			handle, err := Enqueue[string, string](client, queue.Name, "NotifierWorkflow", "hi",
 				WithEnqueueConfigName(inst.channel),
+				WithEnqueueClassName("interop"),
 				WithEnqueueApplicationVersion(serverCtx.GetApplicationVersion()))
 			require.NoError(t, err)
 
@@ -115,6 +116,7 @@ func TestClientEnqueue(t *testing.T) {
 			assert.Equal(t, "NotifierWorkflow", status.Name)
 			require.NotNil(t, status.ConfigName, "config name not recorded")
 			assert.Equal(t, inst.channel, *status.ConfigName)
+			assert.Equal(t, "interop", status.ClassName, "enqueuer-provided class name not preserved")
 		}
 		assert.True(t, queueEntriesAreCleanedUp(serverCtx), "expected queue entries to be cleaned up")
 	})

--- a/dbos/debouncer.go
+++ b/dbos/debouncer.go
@@ -46,14 +46,48 @@ type Debouncer[P any, R any] struct {
 }
 
 // DebouncerOption is a functional option for configuring debouncer creation parameters.
-type DebouncerOption func(*time.Duration)
+type DebouncerOption func(*debouncerOptions)
+
+type debouncerOptions struct {
+	timeout    time.Duration
+	instance   ConfiguredInstance
+	configName string
+}
 
 // WithDebouncerTimeout sets the maximum time before starting the workflow.
 // If timeout is zero (the default), there is no maximum time limit.
 func WithDebouncerTimeout(timeout time.Duration) DebouncerOption {
-	return func(t *time.Duration) {
-		*t = timeout
+	return func(o *debouncerOptions) {
+		o.timeout = timeout
 	}
+}
+
+// WithDebouncerInstance targets the workflow registration bound to the given configured
+// instance (see WithInstance). Required when the debounced workflow is a method of a
+// configured instance:
+//
+//	debouncer := dbos.NewDebouncer(ctx, slack.Send, dbos.WithDebouncerInstance(slack))
+func WithDebouncerInstance(instance ConfiguredInstance) DebouncerOption {
+	return func(o *debouncerOptions) {
+		o.instance = instance
+	}
+}
+
+// WithDebouncerConfigName targets the workflow registration bound to the configured
+// instance with the given config name. Use with NewDebouncerClient, where the instance
+// object itself is not available.
+func WithDebouncerConfigName(configName string) DebouncerOption {
+	return func(o *debouncerOptions) {
+		o.configName = configName
+	}
+}
+
+// resolveConfigName returns the config name from the instance, if set, else the raw config name.
+func (o *debouncerOptions) resolveConfigName() string {
+	if o.instance != nil {
+		return o.instance.ConfigName()
+	}
+	return o.configName
 }
 
 // NewDebouncer creates a new debouncer for the specified workflow.
@@ -63,6 +97,7 @@ func WithDebouncerTimeout(timeout time.Duration) DebouncerOption {
 //   - workflow: The workflow function to debounce (must be registered)
 //   - opts: Optional functional options for configuring the debouncer:
 //   - WithDebouncerTimeout: Maximum time before starting the workflow (0 = no timeout) [optional]
+//   - WithDebouncerInstance: The configured instance the workflow method is bound to [required for instance methods]
 //
 // Returns a pointer to a Debouncer instance that can be used to call Debounce.
 //
@@ -82,9 +117,9 @@ func NewDebouncer[P any, R any](
 	workflow Workflow[P, R],
 	opts ...DebouncerOption,
 ) *Debouncer[P, R] {
-	timeout := time.Duration(0) // Default: no timeout
+	options := debouncerOptions{}
 	for _, opt := range opts {
-		opt(&timeout)
+		opt(&options)
 	}
 
 	dbosCtx, ok := ctx.(*dbosContext)
@@ -98,8 +133,12 @@ func NewDebouncer[P any, R any](
 		panic(newInitializationError("cannot create debouncer after DBOS has launched"))
 	}
 
-	// Get the fully qualified name of the workflow function using reflection
+	// Get the fully qualified name of the workflow function using reflection.
+	// Configured instance workflows are registered under a name qualified with their config name.
 	fqn := resolveWorkflowFunctionName(workflow)
+	if configName := options.resolveConfigName(); configName != "" {
+		fqn = instanceQualifiedName(fqn, configName)
+	}
 
 	dbosCtx.logger.Debug("Creating new debouncer", "workflow_fqn", fqn)
 
@@ -117,7 +156,7 @@ func NewDebouncer[P any, R any](
 
 	return &Debouncer[P, R]{
 		WorkflowFQN:          fqn,
-		Timeout:              timeout,
+		Timeout:              options.timeout,
 		internalDebouncerFQN: internalDebouncerFQN,
 	}
 }
@@ -239,6 +278,7 @@ type DebouncerClient[P any, R any] struct {
 //   - client: The DBOS client to use for operations
 //   - opts: Optional functional options for configuring the debouncer:
 //   - WithDebouncerTimeout: Maximum time before starting the workflow (0 = no timeout) [optional]
+//   - WithDebouncerConfigName: Config name of the configured instance the workflow is bound to [required for instance methods]
 //
 // Returns a pointer to a DebouncerClient instance that can be used to call Debounce.
 func NewDebouncerClient[P any, R any](
@@ -246,15 +286,20 @@ func NewDebouncerClient[P any, R any](
 	client Client,
 	opts ...DebouncerOption,
 ) *DebouncerClient[P, R] {
-	timeout := time.Duration(0) // Default: no timeout
+	options := debouncerOptions{}
 	for _, opt := range opts {
-		opt(&timeout)
+		opt(&options)
+	}
+
+	// Configured instance workflows are registered under a name qualified with their config name.
+	if configName := options.resolveConfigName(); configName != "" {
+		workflowName = instanceQualifiedName(workflowName, configName)
 	}
 
 	return &DebouncerClient[P, R]{
 		WorkflowName: workflowName,
 		Client:       client,
-		Timeout:      timeout,
+		Timeout:      options.timeout,
 		// Use the any,any internal debouncer workflow FQN because that's all the server knows
 		internalDebouncerFQN: resolveWorkflowFunctionName(internalDebouncerWF[any, any]),
 	}

--- a/dbos/debouncer_test.go
+++ b/dbos/debouncer_test.go
@@ -391,3 +391,40 @@ func TestDebouncerWorkflowOptions(t *testing.T) {
 	assert.Equal(t, expectedAuthenticatedRoles, workflow.AuthenticatedRoles, "authenticated roles should match")
 	assert.Equal(t, WorkflowStatusSuccess, workflow.Status, "workflow should have succeeded")
 }
+
+// TestDebouncerConfiguredInstance verifies a debouncer can target a workflow method
+// registered on a configured instance via WithDebouncerInstance, and that each
+// debouncer runs the target on its own instance.
+func TestDebouncerConfiguredInstance(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+
+	internalQueue := dbosCtx.(*dbosContext).queueRunner.workflowQueueRegistry[_DBOS_INTERNAL_QUEUE_NAME]
+	internalQueue.basePollingInterval = 10 * time.Millisecond
+	dbosCtx.(*dbosContext).queueRunner.workflowQueueRegistry[_DBOS_INTERNAL_QUEUE_NAME] = internalQueue
+
+	slack := &configuredNotifier{channel: "slack"}
+	email := &configuredNotifier{channel: "email"}
+	RegisterWorkflow(dbosCtx, slack.Send, WithInstance(slack))
+	RegisterWorkflow(dbosCtx, email.Send, WithInstance(email))
+
+	// Without the instance, the bare (colliding) FQN was never registered: fail loudly
+	require.Panics(t, func() { NewDebouncer(dbosCtx, slack.Send) },
+		"creating a debouncer for an instance method without WithDebouncerInstance should panic")
+
+	slackDebouncer := NewDebouncer(dbosCtx, slack.Send, WithDebouncerInstance(slack))
+	emailDebouncer := NewDebouncer(dbosCtx, email.Send, WithDebouncerInstance(email))
+
+	require.NoError(t, Launch(dbosCtx))
+
+	handle, err := slackDebouncer.Debounce(dbosCtx, "slack-key", 100*time.Millisecond, "hi")
+	require.NoError(t, err, "failed to debounce on the slack instance")
+	result, err := handle.GetResult()
+	require.NoError(t, err, "failed to get result from the slack instance")
+	assert.Equal(t, "slack: hi", result, "debounced workflow should run on the slack instance")
+
+	handle, err = emailDebouncer.Debounce(dbosCtx, "email-key", 100*time.Millisecond, "hi")
+	require.NoError(t, err, "failed to debounce on the email instance")
+	result, err = handle.GetResult()
+	require.NoError(t, err, "failed to get result from the email instance")
+	assert.Equal(t, "email: hi", result, "debounced workflow should run on the email instance")
+}

--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -296,8 +296,13 @@ func (qr *queueRunner) runQueue(ctx *dbosContext, queue WorkflowQueue) {
 				queueLogger.Debug("Dequeued workflows from queue", "workflows", len(dequeuedWorkflows))
 			}
 			for _, workflow := range dequeuedWorkflows {
-				// Find the workflow in the registry
-				wfName, ok := ctx.workflowCustomNametoFQN.Load(workflow.name)
+				// Find the workflow in the registry. Configured instance workflows are
+				// registered under a name qualified with their config name.
+				lookupName := workflow.name
+				if workflow.configName != nil && *workflow.configName != "" {
+					lookupName = instanceQualifiedName(workflow.name, *workflow.configName)
+				}
+				wfName, ok := ctx.workflowCustomNametoFQN.Load(lookupName)
 				if !ok {
 					queueLogger.Error("Workflow not found in registry", "workflow_name", workflow.name)
 					continue

--- a/dbos/recovery.go
+++ b/dbos/recovery.go
@@ -34,7 +34,12 @@ func recoverPendingWorkflows(ctx *dbosContext, executorIDs []string) ([]Workflow
 			continue
 		}
 
-		wfName, ok := ctx.workflowCustomNametoFQN.Load(workflow.Name)
+		// Configured instance workflows are registered under a name qualified with their config name.
+		lookupName := workflow.Name
+		if workflow.ConfigName != nil && *workflow.ConfigName != "" {
+			lookupName = instanceQualifiedName(workflow.Name, *workflow.ConfigName)
+		}
+		wfName, ok := ctx.workflowCustomNametoFQN.Load(lookupName)
 		if !ok {
 			ctx.logger.Error("Workflow not found in registry", "workflow_name", workflow.Name)
 			continue

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1154,7 +1154,7 @@ func (s *sysDB) listWorkflows(ctx context.Context, input listWorkflowsDBInput) (
 		"executor_id", "created_at", "updated_at", "application_version", "application_id",
 		"recovery_attempts", "queue_name", "workflow_timeout_ms", "workflow_deadline_epoch_ms", "started_at_epoch_ms",
 		"deduplication_id", "priority", "queue_partition_key", "forked_from", "parent_workflow_id",
-		"serialization", "delay_until_epoch_ms", "was_forked_from", "completed_at",
+		"serialization", "delay_until_epoch_ms", "was_forked_from", "completed_at", "class_name", "config_name",
 	}
 
 	if input.loadOutput {
@@ -1299,6 +1299,7 @@ func (s *sysDB) listWorkflows(ctx context.Context, input listWorkflowsDBInput) (
 		var applicationID *string
 		var delayUntilEpochMs *int64
 		var completedAtMs *int64
+		var className *string
 
 		// Build scan arguments dynamically based on loaded columns.
 		scanArgs := []any{
@@ -1307,7 +1308,7 @@ func (s *sysDB) listWorkflows(ctx context.Context, input listWorkflowsDBInput) (
 			&updatedAtMs, &applicationVersion, &applicationID,
 			&wf.Attempts, &queueName, &timeoutMs,
 			&deadlineMs, &startedAtMs, &deduplicationID, &wf.Priority, &queuePartitionKey, &forkedFrom, &parentWorkflowID,
-			&serialization, &delayUntilEpochMs, &wf.WasForkedFrom, &completedAtMs,
+			&serialization, &delayUntilEpochMs, &wf.WasForkedFrom, &completedAtMs, &className, &wf.ConfigName,
 		}
 
 		if input.loadOutput {
@@ -1324,6 +1325,9 @@ func (s *sysDB) listWorkflows(ctx context.Context, input listWorkflowsDBInput) (
 
 		if authenticatedUser != nil {
 			wf.AuthenticatedUser = *authenticatedUser
+		}
+		if className != nil {
+			wf.ClassName = *className
 		}
 		if assumedRole != nil {
 			wf.AssumedRole = *assumedRole
@@ -1987,8 +1991,10 @@ func (s *sysDB) forkWorkflow(ctx context.Context, input forkWorkflowDBInput) (st
 		updated_at,
 		recovery_attempts,
 		forked_from,
-		serialization
-	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`, s.dialect.SchemaPrefix(s.schema))
+		serialization,
+		class_name,
+		config_name
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`, s.dialect.SchemaPrefix(s.schema))
 
 	// Marshal authenticated roles (slice of strings) to JSON for TEXT column
 	authenticatedRoles, err := json.Marshal(originalWorkflow.AuthenticatedRoles)
@@ -1999,6 +2005,11 @@ func (s *sysDB) forkWorkflow(ctx context.Context, input forkWorkflowDBInput) (st
 	var queuePartitionKey any
 	if input.queuePartitionKey != "" {
 		queuePartitionKey = input.queuePartitionKey
+	}
+
+	var className any
+	if originalWorkflow.ClassName != "" {
+		className = originalWorkflow.ClassName
 	}
 
 	_, err = execCtx(ctx, insertQuery,
@@ -2016,8 +2027,10 @@ func (s *sysDB) forkWorkflow(ctx context.Context, input forkWorkflowDBInput) (st
 		time.Now().UnixMilli(),
 		time.Now().UnixMilli(),
 		0,
-		input.originalWorkflowID,       // forked_from
-		originalWorkflow.Serialization) // serialization
+		input.originalWorkflowID,      // forked_from
+		originalWorkflow.Serialization,
+		className,
+		originalWorkflow.ConfigName)
 
 	if err != nil {
 		return "", fmt.Errorf("failed to insert forked workflow status: %w", err)
@@ -3967,6 +3980,7 @@ type dequeuedWorkflow struct {
 	name          string
 	input         *string
 	serialization string
+	configName    *string
 }
 
 type dequeueWorkflowsInput struct {
@@ -4133,7 +4147,7 @@ func (s *sysDB) dequeueWorkflows(ctx context.Context, input dequeueWorkflowsInpu
 		        ELSE workflow_deadline_epoch_ms
 		    END
 		WHERE workflow_uuid = $6 AND status = $7
-		RETURNING name, inputs, serialization`, schemaPrefix)
+		RETURNING name, inputs, serialization, config_name`, schemaPrefix)
 
 	var retWorkflows []dequeuedWorkflow
 	for _, id := range dequeuedIDs {
@@ -4152,7 +4166,7 @@ func (s *sysDB) dequeueWorkflows(ctx context.Context, input dequeueWorkflowsInpu
 			time.Now().UnixMilli(),
 			input.queue.RateLimit != nil,
 			id,
-			WorkflowStatusEnqueued).Scan(&retWorkflow.name, &retWorkflow.input, &serialization)
+			WorkflowStatusEnqueued).Scan(&retWorkflow.name, &retWorkflow.input, &serialization, &retWorkflow.configName)
 		if err != nil {
 			if err == pgx.ErrNoRows {
 				continue

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -633,10 +633,25 @@ func resolveWorkflowFunctionName[P any, R any](fn Workflow[P, R]) string {
 // RegisterWorkflow registers a function as a durable workflow that can be executed and recovered.
 // The function is registered with type safety - P represents the input type and R the return type.
 //
+// Workflows are identified by a name derived from the function's code pointer, so each
+// registered function value must have a unique name. Registrable:
+//   - Top-level named functions: the recommended form. Each has a unique name.
+//   - Generic function instantiations: type parameters are automatically appended to the name,
+//     so distinct instantiations are distinct workflows.
+//   - Method values bound to a configured instance (e.g. inst.Run), registered with
+//     WithInstance: the instance's config name qualifies the workflow name, so each
+//     instance registers its own workflow. Run these with WithRunInstance.
+//   - A closure or method value, at most ONE per source expression: all values built
+//     from the same func literal or method (e.g. a.Run and b.Run, or closures from one
+//     factory) share a name. Registering a second one panics with
+//     ConflictingRegistrationError; use WithInstance (methods) or distinct top-level
+//     functions (closures) instead.
+//
 // Registration options include:
 //   - WithMaxRetries: Set maximum retry attempts for workflow recovery
 //   - WithSchedule: Register as a scheduled workflow with cron syntax
-//   - WithWorkflowName:: Set a custom name for the workflow
+//   - WithWorkflowName: Set a custom name for the workflow
+//   - WithInstance: Register a method bound to a named instance
 //
 // Scheduled workflows receive a time.Time as input representing the scheduled execution time.
 //

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -458,11 +458,13 @@ type WorkflowRegistryEntry struct {
 	workflowFn      WorkflowFunc // Type-erased registered function taking a raw (non-encoded) input. Used by RunWorkflow for direct execution.
 	MaxRetries      int
 	Name            string
-	FQN             string // Fully qualified name of the workflow function
+	FQN             string // Fully qualified name of the workflow function. For configured instances, qualified with the config name.
 	CronSchedule    string // Empty string for non-scheduled workflows
+	ClassName       string // Receiver type name for configured instance workflows
+	ConfigName      string // Config name for configured instance workflows
 }
 
-func registerWorkflow(ctx DBOSContext, workflowFQN string, fn wrappedWorkflowFunc, workflowFn WorkflowFunc, maxRetries int, customName string) {
+func registerWorkflow(ctx DBOSContext, entry WorkflowRegistryEntry) {
 	// Skip if we don't have a concrete dbosContext
 	c, ok := ctx.(*dbosContext)
 	if !ok {
@@ -474,29 +476,27 @@ func registerWorkflow(ctx DBOSContext, workflowFQN string, fn wrappedWorkflowFun
 	}
 
 	// Check if workflow already exists and store atomically using LoadOrStore
-	entry := WorkflowRegistryEntry{
-		wrappedFunction: fn,
-		workflowFn:      workflowFn,
-		FQN:             workflowFQN,
-		MaxRetries:      maxRetries,
-		Name:            customName,
-		CronSchedule:    "",
-	}
-
-	if _, exists := c.workflowRegistry.LoadOrStore(workflowFQN, entry); exists {
-		c.logger.Error("workflow function already registered", "fqn", workflowFQN)
-		panic(newConflictingRegistrationError(workflowFQN))
+	if _, exists := c.workflowRegistry.LoadOrStore(entry.FQN, entry); exists {
+		c.logger.Error("workflow function already registered", "fqn", entry.FQN)
+		panic(newConflictingRegistrationError(entry.FQN))
 	}
 
 	// We need to get a mapping from custom name to FQN for registry lookups that might not know the FQN (queue, recovery)
 	// We also panic if we found the name was already registered (this could happen if registering two different workflows under the same custom name)
-	if len(customName) > 0 {
-		if _, exists := c.workflowCustomNametoFQN.LoadOrStore(customName, workflowFQN); exists {
-			c.logger.Error("workflow function already registered", "custom_name", customName)
-			panic(newConflictingRegistrationError(customName))
+	// Configured instance workflows are keyed by name + "/" + config name, matching the lookup key
+	// queue and recovery rebuild from the recorded (name, config_name) pair. The same workflow
+	// name can thus be shared by many instances, like in the other Transact SDKs.
+	if len(entry.Name) > 0 {
+		lookupName := entry.Name
+		if len(entry.ConfigName) > 0 {
+			lookupName = instanceQualifiedName(entry.Name, entry.ConfigName)
+		}
+		if _, exists := c.workflowCustomNametoFQN.LoadOrStore(lookupName, entry.FQN); exists {
+			c.logger.Error("workflow function already registered", "custom_name", lookupName)
+			panic(newConflictingRegistrationError(lookupName))
 		}
 	} else {
-		c.workflowCustomNametoFQN.Store(workflowFQN, workflowFQN) // Store the FQN as the custom name if none was provided
+		c.workflowCustomNametoFQN.Store(entry.FQN, entry.FQN) // Store the FQN as the custom name if none was provided
 	}
 }
 
@@ -551,8 +551,8 @@ type ConfiguredInstance interface {
 }
 
 // instanceQualifiedName returns the per-instance registry key for a workflow method.
-func instanceQualifiedName(fqn string, inst ConfiguredInstance) string {
-	return fqn + "/" + inst.ConfigName()
+func instanceQualifiedName(name, configName string) string {
+	return name + "/" + configName
 }
 
 type workflowRegistrationOptions struct {
@@ -691,12 +691,19 @@ func RegisterWorkflow[P any, R any](ctx DBOSContext, fn Workflow[P, R], opts ...
 	fqn := resolveWorkflowFunctionName(fn)
 
 	// Method values bound to different receivers share an FQN: qualify the registry key
-	// with the instance config name so each instance registers its own entry.
+	// with the instance config name so each instance registers its own entry. The recorded
+	// workflow name stays unqualified; the config name is durably recorded alongside it.
+	var className, configName string
 	if registrationParams.instance != nil {
-		if registrationParams.instance.ConfigName() == "" {
+		configName = registrationParams.instance.ConfigName()
+		if configName == "" {
 			panic(fmt.Sprintf("configured instance for workflow %s must have a non-empty config name", fqn))
 		}
-		fqn = instanceQualifiedName(fqn, registrationParams.instance)
+		className = reflect.Indirect(reflect.ValueOf(registrationParams.instance)).Type().Name()
+		if registrationParams.name == "" {
+			registrationParams.name = fqn
+		}
+		fqn = instanceQualifiedName(fqn, configName)
 	}
 
 	// Register a type-erased version of the durable workflow for recovery and queue runner
@@ -751,7 +758,15 @@ func RegisterWorkflow[P any, R any](ctx DBOSContext, fn Workflow[P, R], opts ...
 		return fn(ctx, typedInput)
 	})
 
-	registerWorkflow(ctx, fqn, typeErasedWrapper, registeredWorkflow, registrationParams.maxRetries, registrationParams.name)
+	registerWorkflow(ctx, WorkflowRegistryEntry{
+		wrappedFunction: typeErasedWrapper,
+		workflowFn:      registeredWorkflow,
+		FQN:             fqn,
+		MaxRetries:      registrationParams.maxRetries,
+		Name:            registrationParams.name,
+		ClassName:       className,
+		ConfigName:      configName,
+	})
 
 	// If this is a scheduled workflow, register a cron job
 	if registrationParams.cronSchedule != "" {
@@ -1024,7 +1039,7 @@ func RunWorkflow[P any, R any](ctx DBOSContext, fn Workflow[P, R], input P, opts
 		opt(&providedOpts)
 	}
 	if providedOpts.runInstance != nil {
-		fqn = instanceQualifiedName(fqn, providedOpts.runInstance)
+		fqn = instanceQualifiedName(fqn, providedOpts.runInstance.ConfigName())
 	}
 
 	// Add the fn name to the options so we can communicate it with DBOSContext.RunWorkflow
@@ -1315,8 +1330,15 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 		}
 	}
 
+	var configName *string
+	if registeredWorkflow.ConfigName != "" {
+		configName = &registeredWorkflow.ConfigName
+	}
+
 	workflowStatus := WorkflowStatus{
 		Name:               params.WorkflowName,
+		ClassName:          registeredWorkflow.ClassName,
+		ConfigName:         configName,
 		ApplicationVersion: params.ApplicationVersion,
 		ExecutorID:         c.GetExecutorID(),
 		Status:             status,

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -455,13 +455,14 @@ type wrappedWorkflowFunc func(ctx DBOSContext, input any, inputSerialization str
 
 type WorkflowRegistryEntry struct {
 	wrappedFunction wrappedWorkflowFunc
+	workflowFn      WorkflowFunc // Type-erased registered function taking a raw (non-encoded) input. Used by RunWorkflow for direct execution.
 	MaxRetries      int
 	Name            string
 	FQN             string // Fully qualified name of the workflow function
 	CronSchedule    string // Empty string for non-scheduled workflows
 }
 
-func registerWorkflow(ctx DBOSContext, workflowFQN string, fn wrappedWorkflowFunc, maxRetries int, customName string) {
+func registerWorkflow(ctx DBOSContext, workflowFQN string, fn wrappedWorkflowFunc, workflowFn WorkflowFunc, maxRetries int, customName string) {
 	// Skip if we don't have a concrete dbosContext
 	c, ok := ctx.(*dbosContext)
 	if !ok {
@@ -475,6 +476,7 @@ func registerWorkflow(ctx DBOSContext, workflowFQN string, fn wrappedWorkflowFun
 	// Check if workflow already exists and store atomically using LoadOrStore
 	entry := WorkflowRegistryEntry{
 		wrappedFunction: fn,
+		workflowFn:      workflowFn,
 		FQN:             workflowFQN,
 		MaxRetries:      maxRetries,
 		Name:            customName,
@@ -539,10 +541,25 @@ func registerScheduledWorkflow(ctx DBOSContext, workflowFQN, customName string, 
 	c.logger.Info("Registered scheduled workflow", "fqn", workflowFQN, "customName", customName, "cron_schedule", cronSchedule)
 }
 
+// ConfiguredInstance is implemented by objects whose methods are registered as workflows.
+// ConfigName must return a stable, unique name for the instance: it disambiguates method
+// values bound to different receivers (which share a function name) and is durably recorded
+// so recovery runs the workflow on the correct instance. Instances must be registered with
+// the same config name on every process start, before Launch.
+type ConfiguredInstance interface {
+	ConfigName() string
+}
+
+// instanceQualifiedName returns the per-instance registry key for a workflow method.
+func instanceQualifiedName(fqn string, inst ConfiguredInstance) string {
+	return fqn + "/" + inst.ConfigName()
+}
+
 type workflowRegistrationOptions struct {
 	cronSchedule string
 	maxRetries   int
 	name         string
+	instance     ConfiguredInstance
 }
 
 type WorkflowRegistrationOption func(*workflowRegistrationOptions)
@@ -577,6 +594,20 @@ func WithSchedule(schedule string) WorkflowRegistrationOption {
 func WithWorkflowName(name string) WorkflowRegistrationOption {
 	return func(p *workflowRegistrationOptions) {
 		p.name = name
+	}
+}
+
+// WithInstance registers a workflow method bound to a specific configured instance.
+// Method values bound to different receivers (e.g. a.Run and b.Run) share a function
+// name, so each instance's method must be registered under a per-instance key:
+//
+//	dbos.RegisterWorkflow(ctx, slack.Send, dbos.WithInstance(slack))
+//	dbos.RegisterWorkflow(ctx, email.Send, dbos.WithInstance(email))
+//
+// Run the workflow with the matching dbos.WithRunInstance option.
+func WithInstance(instance ConfiguredInstance) WorkflowRegistrationOption {
+	return func(p *workflowRegistrationOptions) {
+		p.instance = instance
 	}
 }
 
@@ -644,6 +675,15 @@ func RegisterWorkflow[P any, R any](ctx DBOSContext, fn Workflow[P, R], opts ...
 
 	fqn := resolveWorkflowFunctionName(fn)
 
+	// Method values bound to different receivers share an FQN: qualify the registry key
+	// with the instance config name so each instance registers its own entry.
+	if registrationParams.instance != nil {
+		if registrationParams.instance.ConfigName() == "" {
+			panic(fmt.Sprintf("configured instance for workflow %s must have a non-empty config name", fqn))
+		}
+		fqn = instanceQualifiedName(fqn, registrationParams.instance)
+	}
+
 	// Register a type-erased version of the durable workflow for recovery and queue runner
 	// Input will always come, encoded, from the database, so we decode it into the target type (captured by this wrapped closure)
 	// inputSerialization is the DB-stored serialization format for the encoded input.
@@ -686,7 +726,17 @@ func RegisterWorkflow[P any, R any](ctx DBOSContext, fn Workflow[P, R], opts ...
 		}
 		return newWorkflowPollingHandle[any](ctx, handle.GetWorkflowID()), nil // this is only used by recovery -- the queue runner dismisses it
 	})
-	registerWorkflow(ctx, fqn, typeErasedWrapper, registrationParams.maxRetries, registrationParams.name)
+
+	// Wrapper for direct calls in RunWorkflow
+	registeredWorkflow := WorkflowFunc(func(ctx DBOSContext, input any) (any, error) {
+		typedInput, ok := input.(P)
+		if !ok {
+			return nil, newWorkflowUnexpectedInputType(fqn, fmt.Sprintf("%T", *new(P)), fmt.Sprintf("%T", input))
+		}
+		return fn(ctx, typedInput)
+	})
+
+	registerWorkflow(ctx, fqn, typeErasedWrapper, registeredWorkflow, registrationParams.maxRetries, registrationParams.name)
 
 	// If this is a scheduled workflow, register a cron job
 	if registrationParams.cronSchedule != "" {
@@ -784,6 +834,7 @@ type workflowOptions struct {
 	isDequeue           bool
 	isRecovery          bool
 	isPortableWorkflow  bool
+	runInstance         ConfiguredInstance
 }
 
 // WorkflowOption is a functional option for configuring workflow execution parameters.
@@ -793,6 +844,17 @@ type WorkflowOption func(*workflowOptions)
 func WithWorkflowID(id string) WorkflowOption {
 	return func(p *workflowOptions) {
 		p.WorkflowID = id
+	}
+}
+
+// WithRunInstance runs a workflow method registered with dbos.WithInstance. The instance's
+// config name selects the per-instance registration, so the workflow executes on (and
+// recovers to) the correct instance:
+//
+//	handle, err := dbos.RunWorkflow(ctx, slack.Send, input, dbos.WithRunInstance(slack))
+func WithRunInstance(instance ConfiguredInstance) WorkflowOption {
+	return func(p *workflowOptions) {
+		p.runInstance = instance
 	}
 }
 
@@ -938,12 +1000,32 @@ func RunWorkflow[P any, R any](ctx DBOSContext, fn Workflow[P, R], input P, opts
 		return nil, fmt.Errorf("ctx cannot be nil")
 	}
 
-	// Add the fn name to the options so we can communicate it with DBOSContext.RunWorkflow
-	opts = append(opts, withWorkflowName(resolveWorkflowFunctionName(fn)))
+	fqn := resolveWorkflowFunctionName(fn)
 
+	// If a configured instance was provided, qualify the name with its config name to
+	// select the per-instance registration (see WithInstance).
+	var providedOpts workflowOptions
+	for _, opt := range opts {
+		opt(&providedOpts)
+	}
+	if providedOpts.runInstance != nil {
+		fqn = instanceQualifiedName(fqn, providedOpts.runInstance)
+	}
+
+	// Add the fn name to the options so we can communicate it with DBOSContext.RunWorkflow
+	opts = append(opts, withWorkflowName(fqn))
+
+	// Execute the registered function (fallback on provided function for mocked contexts)
 	typedErasedWorkflow := WorkflowFunc(func(ctx DBOSContext, input any) (any, error) {
 		return fn(ctx, input.(P))
 	})
+	if c, ok := ctx.(*dbosContext); ok {
+		if entryAny, exists := c.workflowRegistry.Load(fqn); exists {
+			if entry, ok := entryAny.(WorkflowRegistryEntry); ok && entry.workflowFn != nil {
+				typedErasedWorkflow = entry.workflowFn
+			}
+		}
+	}
 
 	handle, err := ctx.RunWorkflow(ctx, typedErasedWorkflow, input, opts...)
 	if err != nil {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -788,7 +788,7 @@ func (c *dbosContext) resolveWorkflowName(workflowFn any) (string, error) {
 	fqn := runtime.FuncForPC(reflect.ValueOf(workflowFn).Pointer()).Name()
 	value, ok := c.workflowRegistry.Load(fqn)
 	if !ok {
-		return "", fmt.Errorf("workflow function not registered: %s", fqn)
+		return "", fmt.Errorf("workflow function not registered: %s (note: configured instances are not supported with scheduled workflows)", fqn)
 	}
 	entry := value.(WorkflowRegistryEntry)
 	if entry.Name != "" {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -559,6 +559,14 @@ func TestConfiguredInstanceWorkflows(t *testing.T) {
 		require.NoError(t, err, "failed to get direct result for instance %q", inst.channel)
 		require.Equal(t, inst.channel+": hi", direct, "direct execution ran the wrong instance")
 
+		// The record stores the unqualified workflow name plus the instance class and config names
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get status for instance %q", inst.channel)
+		require.Equal(t, resolveWorkflowFunctionName(inst.Send), status.Name)
+		require.Equal(t, "configuredNotifier", status.ClassName)
+		require.NotNil(t, status.ConfigName, "config name not recorded")
+		require.Equal(t, inst.channel, *status.ConfigName)
+
 		setWorkflowStatusPending(t, dbosCtx, workflowID)
 		recovered, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
 		require.NoError(t, err, "failed to recover pending workflows")

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -385,6 +385,196 @@ func TestWorkflowsRegistration(t *testing.T) {
 	})
 }
 
+// The types and factories below each produce TWO workflow function values that
+// share a fully-qualified name (FQN) under resolveWorkflowFunctionName, even
+// though each carries different captured state. The FQN is derived from the
+// entry program counter via runtime.FuncForPC; the receiver/closure data is
+// lost. These are the five FQN-collision cases from the issue.
+
+// Case 1: value-receiver method values -> "...fqnCollidingValueHolder.Run-fm".
+type fqnCollidingValueHolder struct {
+	label string
+}
+
+func (h fqnCollidingValueHolder) Run(ctx DBOSContext, input string) (string, error) {
+	return h.label, nil
+}
+
+// Case 2: pointer-receiver method values -> "...(*fqnCollidingPtrHolder).Run-fm".
+type fqnCollidingPtrHolder struct {
+	label string
+}
+
+func (h *fqnCollidingPtrHolder) Run(ctx DBOSContext, input string) (string, error) {
+	return h.label, nil
+}
+
+// Case 3: interface method values -> "...fqnCollidingSpeaker.Run-fm" (named for
+// the interface method, independent of the concrete type behind it).
+type fqnCollidingSpeaker interface {
+	Run(ctx DBOSContext, input string) (string, error)
+}
+
+// Case 4: closures from a single literal evaluated multiple times (loop) ->
+// "...fqnCollidingLoopClosures.func1".
+func fqnCollidingLoopClosures(labels ...string) []Workflow[string, string] {
+	fns := make([]Workflow[string, string], 0, len(labels))
+	for _, label := range labels {
+		fns = append(fns, func(ctx DBOSContext, input string) (string, error) {
+			return label, nil
+		})
+	}
+	return fns
+}
+
+// Case 5: factory closures. The factory is kept un-inlined so every call shares
+// "...fqnCollidingFactory.func1". Without go:noinline the compiler may inline the
+// factory per call site, yielding distinct func1/func2 names (no collision).
+//
+//go:noinline
+func fqnCollidingFactory(label string) Workflow[string, string] {
+	return func(ctx DBOSContext, input string) (string, error) {
+		return label, nil
+	}
+}
+
+// TestRunWorkflowProvidedVsRegisteredDivergence reproduces the bug where
+// RunWorkflow directly executes the *provided* function value, while queue and
+// recovery execution run the *registered* function looked up by FQN. When two
+// distinct function values share an FQN, the same workflow ID produces different
+// results depending on the execution path (direct vs recovery), causing
+// nondeterminism. Each subtest exercises one FQN-collision case from the issue.
+func TestRunWorkflowProvidedVsRegisteredDivergence(t *testing.T) {
+	loopClosures := fqnCollidingLoopClosures("registered", "provided")
+
+	cases := []struct {
+		name         string
+		registeredWf Workflow[string, string]
+		providedWf   Workflow[string, string]
+	}{
+		{
+			name:         "value receiver method values",
+			registeredWf: fqnCollidingValueHolder{label: "registered"}.Run,
+			providedWf:   fqnCollidingValueHolder{label: "provided"}.Run,
+		},
+		{
+			name:         "pointer receiver method values",
+			registeredWf: (&fqnCollidingPtrHolder{label: "registered"}).Run,
+			providedWf:   (&fqnCollidingPtrHolder{label: "provided"}).Run,
+		},
+		{
+			name:         "interface method values",
+			registeredWf: fqnCollidingSpeaker(fqnCollidingValueHolder{label: "registered"}).Run,
+			providedWf:   fqnCollidingSpeaker(fqnCollidingValueHolder{label: "provided"}).Run,
+		},
+		{
+			name:         "loop closures from one literal",
+			registeredWf: loopClosures[0],
+			providedWf:   loopClosures[1],
+		},
+		{
+			name:         "factory closures (not inlined)",
+			registeredWf: fqnCollidingFactory("registered"),
+			providedWf:   fqnCollidingFactory("provided"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Precondition: the two values must share an FQN, otherwise the
+			// registry entry for registeredWf would not be the one resolved for
+			// providedWf and the bug would not be exercised.
+			require.Equal(t,
+				resolveWorkflowFunctionName(tc.registeredWf),
+				resolveWorkflowFunctionName(tc.providedWf),
+				"the two function values must share an FQN to exercise the bug")
+
+			dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+
+			RegisterWorkflow(dbosCtx, tc.registeredWf)
+			require.NoError(t, Launch(dbosCtx), "failed to launch DBOS")
+
+			workflowID := uuid.NewString()
+
+			// Direct execution path: RunWorkflow runs the provided fn.
+			handle, err := RunWorkflow(dbosCtx, tc.providedWf, "input", WithWorkflowID(workflowID))
+			require.NoError(t, err, "failed to run workflow")
+			result1, err := handle.GetResult()
+			require.NoError(t, err, "failed to get result from direct execution")
+
+			// Recovery path: resolves the function from the registry by FQN and
+			// runs the registered wrapped function.
+			setWorkflowStatusPending(t, dbosCtx, workflowID)
+			recoveredHandles, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
+			require.NoError(t, err, "failed to recover pending workflows")
+			require.Len(t, recoveredHandles, 1, "expected 1 recovered handle")
+			require.Equal(t, workflowID, recoveredHandles[0].GetWorkflowID())
+			result2, err := recoveredHandles[0].GetResult()
+			require.NoError(t, err, "failed to get result from recovered execution")
+
+			// Invariant: the same workflow ID must produce the same result
+			// regardless of execution path. Under the bug, direct execution runs
+			// the provided body ("provided") while recovery runs the registered
+			// body ("registered") -> nondeterminism. After the fix, both run the
+			// registered body.
+			require.Equal(t, result1, result2,
+				"recovery returned a different result than direct execution for the same workflow ID (nondeterminism): direct=%q recovered=%q",
+				result1, result2)
+		})
+	}
+}
+
+// configuredNotifier is a workflow holder whose method is registered once per instance
+// via WithInstance, distinguishing receivers that would otherwise share an FQN.
+type configuredNotifier struct {
+	channel string
+}
+
+func (n *configuredNotifier) ConfigName() string { return n.channel }
+
+func (n *configuredNotifier) Send(ctx DBOSContext, msg string) (string, error) {
+	return n.channel + ": " + msg, nil
+}
+
+// TestConfiguredInstanceWorkflows verifies that two instances of the same workflow method,
+// registered with WithInstance and run with WithRunInstance, each execute on their own
+// receiver -- on the direct path and on recovery -- and that running without
+// WithRunInstance fails loudly instead of silently using another instance.
+func TestConfiguredInstanceWorkflows(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+
+	slack := &configuredNotifier{channel: "slack"}
+	email := &configuredNotifier{channel: "email"}
+
+	RegisterWorkflow(dbosCtx, slack.Send, WithInstance(slack))
+	RegisterWorkflow(dbosCtx, email.Send, WithInstance(email))
+	require.NoError(t, Launch(dbosCtx), "failed to launch DBOS")
+
+	for _, inst := range []*configuredNotifier{slack, email} {
+		workflowID := uuid.NewString()
+
+		handle, err := RunWorkflow(dbosCtx, inst.Send, "hi", WithWorkflowID(workflowID), WithRunInstance(inst))
+		require.NoError(t, err, "failed to run workflow on instance %q", inst.channel)
+		direct, err := handle.GetResult()
+		require.NoError(t, err, "failed to get direct result for instance %q", inst.channel)
+		require.Equal(t, inst.channel+": hi", direct, "direct execution ran the wrong instance")
+
+		setWorkflowStatusPending(t, dbosCtx, workflowID)
+		recovered, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
+		require.NoError(t, err, "failed to recover pending workflows")
+		require.Len(t, recovered, 1, "expected 1 recovered handle")
+		require.Equal(t, workflowID, recovered[0].GetWorkflowID())
+		recResult, err := recovered[0].GetResult()
+		require.NoError(t, err, "failed to get recovered result for instance %q", inst.channel)
+		require.Equal(t, direct, recResult, "recovery ran a different instance than direct execution")
+	}
+
+	// Without WithRunInstance the bare (colliding) FQN was never registered: fail loudly
+	// rather than silently running some other instance.
+	_, err := RunWorkflow(dbosCtx, slack.Send, "hi")
+	require.Error(t, err, "running an instance method without WithRunInstance should fail")
+}
+
 func stepWithinAStep(ctx context.Context) (string, error) {
 	return simpleStep(ctx)
 }

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -583,6 +583,71 @@ func TestConfiguredInstanceWorkflows(t *testing.T) {
 	require.Error(t, err, "running an instance method without WithRunInstance should fail")
 }
 
+// notifier is implemented by configuredNotifier and loudNotifier. Method values taken
+// through an interface share a single FQN across all implementations and instances.
+type notifier interface {
+	ConfiguredInstance
+	Send(ctx DBOSContext, msg string) (string, error)
+}
+
+type loudNotifier struct {
+	channel string
+}
+
+func (n *loudNotifier) ConfigName() string { return n.channel }
+
+func (n *loudNotifier) Send(ctx DBOSContext, msg string) (string, error) {
+	return strings.ToUpper(n.channel + ": " + msg), nil
+}
+
+// TestConfiguredInstanceInterfaceWorkflows verifies WithInstance disambiguates method values
+// taken through an interface: two different implementations behind the same interface FQN each
+// run on their own concrete receiver, on the direct path and on recovery.
+func TestConfiguredInstanceInterfaceWorkflows(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+
+	var quiet notifier = &configuredNotifier{channel: "quiet"}
+	var loud notifier = &loudNotifier{channel: "loud"}
+	require.Equal(t, resolveWorkflowFunctionName(quiet.Send), resolveWorkflowFunctionName(loud.Send),
+		"precondition: interface method values should share an FQN across implementations")
+
+	RegisterWorkflow(dbosCtx, quiet.Send, WithInstance(quiet))
+	RegisterWorkflow(dbosCtx, loud.Send, WithInstance(loud))
+	require.NoError(t, Launch(dbosCtx), "failed to launch DBOS")
+
+	for _, tc := range []struct {
+		inst      notifier
+		expected  string
+		className string
+	}{
+		{quiet, "quiet: hi", "configuredNotifier"},
+		{loud, "LOUD: HI", "loudNotifier"},
+	} {
+		workflowID := uuid.NewString()
+
+		handle, err := RunWorkflow(dbosCtx, tc.inst.Send, "hi", WithWorkflowID(workflowID), WithRunInstance(tc.inst))
+		require.NoError(t, err, "failed to run workflow on instance %q", tc.inst.ConfigName())
+		direct, err := handle.GetResult()
+		require.NoError(t, err, "failed to get direct result for instance %q", tc.inst.ConfigName())
+		require.Equal(t, tc.expected, direct, "direct execution ran the wrong implementation or instance")
+
+		// The recorded class name is the concrete implementation, not the interface
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get status for instance %q", tc.inst.ConfigName())
+		require.Equal(t, tc.className, status.ClassName)
+		require.NotNil(t, status.ConfigName, "config name not recorded")
+		require.Equal(t, tc.inst.ConfigName(), *status.ConfigName)
+
+		setWorkflowStatusPending(t, dbosCtx, workflowID)
+		recovered, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
+		require.NoError(t, err, "failed to recover pending workflows")
+		require.Len(t, recovered, 1, "expected 1 recovered handle")
+		recResult, err := recovered[0].GetResult()
+		require.NoError(t, err, "failed to get recovered result for instance %q", tc.inst.ConfigName())
+		require.Equal(t, direct, recResult, "recovery ran a different implementation than direct execution")
+	}
+}
+
 func stepWithinAStep(ctx context.Context) (string, error) {
 	return simpleStep(ctx)
 }


### PR DESCRIPTION
#345 exposed a subtle execution bug and a workflow registration limitation. Specifically, Go functions can share the same function entry and return the same name, for example if they are receiver methods. This 1) limits too stringently what can be registered and 2) allows direct execution of non-registered workflows.

This PR does two things:
- Always use the registered workflow during direct execution
- Introduce configured instances

Users can register receiver methods:

```go
dbos.RegisterWorkflow(ctx, slack.Send, dbos.WithInstance(slack))
dbos.RegisterWorkflow(ctx, email.Send, dbos.WithInstance(email))
```

And call them as:

```go
dbos.RunWorkflow(ctx, slack.Send, input, dbos.WithRunInstance(slack))
```

A configured instance must implement the interface:

```go
type ConfiguredInstance interface {
	ConfigName() string
}
```

Note that this model doesn't support registering a variety of closures, non-inlined methods, etc