### PR TITLE
Include was_forked_from in workflow export/import

### DIFF
--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -5881,7 +5881,8 @@ func (s *sysDB) exportWorkflow(ctx context.Context, workflowID string, exportChi
 				output, error, executor_id, created_at, updated_at, application_version, application_id,
 				class_name, config_name, recovery_attempts, queue_name, workflow_timeout_ms,
 				workflow_deadline_epoch_ms, started_at_epoch_ms, deduplication_id, inputs, priority,
-				queue_partition_key, forked_from, parent_workflow_id, delay_until_epoch_ms, serialization
+				queue_partition_key, forked_from, parent_workflow_id, delay_until_epoch_ms, serialization,
+				was_forked_from
 			FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
 
 		row := tx.QueryRow(ctx, statusQuery, wfID)
@@ -5896,6 +5897,7 @@ func (s *sysDB) exportWorkflow(ctx context.Context, workflowID string, exportChi
 			priority                                                     *int
 			delayUntilEpochMs                                            *int64
 			serialization                                                *string
+			wasForkedFrom                                                *bool
 		)
 		err := row.Scan(
 			&wfUUID, &status, &name, &authUser, &assumedRole, &authRoles,
@@ -5903,6 +5905,7 @@ func (s *sysDB) exportWorkflow(ctx context.Context, workflowID string, exportChi
 			&className, &configName, &recoveryAttempts, &queueName, &workflowTimeoutMs,
 			&workflowDeadlineEpochMs, &startedAtEpochMs, &dedupID, &inputs, &priority,
 			&queuePartitionKey, &forkedFrom, &parentWorkflowID, &delayUntilEpochMs, &serialization,
+			&wasForkedFrom,
 		)
 		if err != nil {
 			if err == pgx.ErrNoRows {
@@ -5940,6 +5943,7 @@ func (s *sysDB) exportWorkflow(ctx context.Context, workflowID string, exportChi
 			"parent_workflow_id":         parentWorkflowID,
 			"delay_until_epoch_ms":       delayUntilEpochMs,
 			"serialization":              serialization,
+			"was_forked_from":            wasForkedFrom,
 		}
 
 		// Export operation_outputs
@@ -6111,9 +6115,23 @@ func (s *sysDB) importWorkflow(ctx context.Context, workflows []ExportedWorkflow
 				output, error, executor_id, created_at, updated_at, application_version, application_id,
 				class_name, config_name, recovery_attempts, queue_name, workflow_timeout_ms,
 				workflow_deadline_epoch_ms, started_at_epoch_ms, deduplication_id, inputs, priority,
-				queue_partition_key, forked_from, parent_workflow_id, delay_until_epoch_ms, serialization
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)`,
+				queue_partition_key, forked_from, parent_workflow_id, delay_until_epoch_ms, serialization,
+				was_forked_from
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29)`,
 			s.dialect.SchemaPrefix(s.schema))
+
+		// was_forked_from is NOT NULL; default it to false for payloads exported
+		// before this field was included (older exports, or ones from an SDK that
+		// omits it), so importing them doesn't violate the constraint.
+		wasForkedFrom := false
+		switch v := status["was_forked_from"].(type) {
+		case bool:
+			wasForkedFrom = v
+		case *bool:
+			if v != nil {
+				wasForkedFrom = *v
+			}
+		}
 
 		_, err := tx.Exec(ctx, insertStatusQuery,
 			status["workflow_uuid"], status["status"], status["name"],
@@ -6124,7 +6142,7 @@ func (s *sysDB) importWorkflow(ctx context.Context, workflows []ExportedWorkflow
 			status["workflow_timeout_ms"], status["workflow_deadline_epoch_ms"], status["started_at_epoch_ms"],
 			status["deduplication_id"], status["inputs"], status["priority"],
 			status["queue_partition_key"], status["forked_from"], status["parent_workflow_id"],
-			status["delay_until_epoch_ms"], status["serialization"],
+			status["delay_until_epoch_ms"], status["serialization"], wasForkedFrom,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to import workflow_status: %w", err)

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -7370,80 +7370,6 @@ func TestExportImportWorkflow(t *testing.T) {
 	})
 }
 
-// TestExportImportPreservesWasForkedFrom checks that the was_forked_from flag —
-// which marks a workflow a fork was taken *from* (the fork source), not the fork
-// itself — survives an export/import round trip.
-//
-// Regression: the export/import status column list included forked_from but not
-// was_forked_from, so re-importing a fork source silently lost the flag (it
-// reverted to the column's NOT NULL DEFAULT FALSE).
-func TestExportImportPreservesWasForkedFrom(t *testing.T) {
-	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
-	RegisterWorkflow(dbosCtx, simpleWorkflow)
-	Launch(dbosCtx)
-
-	sdb := dbosCtx.(*dbosContext).systemDB.(*sysDB)
-
-	lookup := func(ids ...string) map[string]WorkflowStatus {
-		wfs, err := sdb.listWorkflows(dbosCtx, listWorkflowsDBInput{workflowIDs: ids})
-		require.NoError(t, err)
-		m := make(map[string]WorkflowStatus, len(wfs))
-		for _, wf := range wfs {
-			m[wf.ID] = wf
-		}
-		return m
-	}
-
-	// Run a workflow, then fork it. Forking marks the ORIGINAL was_forked_from.
-	sourceID := uuid.NewString()
-	handle, err := RunWorkflow(dbosCtx, simpleWorkflow, "hello", WithWorkflowID(sourceID))
-	require.NoError(t, err)
-	_, err = handle.GetResult()
-	require.NoError(t, err)
-
-	forkHandle, err := ForkWorkflow[string](dbosCtx, ForkWorkflowInput{OriginalWorkflowID: sourceID})
-	require.NoError(t, err)
-	forkID := forkHandle.GetWorkflowID()
-	_, err = forkHandle.GetResult()
-	require.NoError(t, err)
-
-	// Sanity check: the source is was_forked_from, the fork itself is not.
-	before := lookup(sourceID, forkID)
-	require.True(t, before[sourceID].WasForkedFrom, "the fork source should be was_forked_from")
-	require.False(t, before[forkID].WasForkedFrom, "the fork itself is not was_forked_from")
-
-	// The exported payload must carry the flag.
-	exported, err := sdb.exportWorkflow(dbosCtx, sourceID, false)
-	require.NoError(t, err)
-	require.Len(t, exported, 1)
-	wff, ok := exported[0].WorkflowStatus["was_forked_from"].(*bool)
-	require.True(t, ok, "was_forked_from must be present in the export payload")
-	require.NotNil(t, wff)
-	assert.True(t, *wff, "exported source should carry was_forked_from=true")
-
-	// Delete both, then re-import the source alone.
-	require.NoError(t, sdb.deleteWorkflows(dbosCtx, deleteWorkflowsDBInput{
-		workflowIDs: []string{sourceID, forkID},
-	}))
-	require.NoError(t, sdb.importWorkflow(dbosCtx, exported))
-
-	// The flag survived the round trip.
-	assert.True(t, lookup(sourceID)[sourceID].WasForkedFrom,
-		"was_forked_from must survive an export/import round trip")
-
-	// And the was_forked_from=true filter finds the re-imported source.
-	wasForkedFrom := true
-	filtered, err := sdb.listWorkflows(dbosCtx, listWorkflowsDBInput{wasForkedFrom: &wasForkedFrom})
-	require.NoError(t, err)
-	found := false
-	for _, wf := range filtered {
-		if wf.ID == sourceID {
-			found = true
-		}
-	}
-	assert.True(t, found, "re-imported source should match the was_forked_from=true filter")
-}
-
 func aggregatesWorkflowSuccess(_ DBOSContext, _ string) (string, error) {
 	return "ok", nil
 }
@@ -8288,6 +8214,12 @@ func TestFork(t *testing.T) {
 			require.Equal(t, int64(3), failStepOneCount.Load())   // replayed for all three forks
 			require.Equal(t, int64(4), failStepTwoCount.Load())   // re-run for wf1's fork only
 			require.Equal(t, int64(5), failStepThreeCount.Load()) // re-run for all three forks
+
+			// A fork also marks its source was_forked_from.
+			srcs, err := sysDB.listWorkflows(dbosCtx, listWorkflowsDBInput{workflowIDs: []string{wf1ID}})
+			require.NoError(t, err)
+			require.Len(t, srcs, 1)
+			require.True(t, srcs[0].WasForkedFrom, "a forked-from workflow should be marked was_forked_from")
 		})
 
 		t.Run("FromLastStep", func(t *testing.T) {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -7370,6 +7370,80 @@ func TestExportImportWorkflow(t *testing.T) {
 	})
 }
 
+// TestExportImportPreservesWasForkedFrom checks that the was_forked_from flag —
+// which marks a workflow a fork was taken *from* (the fork source), not the fork
+// itself — survives an export/import round trip.
+//
+// Regression: the export/import status column list included forked_from but not
+// was_forked_from, so re-importing a fork source silently lost the flag (it
+// reverted to the column's NOT NULL DEFAULT FALSE).
+func TestExportImportPreservesWasForkedFrom(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+	RegisterWorkflow(dbosCtx, simpleWorkflow)
+	Launch(dbosCtx)
+
+	sdb := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+
+	lookup := func(ids ...string) map[string]WorkflowStatus {
+		wfs, err := sdb.listWorkflows(dbosCtx, listWorkflowsDBInput{workflowIDs: ids})
+		require.NoError(t, err)
+		m := make(map[string]WorkflowStatus, len(wfs))
+		for _, wf := range wfs {
+			m[wf.ID] = wf
+		}
+		return m
+	}
+
+	// Run a workflow, then fork it. Forking marks the ORIGINAL was_forked_from.
+	sourceID := uuid.NewString()
+	handle, err := RunWorkflow(dbosCtx, simpleWorkflow, "hello", WithWorkflowID(sourceID))
+	require.NoError(t, err)
+	_, err = handle.GetResult()
+	require.NoError(t, err)
+
+	forkHandle, err := ForkWorkflow[string](dbosCtx, ForkWorkflowInput{OriginalWorkflowID: sourceID})
+	require.NoError(t, err)
+	forkID := forkHandle.GetWorkflowID()
+	_, err = forkHandle.GetResult()
+	require.NoError(t, err)
+
+	// Sanity check: the source is was_forked_from, the fork itself is not.
+	before := lookup(sourceID, forkID)
+	require.True(t, before[sourceID].WasForkedFrom, "the fork source should be was_forked_from")
+	require.False(t, before[forkID].WasForkedFrom, "the fork itself is not was_forked_from")
+
+	// The exported payload must carry the flag.
+	exported, err := sdb.exportWorkflow(dbosCtx, sourceID, false)
+	require.NoError(t, err)
+	require.Len(t, exported, 1)
+	wff, ok := exported[0].WorkflowStatus["was_forked_from"].(*bool)
+	require.True(t, ok, "was_forked_from must be present in the export payload")
+	require.NotNil(t, wff)
+	assert.True(t, *wff, "exported source should carry was_forked_from=true")
+
+	// Delete both, then re-import the source alone.
+	require.NoError(t, sdb.deleteWorkflows(dbosCtx, deleteWorkflowsDBInput{
+		workflowIDs: []string{sourceID, forkID},
+	}))
+	require.NoError(t, sdb.importWorkflow(dbosCtx, exported))
+
+	// The flag survived the round trip.
+	assert.True(t, lookup(sourceID)[sourceID].WasForkedFrom,
+		"was_forked_from must survive an export/import round trip")
+
+	// And the was_forked_from=true filter finds the re-imported source.
+	wasForkedFrom := true
+	filtered, err := sdb.listWorkflows(dbosCtx, listWorkflowsDBInput{wasForkedFrom: &wasForkedFrom})
+	require.NoError(t, err)
+	found := false
+	for _, wf := range filtered {
+		if wf.ID == sourceID {
+			found = true
+		}
+	}
+	assert.True(t, found, "re-imported source should match the was_forked_from=true filter")
+}
+
 func aggregatesWorkflowSuccess(_ DBOSContext, _ string) (string, error) {
 	return "ok", nil
 }


### PR DESCRIPTION
Forking a workflow sets `was_forked_from = true` on the original (the workflow the fork was taken from). It's a real column: the fork writes it, `ListWorkflows` reads it back, and `WithWasForkedFrom(true)` filters on it.

Export/import doesn't preserve it. If you export a workflow that's been forked from and import it elsewhere (or back into an empty DB), `was_forked_from` comes back `false`.

It's just an omission in the column lists. Both the export SELECT and the import INSERT spell out their columns by hand, and they copy `forked_from` but never listed `was_forked_from`. So on import the column falls back to its `NOT NULL DEFAULT FALSE` and the flag is gone. Nothing errors, it just flips.

Python already handles this: it selects `was_forked_from` on export, carries it over on import (defaulting to `False` for older payloads), and has a test for the round trip. Pinned to `dbos-inc/dbos-transact-py@f6cfec5`:

- export, selects the column: [`_sys_db.py#L4501`](https://github.com/dbos-inc/dbos-transact-py/blob/f6cfec5dc0a4318a6569fc789bf94d6bf3c73dce/dbos/_sys_db.py#L4501), puts it in the payload: [`_sys_db.py#L4545`](https://github.com/dbos-inc/dbos-transact-py/blob/f6cfec5dc0a4318a6569fc789bf94d6bf3c73dce/dbos/_sys_db.py#L4545)
- import, carries it over: [`_sys_db.py#L4706`](https://github.com/dbos-inc/dbos-transact-py/blob/f6cfec5dc0a4318a6569fc789bf94d6bf3c73dce/dbos/_sys_db.py#L4706)
- test, asserts the round trip: [`test_workflow_export.py#L93`](https://github.com/dbos-inc/dbos-transact-py/blob/f6cfec5dc0a4318a6569fc789bf94d6bf3c73dce/tests/test_workflow_export.py#L93)

So right now Go and Python disagree on what an export/import keeps. This lines Go up with Python.

## The fix

- Export: add `was_forked_from` to the `workflow_status` SELECT, scan it, and put it in the payload.
- Import: add it to the INSERT. The column is `NOT NULL`, so a payload from before this change won't have the key; default it to `false` (same as Python's `.get("was_forked_from", False)`) so old exports still import cleanly.

## How to reproduce

Run the test in this PR against `main`:

```bash
DBOS_TEST_BACKEND=sqlite go test ./dbos/ -run TestExportImportPreservesWasForkedFrom -v
```

On `main` it fails with `was_forked_from must be present in the export payload`; with this change it passes. Same on Postgres.

By hand it's: run a workflow, fork it (that marks the original), export the original, delete it, re-import, and check `WasForkedFrom` on the reimported row. It's `false` before the fix and `true` after.

## Testing

Added `TestExportImportPreservesWasForkedFrom`: run a workflow, fork it, export the source, delete it, re-import, and assert `was_forked_from` is still `true` (and that `WithWasForkedFrom(true)` still finds it). It fails without the fix and passes with it, on both SQLite and Postgres. `TestExportImportWorkflow` still passes, and `go vet` / `gofmt` are clean.
