### PR TITLE
Client methods

### DIFF
--- a/dbos/client.go
+++ b/dbos/client.go
@@ -41,6 +41,8 @@ type Client interface {
 	ResumeWorkflows(workflowIDs []string, opts ...ResumeWorkflowOption) ([]WorkflowHandle[any], error)
 	ForkWorkflow(input ForkWorkflowInput) (WorkflowHandle[any], error)
 	GetWorkflowSteps(workflowID string) ([]StepInfo, error)
+	ClientListWorkflows(opts ...ListWorkflowsOption) ([]WorkflowStatus, error)
+	ClientGetWorkflowSteps(workflowID string, opts ...GetWorkflowStepsOption) ([]StepInfo, error)
 	ClientReadStream(workflowID string, key string, opts ...ReadStreamOption) ([]any, bool, error)
 	ClientReadStreamAsync(workflowID string, key string) (<-chan StreamValue[any], error)
 
@@ -101,6 +103,23 @@ func NewClient(ctx context.Context, config ClientConfig) (Client, error) {
 	return &client{
 		dbosCtx: dbosCtx,
 	}, nil
+}
+
+func clientCtx(c Client) (DBOSContext, error) {
+	cl, ok := c.(*client)
+	if !ok || cl == nil {
+		return nil, errors.New("client is nil or an unsupported implementation")
+	}
+	return cl.dbosCtx, nil
+}
+
+// typedClientHandle adapts an untyped handle returned by a Client interface
+// method into a WorkflowHandle[R]. Falls back to workflowHandleProxy for the mocking path.
+func typedClientHandle[R any](c Client, handle WorkflowHandle[any]) WorkflowHandle[R] {
+	if cl, ok := c.(*client); ok {
+		return newWorkflowPollingHandle[R](cl.dbosCtx, handle.GetWorkflowID())
+	}
+	return &workflowHandleProxy[R]{wrappedHandle: handle}
 }
 
 // EnqueueOption is a functional option for configuring workflow enqueue parameters.
@@ -453,7 +472,7 @@ func Enqueue[P any, R any](c Client, queueName, workflowName string, input P, op
 		return nil, err
 	}
 
-	return newWorkflowPollingHandle[R](c.(*client).dbosCtx, handle.GetWorkflowID()), nil
+	return typedClientHandle[R](c, handle), nil
 }
 
 // ListWorkflows retrieves a list of workflows based on the provided filters.
@@ -484,9 +503,51 @@ func (c *client) GetEvent(targetWorkflowID, key string, timeout time.Duration) (
 	return result, nil
 }
 
+// ClientGetEvent retrieves a key-value event from a target workflow and decodes
+// it into type R using the serialization recorded with the event.
+//
+// Example:
+//
+//	value, err := dbos.ClientGetEvent[string](client, "workflow-id", "my-key", 10*time.Second)
+func ClientGetEvent[R any](c Client, targetWorkflowID, key string, timeout time.Duration) (R, error) {
+	if c == nil {
+		return *new(R), errors.New("client cannot be nil")
+	}
+	// Built-in client: decode using the serialization recorded with the event.
+	if cl, ok := c.(*client); ok {
+		return GetEvent[R](cl.dbosCtx, targetWorkflowID, key, timeout)
+	}
+	// Mocked client: the interface method returns an already-typed value.
+	value, err := c.GetEvent(targetWorkflowID, key, timeout)
+	if err != nil {
+		return *new(R), err
+	}
+	if value == nil {
+		return *new(R), nil
+	}
+	typed, ok := value.(R)
+	if !ok {
+		return *new(R), fmt.Errorf("mocked GetEvent returned %T, expected %T", value, *new(R))
+	}
+	return typed, nil
+}
+
 // RetrieveWorkflow returns a handle to an existing workflow.
 func (c *client) RetrieveWorkflow(workflowID string) (WorkflowHandle[any], error) {
 	return c.dbosCtx.RetrieveWorkflow(c.dbosCtx, workflowID)
+}
+
+// ClientRetrieveWorkflow returns a typed handle to an existing workflow. The
+// handle's GetResult decodes the workflow output into type R.
+func ClientRetrieveWorkflow[R any](c Client, workflowID string) (WorkflowHandle[R], error) {
+	if c == nil {
+		return nil, errors.New("client cannot be nil")
+	}
+	handle, err := c.RetrieveWorkflow(workflowID)
+	if err != nil {
+		return nil, err
+	}
+	return typedClientHandle[R](c, handle), nil
 }
 
 // CancelWorkflowOption is a function option for configuring workflow cancelling parameters.
@@ -550,14 +611,69 @@ func (c *client) ResumeWorkflows(workflowIDs []string, opts ...ResumeWorkflowOpt
 	return c.dbosCtx.ResumeWorkflows(c.dbosCtx, workflowIDs, opts...)
 }
 
+// ClientResumeWorkflow resumes a workflow and returns a typed handle whose
+// GetResult decodes the workflow output into type R.
+func ClientResumeWorkflow[R any](c Client, workflowID string, opts ...ResumeWorkflowOption) (WorkflowHandle[R], error) {
+	if c == nil {
+		return nil, errors.New("client cannot be nil")
+	}
+	handle, err := c.ResumeWorkflow(workflowID, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return typedClientHandle[R](c, handle), nil
+}
+
+// ClientResumeWorkflows resumes multiple workflows and returns typed handles
+// whose GetResult decodes each workflow output into type R.
+func ClientResumeWorkflows[R any](c Client, workflowIDs []string, opts ...ResumeWorkflowOption) ([]WorkflowHandle[R], error) {
+	if c == nil {
+		return nil, errors.New("client cannot be nil")
+	}
+	anyHandles, err := c.ResumeWorkflows(workflowIDs, opts...)
+	if err != nil {
+		return nil, err
+	}
+	handles := make([]WorkflowHandle[R], 0, len(anyHandles))
+	for _, h := range anyHandles {
+		handles = append(handles, typedClientHandle[R](c, h))
+	}
+	return handles, nil
+}
+
 // ForkWorkflow creates a new workflow instance by copying an existing workflow from a specific step.
 func (c *client) ForkWorkflow(input ForkWorkflowInput) (WorkflowHandle[any], error) {
 	return c.dbosCtx.ForkWorkflow(c.dbosCtx, input)
 }
 
+// ClientForkWorkflow forks a workflow and returns a typed handle whose GetResult
+// decodes the forked workflow's output into type R.
+func ClientForkWorkflow[R any](c Client, input ForkWorkflowInput) (WorkflowHandle[R], error) {
+	if c == nil {
+		return nil, errors.New("client cannot be nil")
+	}
+	handle, err := c.ForkWorkflow(input)
+	if err != nil {
+		return nil, err
+	}
+	return typedClientHandle[R](c, handle), nil
+}
+
 // GetWorkflowSteps retrieves the execution steps of a workflow.
 func (c *client) GetWorkflowSteps(workflowID string) ([]StepInfo, error) {
 	return c.dbosCtx.GetWorkflowSteps(c.dbosCtx, workflowID)
+}
+
+// ClientListWorkflows lists workflows. Input and output are NOT loaded or
+// decoded by default. Pass WithLoadInput(true) / WithLoadOutput(true) to opt in.
+func (c *client) ClientListWorkflows(opts ...ListWorkflowsOption) ([]WorkflowStatus, error) {
+	return c.dbosCtx.ListWorkflows(c.dbosCtx, opts...)
+}
+
+// ClientGetWorkflowSteps retrieves a workflow's execution steps. Step output is
+// NOT loaded or decoded by default. Pass WithStepsLoadOutput(true) to opt in.
+func (c *client) ClientGetWorkflowSteps(workflowID string, opts ...GetWorkflowStepsOption) ([]StepInfo, error) {
+	return c.dbosCtx.GetWorkflowSteps(c.dbosCtx, workflowID, opts...)
 }
 
 // ReadStream reads values from a durable stream.
@@ -586,8 +702,9 @@ func (c *client) ClientReadStream(workflowID string, key string, opts ...ReadStr
 //	    log.Printf("Stream value: %s", value)
 //	}
 func ClientReadStream[R any](c Client, workflowID string, key string, opts ...ReadStreamOption) ([]R, bool, error) {
-	if c == nil {
-		return nil, false, errors.New("client cannot be nil")
+	ctx, err := clientCtx(c)
+	if err != nil {
+		return nil, false, err
 	}
 	values, closed, err := c.ClientReadStream(workflowID, key, opts...)
 	if err != nil {
@@ -595,7 +712,7 @@ func ClientReadStream[R any](c Client, workflowID string, key string, opts ...Re
 	}
 
 	// Decode each value using the serialization stored with that stream entry.
-	customSer := c.(*client).dbosCtx.(*dbosContext).serializer
+	customSer := getCustomSerializerFromCtx(ctx)
 	typedValues := make([]R, len(values))
 	for i, val := range values {
 		entry, ok := val.(streamEntryWithSerialization)
@@ -647,8 +764,9 @@ func (c *client) ClientReadStreamAsync(workflowID string, key string) (<-chan St
 //	    log.Printf("Received value: %s", streamValue.Value)
 //	}
 func ClientReadStreamAsync[R any](c Client, workflowID string, key string) (<-chan StreamValue[R], error) {
-	if c == nil {
-		return nil, errors.New("client cannot be nil")
+	dbosCtx, err := clientCtx(c)
+	if err != nil {
+		return nil, err
 	}
 
 	anyCh, err := c.ClientReadStreamAsync(workflowID, key)
@@ -657,7 +775,6 @@ func ClientReadStreamAsync[R any](c Client, workflowID string, key string) (<-ch
 	}
 
 	typedCh := make(chan StreamValue[R], 1)
-	dbosCtx := c.(*client).dbosCtx
 
 	go func() {
 		defer close(typedCh)
@@ -673,7 +790,7 @@ func ClientReadStreamAsync[R any](c Client, workflowID string, key string) (<-ch
 			}
 		}
 
-		customSer := dbosCtx.(*dbosContext).serializer
+		customSer := getCustomSerializerFromCtx(dbosCtx)
 
 		for streamValue := range anyCh {
 			if streamValue.Err != nil {
@@ -887,6 +1004,19 @@ func (c *client) BackfillSchedule(scheduleName string, start, end time.Time) ([]
 // to the enqueued workflow.
 func (c *client) TriggerSchedule(scheduleName string) (WorkflowHandle[any], error) {
 	return c.dbosCtx.TriggerSchedule(c.dbosCtx, scheduleName)
+}
+
+// ClientTriggerSchedule triggers a schedule and returns a typed handle whose
+// GetResult decodes the triggered workflow's output into type R.
+func ClientTriggerSchedule[R any](c Client, scheduleName string) (WorkflowHandle[R], error) {
+	if c == nil {
+		return nil, errors.New("client cannot be nil")
+	}
+	handle, err := c.TriggerSchedule(scheduleName)
+	if err != nil {
+		return nil, err
+	}
+	return typedClientHandle[R](c, handle), nil
 }
 
 // ListApplicationVersions returns every registered application version ordered

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -2451,3 +2451,275 @@ func TestClientSend(t *testing.T) {
 		require.Contains(t, result, "c-b")
 	})
 }
+
+// TestClientGetEvent verifies ClientGetEvent decodes an event value into the
+// requested type using the serialization recorded with the event.
+func TestClientGetEvent(t *testing.T) {
+	serverCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+	queue := NewWorkflowQueue(serverCtx, "client-getevent-queue")
+
+	type eventPayload struct {
+		Label string
+		Count int
+	}
+
+	eventWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		if err := SetEvent(ctx, "struct-key", eventPayload{Label: "ready", Count: 7}); err != nil {
+			return "", err
+		}
+		if err := SetEvent(ctx, "string-key", "hello-event"); err != nil {
+			return "", err
+		}
+		return "done", nil
+	}
+	RegisterWorkflow(serverCtx, eventWorkflow, WithWorkflowName("EventWorkflow"))
+
+	require.NoError(t, Launch(serverCtx))
+
+	client, err := NewClient(context.Background(), ClientConfig{DatabaseURL: backendDatabaseURL(t)})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Shutdown(30 * time.Second) })
+
+	workflowID := "client-getevent-wf"
+	handle, err := Enqueue[string, string](client, queue.Name, "EventWorkflow", "",
+		WithEnqueueWorkflowID(workflowID),
+		WithEnqueueApplicationVersion(serverCtx.GetApplicationVersion()))
+	require.NoError(t, err)
+	_, err = handle.GetResult()
+	require.NoError(t, err)
+
+	t.Run("DecodesStructEvent", func(t *testing.T) {
+		val, err := ClientGetEvent[eventPayload](client, workflowID, "struct-key", 5*time.Second)
+		require.NoError(t, err)
+		require.Equal(t, eventPayload{Label: "ready", Count: 7}, val)
+	})
+
+	t.Run("DecodesStringEvent", func(t *testing.T) {
+		val, err := ClientGetEvent[string](client, workflowID, "string-key", 5*time.Second)
+		require.NoError(t, err)
+		require.Equal(t, "hello-event", val)
+	})
+
+	t.Run("NilClient", func(t *testing.T) {
+		_, err := ClientGetEvent[string](nil, workflowID, "string-key", time.Second)
+		require.Error(t, err)
+	})
+
+	require.True(t, queueEntriesAreCleanedUp(serverCtx), "expected queue entries to be cleaned up after get event test")
+}
+
+// TestClientTypedHandles verifies the typed handle helpers (ClientRetrieveWorkflow,
+// ClientForkWorkflow, ClientResumeWorkflow, ClientResumeWorkflows) return handles
+// whose GetResult decodes the workflow output into the requested type.
+func TestClientTypedHandles(t *testing.T) {
+	serverCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+	queue := NewWorkflowQueue(serverCtx, "client-typed-handles-queue")
+
+	type sumResult struct {
+		Sum int
+	}
+
+	sumWorkflow := func(ctx DBOSContext, n int) (sumResult, error) {
+		return RunAsStep(ctx, func(context.Context) (sumResult, error) {
+			return sumResult{Sum: n * 2}, nil
+		})
+	}
+	RegisterWorkflow(serverCtx, sumWorkflow, WithWorkflowName("SumWorkflow"))
+
+	require.NoError(t, Launch(serverCtx))
+
+	client, err := NewClient(context.Background(), ClientConfig{DatabaseURL: backendDatabaseURL(t)})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Shutdown(30 * time.Second) })
+
+	appVersion := WithEnqueueApplicationVersion(serverCtx.GetApplicationVersion())
+
+	t.Run("RetrieveWorkflowTyped", func(t *testing.T) {
+		workflowID := "client-retrieve-typed"
+		_, err := Enqueue[int, sumResult](client, queue.Name, "SumWorkflow", 21, WithEnqueueWorkflowID(workflowID), appVersion)
+		require.NoError(t, err)
+
+		handle, err := ClientRetrieveWorkflow[sumResult](client, workflowID)
+		require.NoError(t, err)
+		res, err := handle.GetResult()
+		require.NoError(t, err)
+		require.Equal(t, sumResult{Sum: 42}, res)
+	})
+
+	t.Run("ForkWorkflowTyped", func(t *testing.T) {
+		workflowID := "client-fork-typed"
+		h, err := Enqueue[int, sumResult](client, queue.Name, "SumWorkflow", 5, WithEnqueueWorkflowID(workflowID), appVersion)
+		require.NoError(t, err)
+		_, err = h.GetResult()
+		require.NoError(t, err)
+
+		forkedHandle, err := ClientForkWorkflow[sumResult](client, ForkWorkflowInput{OriginalWorkflowID: workflowID, StartStep: 0})
+		require.NoError(t, err)
+		res, err := forkedHandle.GetResult()
+		require.NoError(t, err)
+		require.Equal(t, sumResult{Sum: 10}, res)
+	})
+
+	t.Run("ResumeWorkflowTyped", func(t *testing.T) {
+		workflowID := "client-resume-typed"
+		h, err := Enqueue[int, sumResult](client, queue.Name, "SumWorkflow", 8, WithEnqueueWorkflowID(workflowID), appVersion)
+		require.NoError(t, err)
+		_, err = h.GetResult()
+		require.NoError(t, err)
+
+		// Resuming a completed workflow returns a typed handle to the existing result.
+		resumeHandle, err := ClientResumeWorkflow[sumResult](client, workflowID)
+		require.NoError(t, err)
+		res, err := resumeHandle.GetResult()
+		require.NoError(t, err)
+		require.Equal(t, sumResult{Sum: 16}, res)
+	})
+
+	t.Run("ResumeWorkflowsTyped", func(t *testing.T) {
+		ids := make([]string, 0, 2)
+		for i := range 2 {
+			workflowID := fmt.Sprintf("client-resume-multi-%d", i)
+			h, err := Enqueue[int, sumResult](client, queue.Name, "SumWorkflow", i+1, WithEnqueueWorkflowID(workflowID), appVersion)
+			require.NoError(t, err)
+			_, err = h.GetResult()
+			require.NoError(t, err)
+			ids = append(ids, workflowID)
+		}
+
+		handles, err := ClientResumeWorkflows[sumResult](client, ids)
+		require.NoError(t, err)
+		require.Len(t, handles, 2)
+		// ResumeWorkflows does not guarantee handle order matches input order,
+		// so verify each result against its own workflow ID.
+		expected := map[string]sumResult{
+			"client-resume-multi-0": {Sum: 2},
+			"client-resume-multi-1": {Sum: 4},
+		}
+		for _, h := range handles {
+			res, err := h.GetResult()
+			require.NoError(t, err)
+			require.Equal(t, expected[h.GetWorkflowID()], res)
+		}
+	})
+
+	t.Run("NilClient", func(t *testing.T) {
+		_, err := ClientRetrieveWorkflow[sumResult](nil, "any")
+		require.Error(t, err)
+	})
+
+	require.True(t, queueEntriesAreCleanedUp(serverCtx), "expected queue entries to be cleaned up after typed handles test")
+}
+
+// TestClientListAndSteps verifies ClientListWorkflows and ClientGetWorkflowSteps
+// do NOT load/decode input/output by default, and decode them when explicitly
+// asked via the load options.
+func TestClientListAndSteps(t *testing.T) {
+	serverCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+	queue := NewWorkflowQueue(serverCtx, "client-list-steps-queue")
+
+	type wfInput struct {
+		Name string
+	}
+	type wfOutput struct {
+		Greeting string
+	}
+
+	listStepsWorkflow := func(ctx DBOSContext, input wfInput) (wfOutput, error) {
+		out, err := RunAsStep(ctx, func(context.Context) (wfOutput, error) {
+			return wfOutput{Greeting: "hi"}, nil
+		}, WithStepName("GreetStep"))
+		if err != nil {
+			return wfOutput{}, err
+		}
+		out.Greeting = out.Greeting + " " + input.Name
+		return out, nil
+	}
+	RegisterWorkflow(serverCtx, listStepsWorkflow, WithWorkflowName("ListStepsWorkflow"))
+
+	require.NoError(t, Launch(serverCtx))
+
+	client, err := NewClient(context.Background(), ClientConfig{DatabaseURL: backendDatabaseURL(t)})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Shutdown(30 * time.Second) })
+
+	workflowID := "client-list-steps-wf"
+	handle, err := Enqueue[wfInput, wfOutput](client, queue.Name, "ListStepsWorkflow", wfInput{Name: "max"},
+		WithEnqueueWorkflowID(workflowID),
+		WithEnqueueApplicationVersion(serverCtx.GetApplicationVersion()))
+	require.NoError(t, err)
+	_, err = handle.GetResult()
+	require.NoError(t, err)
+
+	t.Run("ListWorkflowsNoDecodeByDefault", func(t *testing.T) {
+		workflows, err := client.ClientListWorkflows(WithWorkflowIDs([]string{workflowID}))
+		require.NoError(t, err)
+		require.Len(t, workflows, 1)
+		assert.Nil(t, workflows[0].Input, "input must not be loaded by default")
+		assert.Nil(t, workflows[0].Output, "output must not be loaded by default")
+	})
+
+	t.Run("ListWorkflowsLoadsWhenRequested", func(t *testing.T) {
+		workflows, err := client.ClientListWorkflows(WithWorkflowIDs([]string{workflowID}), WithLoadInput(true), WithLoadOutput(true))
+		require.NoError(t, err)
+		require.Len(t, workflows, 1)
+
+		// With no serializer configured, payloads come back as raw JSON strings
+		// (cross-language friendly), not Go-decoded values.
+		input, ok := workflows[0].Input.(string)
+		require.True(t, ok, "expected loaded input to be a string, got %T", workflows[0].Input)
+		assert.JSONEq(t, `{"Name":"max"}`, input)
+
+		output, ok := workflows[0].Output.(string)
+		require.True(t, ok, "expected loaded output to be a string, got %T", workflows[0].Output)
+		assert.JSONEq(t, `{"Greeting":"hi max"}`, output)
+	})
+
+	t.Run("GetWorkflowStepsNoDecodeByDefault", func(t *testing.T) {
+		steps, err := client.ClientGetWorkflowSteps(workflowID)
+		require.NoError(t, err)
+		require.Len(t, steps, 1)
+		assert.Equal(t, "GreetStep", steps[0].StepName)
+		assert.Nil(t, steps[0].Output, "step output must not be loaded by default")
+	})
+
+	t.Run("GetWorkflowStepsLoadsWhenRequested", func(t *testing.T) {
+		steps, err := client.ClientGetWorkflowSteps(workflowID, WithStepsLoadOutput(true))
+		require.NoError(t, err)
+		require.Len(t, steps, 1)
+		output, ok := steps[0].Output.(string)
+		require.True(t, ok, "expected loaded step output to be a string, got %T", steps[0].Output)
+		assert.JSONEq(t, `{"Greeting":"hi"}`, output)
+	})
+
+	require.True(t, queueEntriesAreCleanedUp(serverCtx), "expected queue entries to be cleaned up after list/steps test")
+}
+
+// TestClientTriggerScheduleTyped verifies ClientTriggerSchedule returns a typed
+// handle whose GetResult decodes the triggered workflow's output.
+func TestClientTriggerScheduleTyped(t *testing.T) {
+	serverCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+	RegisterWorkflow(serverCtx, testWorkflowForSchedule)
+	require.NoError(t, Launch(serverCtx))
+
+	c, err := NewClient(context.Background(), ClientConfig{DatabaseURL: backendDatabaseURL(t)})
+	require.NoError(t, err)
+	t.Cleanup(func() { c.Shutdown(30 * time.Second) })
+
+	const workflowFQN = "github.com/dbos-inc/dbos-transact-golang/dbos.testWorkflowForSchedule"
+	const name = "client-trigger-typed"
+	require.NoError(t, c.CreateSchedule(ClientScheduleInput{
+		ScheduleName: name,
+		WorkflowName: workflowFQN,
+		Schedule:     "0 0 * * * *",
+	}))
+	t.Cleanup(func() { _ = c.DeleteSchedule(name) })
+
+	handle, err := ClientTriggerSchedule[string](c, name)
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+	require.Contains(t, handle.GetWorkflowID(), name)
+
+	result, err := handle.GetResult()
+	require.NoError(t, err)
+	require.Equal(t, "completed", result)
+}

--- a/dbos/pgsql_client_test.go
+++ b/dbos/pgsql_client_test.go
@@ -225,11 +225,13 @@ func TestPgsqlClient(t *testing.T) {
 		wfID2 := fmt.Sprintf("pgsql-dedup-wf2-%d", time.Now().UnixNano())
 		dedupID := fmt.Sprintf("pgsql-dedup-%d", time.Now().UnixNano())
 
+		// Use the blocking workflow so wfID1 cannot complete (completion clears
+		// deduplication_id, which would let the wfID2 enqueue below succeed).
 		// First enqueue succeeds.
 		_, err := callEnqueueWorkflow(context.Background(), pool, schema, map[string]any{
-			"workflow_name":       "pgsql_retrieve_test",
+			"workflow_name":       "pgsql_blocked_workflow",
 			"queue_name":          queue.Name,
-			"positional_args":     []string{`"abc"`},
+			"positional_args":     []string{`""`},
 			"named_args":          `{}`,
 			"workflow_id":         wfID1,
 			"app_version":         serverCtx.GetApplicationVersion(),
@@ -243,9 +245,9 @@ func TestPgsqlClient(t *testing.T) {
 
 		// Same wfID again is idempotent.
 		_, err = callEnqueueWorkflow(context.Background(), pool, schema, map[string]any{
-			"workflow_name":       "pgsql_retrieve_test",
+			"workflow_name":       "pgsql_blocked_workflow",
 			"queue_name":          queue.Name,
-			"positional_args":     []string{`"abc"`},
+			"positional_args":     []string{`""`},
 			"named_args":          `{}`,
 			"workflow_id":         wfID1,
 			"app_version":         serverCtx.GetApplicationVersion(),
@@ -259,9 +261,9 @@ func TestPgsqlClient(t *testing.T) {
 
 		// Different wfID with same dedup key must fail.
 		_, err = callEnqueueWorkflow(context.Background(), pool, schema, map[string]any{
-			"workflow_name":       "pgsql_retrieve_test",
+			"workflow_name":       "pgsql_blocked_workflow",
 			"queue_name":          queue.Name,
-			"positional_args":     []string{`"def"`},
+			"positional_args":     []string{`""`},
 			"named_args":          `{}`,
 			"workflow_id":         wfID2,
 			"app_version":         serverCtx.GetApplicationVersion(),
@@ -278,11 +280,12 @@ func TestPgsqlClient(t *testing.T) {
 		assert.Equal(t, "DBOS queue duplicated", pgErr.Message)
 		assert.Contains(t, pgErr.Detail, fmt.Sprintf("Workflow %s with queue %s and deduplication ID %s already exists", wfID2, queue.Name, dedupID))
 
+		// Release the dedup slot and wait for wfID1 to finish.
+		require.NoError(t, CancelWorkflow(serverCtx, wfID1))
 		handle, err := RetrieveWorkflow[string](serverCtx, wfID1)
 		require.NoError(t, err)
-		result, err := handle.GetResult()
-		require.NoError(t, err)
-		assert.Equal(t, "abc", result)
+		_, err = handle.GetResult()
+		require.Error(t, err, "expected cancellation error")
 	})
 
 	t.Run("EnqueueWithPriority", func(t *testing.T) {

--- a/integration/mocks_test.go
+++ b/integration/mocks_test.go
@@ -421,3 +421,66 @@ func TestMocks(t *testing.T) {
 		t.Fatalf("clientMethodsFunction failed: %v", err)
 	}
 }
+
+// TestClientTypedHelpersWithMock verifies the typed, package-level Client helpers
+// (dbos.ClientGetEvent, dbos.Enqueue, dbos.ClientRetrieveWorkflow, etc.) route
+// through the Client interface methods and therefore work with a mocked Client,
+// rather than requiring the concrete built-in client implementation.
+func TestClientTypedHelpersWithMock(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	mockClient := mocks.NewMockClient(t)
+
+	// ClientGetEvent decodes via the interface GetEvent on a mocked client.
+	mockClient.On("GetEvent", "wf-evt", "key", 1*time.Second).Return(42, nil).Once()
+	evt, err := dbos.ClientGetEvent[int](mockClient, "wf-evt", "key", 1*time.Second)
+	if err != nil {
+		t.Fatalf("ClientGetEvent failed: %v", err)
+	}
+	if evt != 42 {
+		t.Fatalf("ClientGetEvent = %d, want 42", evt)
+	}
+
+	// Enqueue returns a typed handle backed by the mocked handle.
+	enqHandle := mocks.NewMockWorkflowHandle[any](t)
+	enqHandle.On("GetResult").Return(7, nil).Once()
+	mockClient.On("Enqueue", "q", "wf", "in", mock.Anything).Return(enqHandle, nil).Once()
+	eh, err := dbos.Enqueue[string, int](mockClient, "q", "wf", "in")
+	if err != nil {
+		t.Fatalf("Enqueue failed: %v", err)
+	}
+	if res, err := eh.GetResult(); err != nil || res != 7 {
+		t.Fatalf("Enqueue handle GetResult = (%d, %v), want (7, nil)", res, err)
+	}
+
+	// ClientRetrieveWorkflow returns a typed handle.
+	retHandle := mocks.NewMockWorkflowHandle[any](t)
+	retHandle.On("GetResult").Return(9, nil).Once()
+	mockClient.On("RetrieveWorkflow", "wf-ret").Return(retHandle, nil).Once()
+	rh, err := dbos.ClientRetrieveWorkflow[int](mockClient, "wf-ret")
+	if err != nil {
+		t.Fatalf("ClientRetrieveWorkflow failed: %v", err)
+	}
+	if res, err := rh.GetResult(); err != nil || res != 9 {
+		t.Fatalf("ClientRetrieveWorkflow handle GetResult = (%d, %v), want (9, nil)", res, err)
+	}
+
+	// ClientForkWorkflow returns a typed handle.
+	forkHandle := mocks.NewMockWorkflowHandle[any](t)
+	forkHandle.On("GetResult").Return(11, nil).Once()
+	mockClient.On("ForkWorkflow", mock.Anything).Return(forkHandle, nil).Once()
+	fh, err := dbos.ClientForkWorkflow[int](mockClient, dbos.ForkWorkflowInput{OriginalWorkflowID: "wf-ret"})
+	if err != nil {
+		t.Fatalf("ClientForkWorkflow failed: %v", err)
+	}
+	if res, err := fh.GetResult(); err != nil || res != 11 {
+		t.Fatalf("ClientForkWorkflow handle GetResult = (%d, %v), want (11, nil)", res, err)
+	}
+
+	// ClientListWorkflows is an interface method, so it mocks directly.
+	mockClient.On("ClientListWorkflows", mock.Anything).Return([]dbos.WorkflowStatus{{ID: "wf-ret"}}, nil).Once()
+	list, err := mockClient.ClientListWorkflows()
+	if err != nil || len(list) != 1 || list[0].ID != "wf-ret" {
+		t.Fatalf("ClientListWorkflows = (%v, %v), want one status with ID wf-ret", list, err)
+	}
+}


### PR DESCRIPTION
Currently the client passes through most of its call to the underlying DBOS context interface, losing typing. This is particularly annoying for `GetEvent`.

This PR adds typed package method for a few client methods. Also add `ClientListWorkflows` and `ClientGetWorkflowSteps` so, when using load input/outputs, the client can benefit from automatic decoding.


Also fix a race in a plsql test.