### PR TITLE
Fix GC row-threshold ties on created_at

### DIFF
--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1786,16 +1786,19 @@ func (s *sysDB) garbageCollectWorkflows(ctx context.Context, input garbageCollec
 	}
 
 	cutoffTimestamp := input.cutoffEpochTimestampMs
+	var rowsBasedCutoffWorkflowID string
+	useRowsThresholdCutoff := false
 
-	// If rowsThreshold is provided, get the timestamp of the Nth newest workflow
+	// If rowsThreshold is provided, get the Nth newest workflow using workflow_uuid
+	// as a deterministic tiebreaker for workflows created in the same millisecond.
 	if input.rowsThreshold != nil {
-		query := s.renderSQL(`SELECT created_at
+		query := s.renderSQL(`SELECT created_at, workflow_uuid
 				  FROM %sworkflow_status
-				  ORDER BY created_at DESC
+				  ORDER BY created_at DESC, workflow_uuid DESC
 				  LIMIT 1 OFFSET $1`, s.dialect.SchemaPrefix(s.schema))
 
 		var rowsBasedCutoff int64
-		err := s.pool.QueryRow(ctx, query, *input.rowsThreshold-1).Scan(&rowsBasedCutoff)
+		err := s.pool.QueryRow(ctx, query, *input.rowsThreshold-1).Scan(&rowsBasedCutoff, &rowsBasedCutoffWorkflowID)
 		if err != nil && err != pgx.ErrNoRows {
 			return fmt.Errorf("failed to query cutoff timestamp by rows threshold: %w", err)
 		}
@@ -1804,6 +1807,9 @@ func (s *sysDB) garbageCollectWorkflows(ctx context.Context, input garbageCollec
 		// Use the cutoff timestamp found in the database
 		if rowsBasedCutoff > 0 && cutoffTimestamp == nil || (cutoffTimestamp != nil && rowsBasedCutoff > *cutoffTimestamp) {
 			cutoffTimestamp = &rowsBasedCutoff
+			useRowsThresholdCutoff = true
+		} else {
+			rowsBasedCutoffWorkflowID = ""
 		}
 	}
 
@@ -1812,16 +1818,36 @@ func (s *sysDB) garbageCollectWorkflows(ctx context.Context, input garbageCollec
 		return nil
 	}
 
-	// Delete all workflows older than cutoff that are NOT PENDING, ENQUEUED, or DELAYED
-	query := s.renderSQL(`DELETE FROM %sworkflow_status
+	var (
+		commandTag Result
+		err        error
+	)
+	if useRowsThresholdCutoff && rowsBasedCutoffWorkflowID != "" {
+		// When the row-threshold cutoff wins, delete rows strictly older than the
+		// chosen (created_at, workflow_uuid) pair so ties at the cutoff millisecond
+		// do not retain extra completed workflows.
+		query := s.renderSQL(`DELETE FROM %sworkflow_status
+			  WHERE (created_at < $1 OR (created_at = $1 AND workflow_uuid < $2))
+			    AND status NOT IN ($3, $4, $5)`, s.dialect.SchemaPrefix(s.schema))
+
+		commandTag, err = s.pool.Exec(ctx, query,
+			*cutoffTimestamp,
+			rowsBasedCutoffWorkflowID,
+			WorkflowStatusPending,
+			WorkflowStatusEnqueued,
+			WorkflowStatusDelayed)
+	} else {
+		// Delete all workflows older than cutoff that are NOT PENDING, ENQUEUED, or DELAYED.
+		query := s.renderSQL(`DELETE FROM %sworkflow_status
 			  WHERE created_at < $1
 			    AND status NOT IN ($2, $3, $4)`, s.dialect.SchemaPrefix(s.schema))
 
-	commandTag, err := s.pool.Exec(ctx, query,
-		*cutoffTimestamp,
-		WorkflowStatusPending,
-		WorkflowStatusEnqueued,
-		WorkflowStatusDelayed)
+		commandTag, err = s.pool.Exec(ctx, query,
+			*cutoffTimestamp,
+			WorkflowStatusPending,
+			WorkflowStatusEnqueued,
+			WorkflowStatusDelayed)
+	}
 
 	if err != nil {
 		return fmt.Errorf("failed to garbage collect workflows: %w", err)
@@ -1830,6 +1856,7 @@ func (s *sysDB) garbageCollectWorkflows(ctx context.Context, input garbageCollec
 	deletedCount, _ := commandTag.RowsAffected()
 	s.logger.Info("Garbage collected workflows",
 		"cutoff_timestamp", *cutoffTimestamp,
+		"cutoff_workflow_id", rowsBasedCutoffWorkflowID,
 		"deleted_count", deletedCount)
 
 	return nil

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -5137,6 +5138,22 @@ func gcBlockedWorkflow(dbosCtx DBOSContext, event *Event) (string, error) {
 }
 
 func TestGarbageCollect(t *testing.T) {
+	setWorkflowCreatedAt := func(t *testing.T, dbosCtx DBOSContext, workflowIDs []string, createdAt int64) {
+		t.Helper()
+		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+		query := sysDB.renderSQL(`UPDATE %sworkflow_status SET created_at = $1 WHERE workflow_uuid = $2`, sysDB.dialect.SchemaPrefix(sysDB.schema))
+		for _, workflowID := range workflowIDs {
+			_, err := sysDB.pool.Exec(dbosCtx, query, createdAt, workflowID)
+			require.NoError(t, err, "failed to set created_at for workflow %s", workflowID)
+		}
+	}
+
+	sortedWorkflowIDsDesc := func(workflowIDs []string) []string {
+		sorted := append([]string(nil), workflowIDs...)
+		sort.Sort(sort.Reverse(sort.StringSlice(sorted)))
+		return sorted
+	}
+
 	t.Run("GarbageCollectWithOffset", func(t *testing.T) {
 		// Start with clean database for precise workflow counting
 		databaseURL := backendDatabaseURL(t)
@@ -5160,6 +5177,7 @@ func TestGarbageCollect(t *testing.T) {
 		require.NoError(t, err, "failed to start blocked workflow")
 
 		var completedHandles []WorkflowHandle[int]
+		var completedIDs []string
 		for i := range numWorkflows {
 			handle, err := RunWorkflow(dbosCtx, gcTestWorkflow, i)
 			require.NoError(t, err, "failed to start test workflow %d", i)
@@ -5167,7 +5185,12 @@ func TestGarbageCollect(t *testing.T) {
 			require.NoError(t, err, "failed to get result from test workflow %d", i)
 			require.Equal(t, i, result, "expected result %d, got %d", i, result)
 			completedHandles = append(completedHandles, handle)
+			completedIDs = append(completedIDs, handle.GetWorkflowID())
 		}
+
+		// Force identical millisecond timestamps for completed workflows so the
+		// row-threshold GC path must apply its workflow_uuid tiebreaker.
+		setWorkflowCreatedAt(t, dbosCtx, completedIDs, time.Now().UnixMilli())
 
 		// Verify exactly 11 workflows exist before GC (1 blocked + 10 completed)
 		workflows, err := ListWorkflows(dbosCtx)
@@ -5206,18 +5229,16 @@ func TestGarbageCollect(t *testing.T) {
 			}
 		}
 
-		// Verify that the 5 newest completed workflows are preserved
-		// The completedHandles slice is in order of creation (0 is oldest, 9 is newest)
-		// So indices 5-9 (the last 5) should be preserved
+		// All completed workflows share the same created_at, so GC should keep the
+		// threshold newest rows according to workflow_uuid DESC.
+		expectedRetainedCompleted := sortedWorkflowIDsDesc(completedIDs)[:threshold]
+		expectedRetainedSet := make(map[string]bool, len(expectedRetainedCompleted))
+		for _, workflowID := range expectedRetainedCompleted {
+			expectedRetainedSet[workflowID] = true
+		}
 		for i := range numWorkflows {
 			wfID := completedHandles[i].GetWorkflowID()
-			if i < numWorkflows-threshold {
-				// Older workflows (indices 0-4) should be deleted
-				require.False(t, remainingIDs[wfID], "older workflow at index %d (ID: %s) should have been deleted", i, wfID)
-			} else {
-				// Newer workflows (indices 5-9) should be preserved
-				require.True(t, remainingIDs[wfID], "newer workflow at index %d (ID: %s) should have been preserved", i, wfID)
-			}
+			require.Equal(t, expectedRetainedSet[wfID], remainingIDs[wfID], "unexpected retention for workflow at index %d (ID: %s)", i, wfID)
 		}
 
 		// Complete the blocked workflow
@@ -5398,13 +5419,19 @@ func TestGarbageCollect(t *testing.T) {
 		require.NoError(t, err, "failed to start blocked workflow")
 
 		// Execute normal workflows to completion
+		completedIDs := make([]string, 0, numWorkflows)
 		for i := range numWorkflows {
 			handle, err := RunWorkflow(dbosCtx, gcTestWorkflow, i)
 			require.NoError(t, err, "failed to start test workflow %d", i)
 			result, err := handle.GetResult()
 			require.NoError(t, err, "failed to get result from test workflow %d", i)
 			require.Equal(t, i, result, "expected result %d, got %d", i, result)
+			completedIDs = append(completedIDs, handle.GetWorkflowID())
 		}
+
+		// Force all completed workflows onto the same millisecond to reproduce the
+		// original flake deterministically.
+		setWorkflowCreatedAt(t, dbosCtx, completedIDs, time.Now().UnixMilli())
 
 		// Verify exactly 6 workflows exist (1 blocked + 5 completed)
 		workflows, err := ListWorkflows(dbosCtx)
@@ -5440,6 +5467,7 @@ func TestGarbageCollect(t *testing.T) {
 		require.Equal(t, 2, len(workflows), "expected exactly 2 workflows after GC (1 newest + 1 pending)")
 
 		// Verify pending workflow still exists
+		expectedRetainedCompletedID := sortedWorkflowIDsDesc(completedIDs)[0]
 		found := false
 		pendingCount = 0
 		completedCount = 0
@@ -5453,6 +5481,7 @@ func TestGarbageCollect(t *testing.T) {
 				pendingCount++
 			case WorkflowStatusSuccess:
 				completedCount++
+				require.Equal(t, expectedRetainedCompletedID, wf.ID, "expected GC to retain the workflow with the highest workflow_uuid at the cutoff timestamp")
 			}
 		}
 		require.True(t, found, "pending workflow should remain")


### PR DESCRIPTION
## Summary

This fixes flaky garbage-collection behavior when multiple workflows share the same `created_at` millisecond.

The row-threshold GC path selected the Nth newest workflow using only `created_at`, then deleted workflows with `created_at < cutoff`. When several workflows were created within the same millisecond as the cutoff row, they were all retained, causing GC to keep more rows than the configured threshold.

## Root Cause

`created_at` is stored with millisecond precision, so it is not guaranteed to be unique. The existing logic treated the cutoff as a timestamp, while the threshold query was actually selecting a specific row. That mismatch caused the flaky behavior.

## Fix

The row-threshold cutoff is now deterministic by using `workflow_uuid` as a tiebreaker.

The cutoff row is selected with:

```sql
ORDER BY created_at DESC, workflow_uuid DESC
```

This ensures GC retains exactly the intended number of newest workflows, even when multiple workflows share the same `created_at` timestamp.

## Verification

Ran:

```bash
DBOS_TEST_BACKEND=sqlite go test ./dbos -run '^TestGarbageCollect/(GarbageCollectWithOffset|GarbageCollectOnlyCompletedWorkflows)$' -count=100

go test ./dbos -run '^TestGarbageCollect$'
```
