### PR TITLE
fix(stream): drain to the end of the stream when the producer goes inactive

### DIFF
--- a/dbos/read_stream_drain_test.go
+++ b/dbos/read_stream_drain_test.go
@@ -1,0 +1,59 @@
+package dbos
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStreamDB implements only the two systemDatabase methods that readStream
+// uses. It embeds the interface so it satisfies the rest (none of which are
+// called here) without a pile of stub methods.
+type fakeStreamDB struct {
+	systemDatabase
+	reads int
+}
+
+func (f *fakeStreamDB) readStream(_ context.Context, _ readStreamDBInput) ([]streamEntry, bool, error) {
+	f.reads++
+	if f.reads == 1 {
+		// First read: the producer's final value is not visible yet — it commits
+		// in the window between this read and the status check below.
+		return nil, false, nil
+	}
+	// The post-inactive final read drains the value the producer committed just
+	// before it completed.
+	return []streamEntry{{Value: "final", Offset: 0}}, false, nil
+}
+
+func (f *fakeStreamDB) listWorkflows(_ context.Context, _ listWorkflowsDBInput) ([]WorkflowStatus, error) {
+	// The producer is terminal, but it committed "final" after the reader's first
+	// stream read above — so its writes are all committed by now.
+	return []WorkflowStatus{{Status: WorkflowStatusSuccess}}, nil
+}
+
+// A reader must not drop a value the producer commits between the reader's
+// stream read and its status check. When the reader observes the producer is
+// inactive it must make one more read pass to drain to the end of the stream,
+// because all of the producer's writes are committed once it is terminal.
+//
+// Without that final read, this interleaving — first read empty, producer
+// commits "final" and completes, status check sees terminal — drops "final".
+func TestReadStreamDrainsValueCommittedBeforeProducerInactive(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	c := &dbosContext{
+		ctx:      ctx,
+		systemDB: &fakeStreamDB{},
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	values, closed, err := c.ReadStream(c, "wf", "stream")
+	require.NoError(t, err)
+	require.True(t, closed, "stream should be reported closed once the producer is terminal")
+	require.Len(t, values, 1, "reader must drain the value committed just before the producer went inactive")
+}

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -2843,6 +2843,10 @@ func (c *dbosContext) readStream(workflowID string, key string, snapshot bool, f
 
 		currentOffset := fromOffset
 		closed := false
+		// finalRead is set once the producer is observed inactive; the loop then
+		// makes one more read pass to drain any values it committed just before
+		// terminating, then closes the stream.
+		finalRead := false
 
 		// Continue reading until workflow is inactive or stream is closed
 		for {
@@ -2885,6 +2889,13 @@ func (c *dbosContext) readStream(workflowID string, key string, snapshot bool, f
 				return
 			}
 
+			// A previous iteration observed the workflow was inactive; this pass
+			// has now drained anything it committed in the meantime, so close.
+			if finalRead {
+				send(StreamValue[any]{Closed: true})
+				return
+			}
+
 			// Check if workflow is still active (PENDING or ENQUEUED)
 			status, err := retryWithResult(c, func() (WorkflowStatusType, error) {
 				workflows, err := c.systemDB.listWorkflows(c, listWorkflowsDBInput{
@@ -2906,10 +2917,14 @@ func (c *dbosContext) readStream(workflowID string, key string, snapshot bool, f
 				return
 			}
 
-			// If workflow is inactive, send final message with Closed: true (BUG FIX)
+			// If the workflow is inactive it may still have committed values
+			// between the read above and this status check. Once it is terminal
+			// all of its writes are committed, so make one more read pass to drain
+			// to the end of the stream before closing, rather than returning here
+			// and dropping a value written just before completion.
 			if status != WorkflowStatusPending && status != WorkflowStatusEnqueued {
-				send(StreamValue[any]{Closed: true})
-				return
+				finalRead = true
+				continue
 			}
 
 			// If no new entries, wait a bit before polling again


### PR DESCRIPTION
A stream reader can drop the producer's last value if it's written right as the producer finishes.

`readStream` reads the stream, then makes a separate call to check whether the producing workflow is still active. If the producer commits its final value and completes in the gap between those two calls, the reader sees the workflow is done and closes the stream without ever reading that value.

The window is small, and it only affects a producer that finishes *without* calling `CloseStream` (so the reader is relying on the "stop once the workflow goes inactive" fallback) while another reader is draining concurrently. The normal `CloseStream` path is fine — the close sentinel guarantees the reader sees everything.

**Fix:** once the reader notices the producer has gone inactive, do one more read before closing. All of a workflow's writes are committed by the time its status is terminal, so that final pass reliably catches anything written just before it finished.

**This matches Python.** The Python SDK fixed the same race in [dbos-inc/dbos-transact-py#713](https://github.com/dbos-inc/dbos-transact-py/pull/713): its `read_stream` keeps a `final_read` flag so that when it sees the workflow has gone inactive it reads to the end of the stream before stopping, instead of returning right away. 

**Test:** a deterministic unit test (no database needed) that forces the exact interleaving with a fake `systemDatabase` — first read empty, producer reported terminal, value shows up on the next read. It fails without the fix and passes with it.

