### PR TITLE
Preemptible sleep

### DIFF
--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -3050,8 +3050,16 @@ func (s *sysDB) sleep(ctx context.Context, input sleepInput) (time.Duration, err
 	remainingDuration := max(0, time.Until(endTime))
 
 	if !input.skipSleep {
-		// Actually sleep for the remaining duration
-		time.Sleep(remainingDuration)
+		// Sleep for the remaining duration, but wake early if the context is cancelled.
+		// If interrupted, return the duration actually slept.
+		sleepStart := time.Now()
+		timer := time.NewTimer(remainingDuration)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return time.Since(sleepStart), ctx.Err()
+		}
 	}
 
 	return remainingDuration, nil

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -4074,6 +4074,28 @@ func TestSleep(t *testing.T) {
 		expectedMessagePart := "workflow state not found in context: are you running this step within a workflow?"
 		require.Contains(t, err.Error(), expectedMessagePart)
 	})
+
+	t.Run("SleepContextCancellation", func(t *testing.T) {
+		// Cancelling Sleep's context mid-sleep should interrupt it and return the
+		// partial duration actually slept (less than the full requested duration).
+		sleepCancelWorkflow := func(ctx DBOSContext, _ string) (time.Duration, error) {
+			cancelCtx, cancel := WithCancel(ctx)
+			defer cancel()
+			go func() {
+				time.Sleep(500 * time.Millisecond)
+				cancel()
+			}()
+			return Sleep(cancelCtx, time.Minute)
+		}
+		RegisterWorkflow(dbosCtx, sleepCancelWorkflow)
+
+		handle, err := RunWorkflow(dbosCtx, sleepCancelWorkflow, "")
+		require.NoError(t, err, "failed to start sleep workflow")
+
+		slept, err := handle.GetResult()
+		require.Error(t, err, "expected a cancellation error from the interrupted Sleep")
+		assert.Less(t, slept, time.Minute, "expected interrupted Sleep to return a partial duration, got %v", slept)
+	})
 }
 
 func TestWorkflowTimeout(t *testing.T) {


### PR DESCRIPTION
Go supports trivially the ability to interrupt a long durable sleep, when the context is cancelled.