### PR TITLE
Special steps runAsTxn

### DIFF
--- a/dbos/serialization.go
+++ b/dbos/serialization.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 )
 
 const (
@@ -337,6 +338,7 @@ func init() {
 	// type preserved on the Go <-> Go error path (see serializeWorkflowError).
 	gob.Register(&DBOSError{})
 	gob.Register(&PortableWorkflowError{})
+	gob.Register(time.Time{})
 }
 
 // serializeWorkflowError encodes an error for DB storage.

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -1424,6 +1424,110 @@ func TestChickenSerializer(t *testing.T) {
 	})
 }
 
+// timeHostileSerializer behaves like the default JSON serializer but refuses to
+// encode a time.Time. It models a realistic custom serializer (schema/protobuf
+// based, or one with a type allowlist) that has no mapping for time.Time. It is
+// used to guard against DBOS routing an internal deadline through the user
+// serializer as a time.Time: the special steps (Sleep, and the timeout sleep of
+// Recv/GetEvent) must checkpoint the deadline as epoch millis (int64), which any
+// serializer can round-trip, rather than a time.Time.
+type timeHostileSerializer struct{}
+
+func (timeHostileSerializer) Name() string { return "TIME_HOSTILE" }
+
+func (timeHostileSerializer) Encode(data any) (*string, error) {
+	if _, ok := data.(time.Time); ok {
+		return nil, fmt.Errorf("timeHostileSerializer refuses to encode time.Time")
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	s := string(b)
+	return &s, nil
+}
+
+func (timeHostileSerializer) Decode(data *string) (any, error) {
+	if data == nil {
+		return nil, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader([]byte(*data)))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	// Return whole numbers as int64 so DBOS's typed decode of the epoch-millis
+	// deadline round-trips instead of surfacing a float64.
+	if n, ok := v.(json.Number); ok {
+		if i, ierr := n.Int64(); ierr == nil {
+			return i, nil
+		}
+		f, ferr := n.Float64()
+		if ferr != nil {
+			return nil, ferr
+		}
+		return f, nil
+	}
+	return v, nil
+}
+
+// TestTimeHostileSerializer verifies the special steps whose durable deadline is
+// a timestamp (Sleep, and the internal timeout sleep of Recv/GetEvent) encode that deadline as int64.
+func TestTimeHostileSerializer(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true, serializer: timeHostileSerializer{}})
+
+	sleepWorkflow := func(ctx DBOSContext, ms int) (time.Duration, error) {
+		return Sleep(ctx, time.Duration(ms)*time.Millisecond)
+	}
+	recvTimeoutWorkflow := func(ctx DBOSContext, topic string) (string, error) {
+		return Recv[string](ctx, topic, 500*time.Millisecond)
+	}
+	getEventTimeoutWorkflow := func(ctx DBOSContext, targetID string) (string, error) {
+		return GetEvent[string](ctx, targetID, "no-such-key", 500*time.Millisecond)
+	}
+	RegisterWorkflow(dbosCtx, sleepWorkflow)
+	RegisterWorkflow(dbosCtx, recvTimeoutWorkflow)
+	RegisterWorkflow(dbosCtx, getEventTimeoutWorkflow)
+
+	err := Launch(dbosCtx)
+	require.NoError(t, err)
+
+	t.Run("Sleep", func(t *testing.T) {
+		handle, err := RunWorkflow(dbosCtx, sleepWorkflow, 100)
+		require.NoError(t, err, "failed to start sleep workflow")
+		slept, err := handle.GetResult()
+		require.NoError(t, err, "Sleep must succeed: the deadline is stored as epoch millis, not a time.Time the serializer rejects")
+		require.LessOrEqual(t, slept, 100*time.Millisecond)
+
+		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err)
+		require.Len(t, steps, 1)
+		require.Equal(t, "DBOS.sleep", steps[0].StepName)
+		require.Nil(t, steps[0].Error, "the sleep deadline must checkpoint cleanly")
+	})
+
+	t.Run("RecvTimeout", func(t *testing.T) {
+		handle, err := RunWorkflow(dbosCtx, recvTimeoutWorkflow, "time-hostile-topic")
+		require.NoError(t, err, "failed to start recv workflow")
+		_, err = handle.GetResult()
+		require.Error(t, err, "expected a timeout")
+		dbosErr, ok := err.(*DBOSError)
+		require.True(t, ok, "expected *DBOSError, got %T (a serialization failure here would mean the deadline was routed through the serializer as a time.Time)", err)
+		require.Equal(t, TimeoutError, dbosErr.Code, "expected TimeoutError, not a serialization error")
+	})
+
+	t.Run("GetEventTimeout", func(t *testing.T) {
+		handle, err := RunWorkflow(dbosCtx, getEventTimeoutWorkflow, "time-hostile-nonexistent-target")
+		require.NoError(t, err, "failed to start getEvent workflow")
+		_, err = handle.GetResult()
+		require.Error(t, err, "expected a timeout")
+		dbosErr, ok := err.(*DBOSError)
+		require.True(t, ok, "expected *DBOSError, got %T", err)
+		require.Equal(t, TimeoutError, dbosErr.Code, "expected TimeoutError, not a serialization error")
+	})
+}
+
 // TestPortableInterop tests cross-language interoperability using the portable JSON format.
 // It simulates another language inserting a workflow into the DB with portable_json serialization,
 // and verifies that Go can recover and execute it correctly.

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -3753,18 +3753,28 @@ func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key st
 	if loaded {
 		// Reuse the existing condition variable
 		cond.L.Unlock()
-		cond = existingCond.(*sync.Cond)
+		ec, ok := existingCond.(*sync.Cond)
+		if !ok {
+			return nil, fmt.Errorf("workflow events map holds unexpected %T for %s", existingCond, payload)
+		}
+		cond = ec
 		cond.L.Lock()
 	}
-	repollChannel := make(chan struct{}, 1)
-	existingRepoll, _ := s.workflowEventsRepollMap.LoadOrStore(payload, repollChannel)
-	repollChannel = existingRepoll.(chan struct{})
 	release := func() {
 		// Clean up the condition variable and broadcast to wake up any waiting goroutines
 		cond.Broadcast()
 		s.workflowEventsMap.Delete(payload)
 		s.workflowEventsRepollMap.Delete(payload)
 	}
+	repollChannel := make(chan struct{}, 1)
+	existingRepoll, _ := s.workflowEventsRepollMap.LoadOrStore(payload, repollChannel)
+	rc, ok := existingRepoll.(chan struct{})
+	if !ok {
+		cond.L.Unlock()
+		release()
+		return nil, fmt.Errorf("workflow events repoll map holds unexpected %T for %s", existingRepoll, payload)
+	}
+	repollChannel = rc
 
 	// Now check if the event already exists in the database.
 	// If not, the caller will wait for a notification or its deadline.

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -3621,8 +3621,10 @@ func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic stri
 	repollChannel := make(chan struct{}, 1)
 	s.workflowNotificationRepollMap.LoadOrStore(payload, repollChannel)
 	release := func() {
-		// Clean up the condition variable and broadcast to wake up any waiting goroutines
+		// Clean up the condition variable and broadcast to wake up any waiting goroutines.
+		cond.L.Lock()
 		cond.Broadcast()
+		cond.L.Unlock()
 		s.workflowNotificationsMap.Delete(payload)
 		s.workflowNotificationRepollMap.Delete(payload)
 	}
@@ -3761,8 +3763,10 @@ func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key st
 		cond.L.Lock()
 	}
 	release := func() {
-		// Clean up the condition variable and broadcast to wake up any waiting goroutines
+		// Clean up the condition variable and broadcast to wake up any waiting goroutines.
+		cond.L.Lock()
 		cond.Broadcast()
+		cond.L.Unlock()
 		s.workflowEventsMap.Delete(payload)
 		s.workflowEventsRepollMap.Delete(payload)
 	}

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -62,9 +62,11 @@ type systemDatabase interface {
 
 	// Communication (special steps)
 	send(ctx context.Context, input WorkflowSendInput) error
-	recv(ctx context.Context, input recvInput) (*recvResult, error)
+	startRecvListener(ctx context.Context, destinationID, topic string) (*notificationWaiter, error)
+	consumeMessage(ctx context.Context, tx Tx, destinationID, topic string) (*string, *string, error)
 	setEvent(ctx context.Context, input WorkflowSetEventInput) error
-	getEvent(ctx context.Context, input getEventInput) (*getEventResult, error)
+	startEventListener(ctx context.Context, targetWorkflowID, key string) (*notificationWaiter, error)
+	getEventValue(ctx context.Context, q Querier, targetWorkflowID, key string) (*string, *string, error)
 
 	// Communication observability
 	getAllEvents(ctx context.Context, workflowID string) ([]eventRecord, error)
@@ -76,7 +78,6 @@ type systemDatabase interface {
 	readStream(ctx context.Context, input readStreamDBInput) ([]streamEntry, bool, error)
 
 	// Timers (special steps)
-	sleep(ctx context.Context, input sleepInput) (time.Duration, error)
 
 	// Patches
 	patch(ctx context.Context, input patchDBInput) (bool, error)
@@ -3239,105 +3240,6 @@ func (s *sysDB) getStepAggregates(ctx context.Context, input getStepAggregatesDB
 	return results, nil
 }
 
-type sleepInput struct {
-	duration   time.Duration // Duration to sleep
-	skipSleep  bool          // If true, the function will not actually sleep and just return the remaining sleep duration
-	workflowID string        // Workflow that owns this sleep (resolved by the caller from context)
-	stepID     int           // Step ID for this sleep
-}
-
-// Sleep is a special type of step that sleeps for a specified duration
-// A wakeup time is computed and recorded in the database
-// If we sleep is re-executed, it will only sleep for the remaining duration until the wakeup time
-// sleep can be called within other special steps (e.g., getEvent, recv) to provide durable sleep
-
-func (s *sysDB) sleep(ctx context.Context, input sleepInput) (time.Duration, error) {
-	functionName := "DBOS.sleep"
-
-	stepID := input.stepID
-	startTime := time.Now()
-
-	// Check if operation was already executed
-	checkInput := checkOperationExecutionDBInput{
-		workflowID: input.workflowID,
-		stepID:     stepID,
-		stepName:   functionName,
-	}
-	recordedResult, err := s.checkOperationExecution(ctx, checkInput)
-	if err != nil {
-		return 0, fmt.Errorf("failed to check operation execution: %w", err)
-	}
-
-	var endTime time.Time
-
-	if recordedResult != nil {
-		if recordedResult.output == nil { // This should never happen
-			return 0, fmt.Errorf("no recorded end time for recorded sleep operation")
-		}
-
-		// Decode the recorded end time directly into time.Time
-		// recordedResult.output is an encoded *string
-		serializer := newJSONSerializer[time.Time]()
-		endTime, err = serializer.Decode(recordedResult.output)
-		if err != nil {
-			return 0, fmt.Errorf("failed to decode sleep end time: %w", err)
-		}
-
-		if recordedResult.errStr != nil { // This should never happen
-			return 0, errors.New(*recordedResult.errStr)
-		}
-	} else {
-		// First execution: calculate and record the end time
-		endTime = time.Now().Add(input.duration)
-
-		// Serialize the end time before recording
-		serializer := newJSONSerializer[time.Time]()
-		encodedEndTime, serErr := serializer.Encode(endTime)
-		if serErr != nil {
-			return 0, fmt.Errorf("failed to serialize sleep end time: %w", serErr)
-		}
-
-		// Record the operation result with the calculated end time
-		completedTime := time.Now()
-		recordInput := recordOperationResultDBInput{
-			workflowID:    input.workflowID,
-			stepID:        stepID,
-			stepName:      functionName,
-			output:        encodedEndTime,
-			startedAt:     startTime,
-			completedAt:   completedTime,
-			serialization: "DBOS_JSON",
-		}
-
-		err = s.recordOperationResult(ctx, recordInput)
-		if err != nil {
-			// Check if this is a ConflictingIDError (operation already recorded by another process)
-			if dbosErr, ok := err.(*DBOSError); ok && dbosErr.Code == ConflictingIDError {
-			} else {
-				return 0, fmt.Errorf("failed to record sleep operation result: %w", err)
-			}
-		}
-	}
-
-	// Calculate remaining duration until wake up time
-	remainingDuration := max(0, time.Until(endTime))
-
-	if !input.skipSleep {
-		// Sleep for the remaining duration, but wake early if the context is cancelled.
-		// If interrupted, return the duration actually slept.
-		sleepStart := time.Now()
-		timer := time.NewTimer(remainingDuration)
-		defer timer.Stop()
-		select {
-		case <-timer.C:
-		case <-ctx.Done():
-			return time.Since(sleepStart), ctx.Err()
-		}
-	}
-
-	return remainingDuration, nil
-}
-
 /****************************************/
 /******* PATCHES ********/
 /****************************************/
@@ -3667,38 +3569,47 @@ func (s *sysDB) send(ctx context.Context, input WorkflowSendInput) error {
 	return nil
 }
 
-// Recv is a special type of step that receives a message destined for a given workflow
-func (s *sysDB) recv(ctx context.Context, input recvInput) (*recvResult, error) {
-	functionName := "DBOS.recv"
+// notificationWaiter tracks a waiter registered for a notification (recv message or workflow event).
+type notificationWaiter struct {
+	pending bool                                   // the awaited row already existed at registration time
+	wait    func(deadline time.Time) (bool, error) // block until the row is pending or the deadline passes; true means timeout
+	release func()                                 // unregister the waiter and wake any waiting goroutine; must be called after the result is read (or on abandonment)
+}
 
-	stepID := input.stepID
-	sleepStepID := input.sleepStepID
-	destinationID := input.workflowID
-
-	// Set default topic if not provided
-	topic := _DBOS_NULL_TOPIC
-	if len(input.Topic) > 0 {
-		topic = input.Topic
-	}
-
-	// Check if operation was already executed
-	checkInput := checkOperationExecutionDBInput{
-		workflowID: destinationID,
-		stepID:     stepID,
-		stepName:   functionName,
-	}
-	recordedResult, err := s.checkOperationExecution(ctx, checkInput)
-	if err != nil {
-		return nil, err
-	}
-	if recordedResult != nil {
-		var recvErr error
-		if recordedResult.errStr != nil {
-			recvErr = errors.New(*recordedResult.errStr)
+// notificationWait builds the wait closure shared by recv and getEvent: block until a
+// notification arrives (done closed), the deadline passes (returns true), a repoll
+// signal triggers a recheck of the database, or the context is cancelled.
+func (s *sysDB) notificationWait(ctx context.Context, opName, payload string, exists bool, done <-chan struct{}, repollChannel chan struct{}, recheck func() (bool, error)) func(deadline time.Time) (bool, error) {
+	return func(deadline time.Time) (bool, error) {
+		found := exists
+		for !found {
+			select {
+			case <-done:
+				return false, nil
+			case <-time.After(max(0, time.Until(deadline))):
+				s.logger.Warn(opName+" timeout reached", "payload", payload, "deadline", deadline)
+				return true, nil
+			case <-repollChannel:
+				s.logger.Warn(opName+" polling after repoll channel signal", "payload", payload)
+				// We were instructed to poll again because the connection was disconnected
+				var err error
+				if found, err = recheck(); err != nil {
+					return false, err
+				}
+				// Restart at the beginning of the loop. If the value was found, we'll exit the loop and proceed to reading the value.
+				continue
+			case <-ctx.Done():
+				s.logger.Warn(opName+" context cancelled", "payload", payload, "cause", context.Cause(ctx))
+				return false, ctx.Err()
+			}
 		}
-		return &recvResult{message: recordedResult.output, serialization: recordedResult.serialization}, recvErr
+		return false, nil
 	}
+}
 
+// startRecvListener registers the calling workflow as the sole receiver for
+// (destinationID, topic) and checks whether a message is already pending.
+func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic string) (*notificationWaiter, error) {
 	// First check if there's already a receiver for this workflow/topic to avoid unnecessary database load
 	payload := fmt.Sprintf("%s::%s", destinationID, topic)
 	cond := sync.NewCond(&sync.Mutex{})
@@ -3711,30 +3622,30 @@ func (s *sysDB) recv(ctx context.Context, input recvInput) (*recvResult, error) 
 	}
 	repollChannel := make(chan struct{}, 1)
 	s.workflowNotificationRepollMap.LoadOrStore(payload, repollChannel)
-	defer func() {
-		// Clean up the condition variable after we're done and broadcast to wake up any waiting goroutines
+	release := func() {
+		// Clean up the condition variable and broadcast to wake up any waiting goroutines
 		cond.Broadcast()
 		s.workflowNotificationsMap.Delete(payload)
 		s.workflowNotificationRepollMap.Delete(payload)
-	}()
+	}
 
 	// Now check if there is already an unconsumed message available in the database.
-	// If not, we'll wait for a notification and timeout
+	// If not, the caller will wait for a notification or its deadline.
 	var exists bool
 	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %snotifications WHERE destination_uuid = $1 AND topic = $2 AND consumed = false)`, s.dialect.SchemaPrefix(s.schema))
-	err = s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&exists)
+	err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&exists)
 	if err != nil {
 		cond.L.Unlock()
+		release()
 		return nil, fmt.Errorf("failed to check message: %w", err)
 	}
-	var timeoutOccurred bool
 
 	// Create the waiting goroutine once (only if !exists, so we don't attempt to unlock twice)
 	done := make(chan struct{})
 	if !exists {
 		go func() {
 			// This is the only place we unlock the condition variable if the value did not exist
-			// Because of the deferred Broadcast, we'll eventually hit this before returning
+			// Because of the Broadcast in release, we'll eventually hit this before the caller returns
 			defer cond.L.Unlock()
 			cond.Wait()
 			close(done)
@@ -3743,53 +3654,23 @@ func (s *sysDB) recv(ctx context.Context, input recvInput) (*recvResult, error) 
 		cond.L.Unlock()
 	}
 
-loop:
-	for !exists {
-		timeout, err := s.sleep(ctx, sleepInput{
-			duration:   input.Timeout,
-			skipSleep:  true,
-			workflowID: destinationID,
-			stepID:     sleepStepID,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to sleep before recv timeout: %w", err)
+	recheck := func() (bool, error) {
+		var found bool
+		if err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&found); err != nil {
+			return false, fmt.Errorf("failed to check message: %w", err)
 		}
-
-		select {
-		case <-done:
-			break loop
-		case <-time.After(timeout):
-			timeoutOccurred = true
-			s.logger.Warn("Recv() timeout reached", "payload", payload, "timeout", input.Timeout)
-			break loop
-		case <-repollChannel:
-			s.logger.Warn("Receive polling after repoll channel signal", "payload", payload)
-			// We were instructed to poll again because the connection was disconnected
-			err = s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&exists)
-			if err != nil {
-				return nil, fmt.Errorf("failed to check message: %w", err)
-			}
-			// Restart at the beginning of the loop. If the value was found, we'll exit the loop and process to consuming the value.
-			continue
-		case <-ctx.Done():
-			s.logger.Warn("Recv() context cancelled", "payload", payload, "cause", context.Cause(ctx))
-			return nil, ctx.Err()
-		}
+		return found, nil
 	}
+	wait := s.notificationWait(ctx, "Recv()", payload, exists, done, repollChannel, recheck)
 
-	// Capture start time before finding and consuming the message
-	startTime := time.Now()
+	return &notificationWaiter{pending: exists, wait: wait, release: release}, nil
+}
 
-	// Find the oldest unconsumed message and atomically mark it consumed.
-	// Notifications are retained (consumed=true) so they remain visible for observability;
-	// rows are eventually cleaned up by FK cascade when the parent workflow is garbage-collected.
-	tx, err := s.pool.BeginTx(ctx, TxOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer tx.Rollback(ctx)
+// consumeMessage finds the oldest unconsumed message for (destinationID, topic) and
+// atomically marks it consumed. Returns a nil message if none is pending.
+func (s *sysDB) consumeMessage(ctx context.Context, tx Tx, destinationID, topic string) (*string, *string, error) {
 	// Use message_uuid so we update exactly one row; created_at_epoch_ms can match multiple rows when inserts occur in the same millisecond.
-	query = s.renderSQL(`
+	query := s.renderSQL(`
     WITH oldest_entry AS (
         SELECT message_uuid
         FROM %snotifications
@@ -3804,51 +3685,11 @@ loop:
 
 	var messageString *string
 	var msgSerialization *string
-	err = tx.QueryRow(ctx, query, destinationID, topic).Scan(&messageString, &msgSerialization)
-	if err != nil {
-		if err != pgx.ErrNoRows {
-			return nil, fmt.Errorf("failed to consume message: %w", err)
-		}
+	err := tx.QueryRow(ctx, query, destinationID, topic).Scan(&messageString, &msgSerialization)
+	if err != nil && err != pgx.ErrNoRows {
+		return nil, nil, fmt.Errorf("failed to consume message: %w", err)
 	}
-
-	// Use the sender's serialization from the notification; fall back to receiver's format for timeout/no-message case
-	serialization := input.serialization
-	if msgSerialization != nil && len(*msgSerialization) > 0 {
-		serialization = *msgSerialization
-	}
-
-	// Record the operation result (with encoded message string)
-	completedTime := time.Now()
-	recordInput := recordOperationResultDBInput{
-		workflowID:    destinationID,
-		stepID:        stepID,
-		stepName:      functionName,
-		output:        messageString,
-		tx:            tx,
-		startedAt:     startTime,
-		completedAt:   completedTime,
-		serialization: serialization,
-	}
-
-	// Record an error if no message found and timeout occurred
-	var timeoutErr error
-	if timeoutOccurred && messageString == nil {
-		timeoutErr = newTimeoutError(destinationID, functionName, fmt.Sprintf("no message received within %v", input.Timeout))
-		s := timeoutErr.Error()
-		recordInput.errStr = &s
-	}
-
-	err = s.recordOperationResult(ctx, recordInput)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := tx.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("failed to commit transaction: %w", err)
-	}
-
-	// Return the message and its serialization format
-	return &recvResult{message: messageString, serialization: serialization}, timeoutErr
+	return messageString, msgSerialization, nil
 }
 
 type WorkflowSetEventInput struct {
@@ -3896,185 +3737,82 @@ func (s *sysDB) setEvent(ctx context.Context, input WorkflowSetEventInput) error
 	return err
 }
 
-func (s *sysDB) getEvent(ctx context.Context, input getEventInput) (*getEventResult, error) {
-	functionName := "DBOS.getEvent"
-
-	stepID := input.stepID
-	sleepStepID := input.sleepStepID
-	isInWorkflow := input.isInWorkflow
-
-	startTime := time.Now()
-	if isInWorkflow {
-		// Check if operation was already executed (only if in workflow)
-		checkInput := checkOperationExecutionDBInput{
-			workflowID: input.workflowID,
-			stepID:     stepID,
-			stepName:   functionName,
-		}
-		recordedResult, err := s.checkOperationExecution(ctx, checkInput)
-		if err != nil {
-			return nil, err
-		}
-		if recordedResult != nil {
-			var evtErr error
-			if recordedResult.errStr != nil {
-				evtErr = errors.New(*recordedResult.errStr)
-			}
-			return &getEventResult{value: recordedResult.output, serialization: recordedResult.serialization}, evtErr
-		}
-	}
-
-	// Create notification payload and condition variable
-	payload := fmt.Sprintf("%s::%s", input.TargetWorkflowID, input.Key)
+// startEventListener registers the caller as a waiter for the (targetWorkflowID, key)
+// event and checks whether the event is already set. Unlike recv, multiple waiters
+// may listen for the same event and share its condition variable.
+func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key string) (*notificationWaiter, error) {
+	payload := fmt.Sprintf("%s::%s", targetWorkflowID, key)
 	cond := sync.NewCond(&sync.Mutex{})
 	cond.L.Lock()
 	existingCond, loaded := s.workflowEventsMap.LoadOrStore(payload, cond)
 	if loaded {
-		cond.L.Unlock()
 		// Reuse the existing condition variable
+		cond.L.Unlock()
 		cond = existingCond.(*sync.Cond)
+		cond.L.Lock()
 	}
 	repollChannel := make(chan struct{}, 1)
-	s.workflowEventsRepollMap.LoadOrStore(payload, repollChannel)
-
-	// Defer broadcast to ensure any waiting goroutines eventually unlock
-	defer func() {
+	existingRepoll, _ := s.workflowEventsRepollMap.LoadOrStore(payload, repollChannel)
+	repollChannel = existingRepoll.(chan struct{})
+	release := func() {
+		// Clean up the condition variable and broadcast to wake up any waiting goroutines
 		cond.Broadcast()
-		// Clean up the condition variable after we're done (Delete is a no-op if the key doesn't exist)
 		s.workflowEventsMap.Delete(payload)
 		s.workflowEventsRepollMap.Delete(payload)
-	}()
-
-	// Check if the event already exists in the database
-	query := s.renderSQL(`SELECT value, serialization FROM %sworkflow_events WHERE workflow_uuid = $1 AND key = $2`, s.dialect.SchemaPrefix(s.schema))
-	var valueString *string
-	var evtSerialization *string
-	var row pgx.Row
-	var err error
-
-	// Helper function to query the event and handle errors
-	queryEvent := func() error {
-		row = s.pool.QueryRow(ctx, query, input.TargetWorkflowID, input.Key)
-		err = row.Scan(&valueString, &evtSerialization)
-		if err != nil && err != pgx.ErrNoRows {
-			if !loaded {
-				cond.L.Unlock()
-			}
-			return fmt.Errorf("failed to query workflow event: %w", err)
-		}
-		return nil
 	}
 
-	if err := queryEvent(); err != nil {
-		return nil, err
+	// Now check if the event already exists in the database.
+	// If not, the caller will wait for a notification or its deadline.
+	var exists bool
+	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %sworkflow_events WHERE workflow_uuid = $1 AND key = $2)`, s.dialect.SchemaPrefix(s.schema))
+	err := s.pool.QueryRow(ctx, query, targetWorkflowID, key).Scan(&exists)
+	if err != nil {
+		cond.L.Unlock()
+		release()
+		return nil, fmt.Errorf("failed to check event: %w", err)
 	}
 
-	var timeoutOccurred bool
-	if valueString == nil {
-		// Start a goroutine to wait for the event to be set
-		// This goroutine is responsible for unlocking the CV, which will happen whenever the event is set (through either the deferred Broadcast or from the notification listener)
-		done := make(chan struct{})
+	// Create the waiting goroutine once (only if !exists, so we don't attempt to unlock twice)
+	done := make(chan struct{})
+	if !exists {
 		go func() {
-			if !loaded {
-				defer cond.L.Unlock()
-			}
+			// This is the only place we unlock the condition variable if the value did not exist
+			// Because of the Broadcast in release, we'll eventually hit this before the caller returns
+			defer cond.L.Unlock()
 			cond.Wait()
 			close(done)
 		}()
-
-	loop:
-		for valueString == nil {
-			// Wait for notification with timeout using condition variable
-			timeout := input.Timeout
-			if isInWorkflow {
-				timeout, err = s.sleep(ctx, sleepInput{
-					duration:   input.Timeout,
-					skipSleep:  true,
-					workflowID: input.workflowID,
-					stepID:     sleepStepID,
-				})
-				if err != nil {
-					return nil, fmt.Errorf("failed to sleep before getEvent timeout: %w", err)
-				}
-			}
-
-			select {
-			case <-done:
-				// Received notification
-				if err := queryEvent(); err != nil {
-					return nil, err
-				}
-				break loop
-			case <-time.After(timeout):
-				timeoutOccurred = true
-				s.logger.Warn("GetEvent() timeout reached", "target_workflow_id", input.TargetWorkflowID, "key", input.Key, "timeout", input.Timeout)
-				// Check if the event exists in the database -- we never know
-				if err := queryEvent(); err != nil {
-					return nil, err
-				}
-				break loop
-			case <-repollChannel:
-				// We were instructed to poll again because the connection was disconnected
-				if err := queryEvent(); err != nil {
-					return nil, err
-				}
-				// Restart at the beginning of the loop.
-				// If the value was found, we'll exit the loop
-				continue
-			case <-ctx.Done():
-				s.logger.Warn("GetEvent() context cancelled", "target_workflow_id", input.TargetWorkflowID, "key", input.Key, "cause", context.Cause(ctx))
-				if !loaded {
-					cond.L.Unlock()
-				}
-				return nil, ctx.Err()
-			}
-		}
 	} else {
-		if !loaded {
-			cond.L.Unlock()
-		}
+		cond.L.Unlock()
 	}
 
-	// Use the event's serialization from the DB; fall back to caller's format for timeout/no-event case
-	serialization := input.serialization
-	if evtSerialization != nil && len(*evtSerialization) > 0 {
-		serialization = *evtSerialization
+	recheck := func() (bool, error) {
+		var found bool
+		if err := s.pool.QueryRow(ctx, query, targetWorkflowID, key).Scan(&found); err != nil {
+			return false, fmt.Errorf("failed to check event: %w", err)
+		}
+		return found, nil
 	}
+	wait := s.notificationWait(ctx, "GetEvent()", payload, exists, done, repollChannel, recheck)
 
-	// Record the operation result if this is called within a workflow
-	var timeoutErr error
-	if isInWorkflow {
-		completedTime := time.Now()
-		recordInput := recordOperationResultDBInput{
-			workflowID:    input.workflowID,
-			stepID:        stepID,
-			stepName:      functionName,
-			output:        valueString,
-			startedAt:     startTime,
-			completedAt:   completedTime,
-			serialization: serialization,
-		}
+	return &notificationWaiter{pending: exists, wait: wait, release: release}, nil
+}
 
-		// Record an error if no event found and timeout occurred
-		if timeoutOccurred && valueString == nil {
-			timeoutErr = newTimeoutError(input.workflowID, functionName, fmt.Sprintf("no event found for key '%s' within %v", input.Key, input.Timeout))
-			s := timeoutErr.Error()
-			recordInput.errStr = &s
-		}
-
-		err = s.recordOperationResult(ctx, recordInput)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		// If not in workflow and timeout occurred with no event found, return error
-		if timeoutOccurred && valueString == nil {
-			timeoutErr = newTimeoutError("", functionName, fmt.Sprintf("no event found for key '%s' within %v", input.Key, input.Timeout))
-		}
+// getEventValue reads the current value and serialization for (targetWorkflowID, key)
+// from the workflow_events table. Returns a nil value if the event is not set.
+// A nil Querier defaults to the pool (for callers outside a transaction).
+func (s *sysDB) getEventValue(ctx context.Context, q Querier, targetWorkflowID, key string) (*string, *string, error) {
+	if q == nil {
+		q = s.pool
 	}
-
-	// Return the event value and its serialization format
-	return &getEventResult{value: valueString, serialization: serialization}, timeoutErr
+	query := s.renderSQL(`SELECT value, serialization FROM %sworkflow_events WHERE workflow_uuid = $1 AND key = $2`, s.dialect.SchemaPrefix(s.schema))
+	var value *string
+	var serialization *string
+	err := q.QueryRow(ctx, query, targetWorkflowID, key).Scan(&value, &serialization)
+	if err != nil && err != pgx.ErrNoRows {
+		return nil, nil, fmt.Errorf("failed to query workflow event: %w", err)
+	}
+	return value, serialization, nil
 }
 
 /*******************************/

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -77,8 +77,6 @@ type systemDatabase interface {
 	writeStream(ctx context.Context, input writeStreamDBInput) error
 	readStream(ctx context.Context, input readStreamDBInput) ([]streamEntry, bool, error)
 
-	// Timers (special steps)
-
 	// Patches
 	patch(ctx context.Context, input patchDBInput) (bool, error)
 	doesPatchExists(ctx context.Context, input patchDBInput) (string, error)
@@ -3631,13 +3629,18 @@ func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic stri
 
 	// Now check if there is already an unconsumed message available in the database.
 	// If not, the caller will wait for a notification or its deadline.
-	var exists bool
 	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %snotifications WHERE destination_uuid = $1 AND topic = $2 AND consumed = false)`, s.dialect.SchemaPrefix(s.schema))
-	err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&exists)
+	exists, err := retryWithResult(ctx, func() (bool, error) {
+		var e bool
+		if err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&e); err != nil {
+			return false, fmt.Errorf("failed to check message: %w", err)
+		}
+		return e, nil
+	}, withRetrierLogger(s.logger))
 	if err != nil {
 		cond.L.Unlock()
 		release()
-		return nil, fmt.Errorf("failed to check message: %w", err)
+		return nil, err
 	}
 
 	// Create the waiting goroutine once (only if !exists, so we don't attempt to unlock twice)
@@ -3655,11 +3658,13 @@ func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic stri
 	}
 
 	recheck := func() (bool, error) {
-		var found bool
-		if err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&found); err != nil {
-			return false, fmt.Errorf("failed to check message: %w", err)
-		}
-		return found, nil
+		return retryWithResult(ctx, func() (bool, error) {
+			var found bool
+			if err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&found); err != nil {
+				return false, fmt.Errorf("failed to check message: %w", err)
+			}
+			return found, nil
+		}, withRetrierLogger(s.logger))
 	}
 	wait := s.notificationWait(ctx, "Recv()", payload, exists, done, repollChannel, recheck)
 
@@ -3763,13 +3768,18 @@ func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key st
 
 	// Now check if the event already exists in the database.
 	// If not, the caller will wait for a notification or its deadline.
-	var exists bool
 	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %sworkflow_events WHERE workflow_uuid = $1 AND key = $2)`, s.dialect.SchemaPrefix(s.schema))
-	err := s.pool.QueryRow(ctx, query, targetWorkflowID, key).Scan(&exists)
+	exists, err := retryWithResult(ctx, func() (bool, error) {
+		var e bool
+		if err := s.pool.QueryRow(ctx, query, targetWorkflowID, key).Scan(&e); err != nil {
+			return false, fmt.Errorf("failed to check event: %w", err)
+		}
+		return e, nil
+	}, withRetrierLogger(s.logger))
 	if err != nil {
 		cond.L.Unlock()
 		release()
-		return nil, fmt.Errorf("failed to check event: %w", err)
+		return nil, err
 	}
 
 	// Create the waiting goroutine once (only if !exists, so we don't attempt to unlock twice)
@@ -3787,11 +3797,13 @@ func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key st
 	}
 
 	recheck := func() (bool, error) {
-		var found bool
-		if err := s.pool.QueryRow(ctx, query, targetWorkflowID, key).Scan(&found); err != nil {
-			return false, fmt.Errorf("failed to check event: %w", err)
-		}
-		return found, nil
+		return retryWithResult(ctx, func() (bool, error) {
+			var found bool
+			if err := s.pool.QueryRow(ctx, query, targetWorkflowID, key).Scan(&found); err != nil {
+				return false, fmt.Errorf("failed to check event: %w", err)
+			}
+			return found, nil
+		}, withRetrierLogger(s.logger))
 	}
 	wait := s.notificationWait(ctx, "GetEvent()", payload, exists, done, repollChannel, recheck)
 

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -104,6 +104,14 @@ type stepCheckpointedOutcome struct {
 	serialization string // DB-stored serialization format
 }
 
+// rawStepOutput is returned by internal special steps (e.g. recv) whose output is
+// already serialized. runAsTxn records value as-is under the given serialization
+// name instead of re-encoding it with the workflow serializer.
+type rawStepOutput struct {
+	value         *string
+	serialization string
+}
+
 // WorkflowHandle provides methods to interact with a running or completed workflow.
 // The type parameter R represents the expected return type of the workflow.
 // Handles can be used to wait for workflow completion, check status, and retrieve results.
@@ -2158,6 +2166,10 @@ func (c *dbosContext) runAsTxn(_ DBOSContext, fn TxnFunc, opts ...StepOption) (a
 	if stepOpts.txIsoLevel != nil {
 		txOpts.IsoLevel = *stepOpts.txIsoLevel
 	}
+	txnRetryOpts := []retryOption{withRetrierLogger(c.logger)}
+	if sysDB, ok := c.systemDB.(*sysDB); ok && sysDB.isCockroachDB {
+		txnRetryOpts = append(txnRetryOpts, withRetryCondition(cockroachDialect{}.IsRetryableTransaction))
+	}
 	return retryWithResult(c, func() (any, error) {
 		tx, err := pool.BeginTx(uncancellableCtx, txOpts)
 		if err != nil {
@@ -2198,9 +2210,18 @@ func (c *dbosContext) runAsTxn(_ DBOSContext, fn TxnFunc, opts ...StepOption) (a
 		})
 
 		txnSer := resolveEncoder(c)
-		encodedStepOutput, serErr := txnSer.Encode(stepOutput)
-		if serErr != nil {
-			return nil, newStepExecutionError(stepState.workflowID, stepOpts.stepName, fmt.Errorf("failed to serialize step output: %w", serErr))
+		serialization := txnSer.Name()
+		var encodedStepOutput *string
+		if raw, ok := stepOutput.(rawStepOutput); ok {
+			// Pre-serialized payload: record as-is under its own serialization name
+			encodedStepOutput = raw.value
+			serialization = raw.serialization
+		} else {
+			var serErr error
+			encodedStepOutput, serErr = txnSer.Encode(stepOutput)
+			if serErr != nil {
+				return nil, newStepExecutionError(stepState.workflowID, stepOpts.stepName, fmt.Errorf("failed to serialize step output: %w", serErr))
+			}
 		}
 
 		var serializedTxnErr *string
@@ -2217,7 +2238,7 @@ func (c *dbosContext) runAsTxn(_ DBOSContext, fn TxnFunc, opts ...StepOption) (a
 			completedAt:   time.Now(),
 			output:        encodedStepOutput,
 			tx:            tx,
-			serialization: txnSer.Name(),
+			serialization: serialization,
 		}
 		recErr := c.systemDB.recordOperationResult(uncancellableCtx, dbInput)
 		if recErr != nil {
@@ -2230,7 +2251,7 @@ func (c *dbosContext) runAsTxn(_ DBOSContext, fn TxnFunc, opts ...StepOption) (a
 			return nil, newStepExecutionError(stepState.workflowID, stepOpts.stepName, fmt.Errorf("failed to commit transaction: %w", err))
 		}
 		return stepOutput, stepError
-	}, withRetrierLogger(c.logger))
+	}, txnRetryOpts...)
 }
 
 // Go runs a step inside a Go routine and returns a channel to receive the result.
@@ -2562,15 +2583,6 @@ func Send[P any](ctx DBOSContext, destinationID string, message P, topic string,
 	return ctx.Send(ctx, destinationID, message, topic, opts...)
 }
 
-type recvInput struct {
-	Topic         string        // Topic to listen for (empty string receives from default topic)
-	Timeout       time.Duration // Maximum time to wait for a message
-	serialization string        // fallback serialization format (receiver's) for recording when no message is found
-	workflowID    string        // Receiving workflow (resolved by the caller from context)
-	stepID        int           // Step ID for the recv
-	sleepStepID   int           // Step ID for the internal timeout sleep
-}
-
 // recvResult carries the received message along with its serialization format from the notifications table.
 type recvResult struct {
 	message       *string
@@ -2585,21 +2597,88 @@ func (c *dbosContext) Recv(_ DBOSContext, topic string, timeout time.Duration) (
 	if wfState.isWithinStep {
 		return nil, newStepExecutionError(wfState.workflowID, "DBOS.recv", fmt.Errorf("cannot call Recv within a step"))
 	}
-	input := recvInput{
-		Topic:         topic,
-		Timeout:       timeout,
-		serialization: resolveEncoder(c).Name(),
-		workflowID:    wfState.workflowID,
-		stepID:        wfState.nextStepID(),
-		sleepStepID:   wfState.nextStepID(),
+	workflowID := wfState.workflowID
+	// The recv step ID precedes its internal timeout sleep's; both are allocated
+	// up front so the recorded layout matches even when the sleep is skipped.
+	stepID := wfState.nextStepID()
+	sleepStepID := wfState.nextStepID()
+	if len(topic) == 0 {
+		topic = _DBOS_NULL_TOPIC
 	}
-	recvRetryOpts := []retryOption{withRetrierLogger(c.logger)}
-	if sysDB, ok := c.systemDB.(*sysDB); ok && sysDB.isCockroachDB {
-		recvRetryOpts = append(recvRetryOpts, withRetryCondition(cockroachDialect{}.IsRetryableTransaction))
+
+	// Early exit when this recv already has a checkpoint (recovery, fork),
+	// so replay neither waits nor records a spurious sleep step.
+	recorded, err := retryWithResult(c, func() (*recordedResult, error) {
+		return c.systemDB.checkOperationExecution(WithoutCancel(c), checkOperationExecutionDBInput{
+			workflowID: workflowID,
+			stepID:     stepID,
+			stepName:   "DBOS.recv",
+		})
+	}, withRetrierLogger(c.logger))
+	if err != nil {
+		return nil, err
 	}
-	return retryWithResult(c, func() (*recvResult, error) {
-		return c.systemDB.recv(c, input)
-	}, recvRetryOpts...)
+	if recorded != nil {
+		return &recvResult{message: recorded.output, serialization: recorded.serialization}, deserializeWorkflowError(recorded.errStr)
+	}
+
+	// Register as the receiver for this workflow/topic.
+	waiter, err := c.systemDB.startRecvListener(c, workflowID, topic)
+	if err != nil {
+		return nil, err
+	}
+	defer waiter.release()
+
+	var timeoutOccurred bool
+	if !waiter.pending {
+		// Checkpoint the timeout deadline as a "DBOS.sleep" step before waiting. On
+		// re-execution the recorded deadline is returned, so only the remaining time is waited.
+		deadline, err := runAsTxn(c, func(ctx context.Context, tx Tx) (time.Time, error) {
+			return time.Now().Add(timeout), nil
+		}, WithStepName("DBOS.sleep"), WithNextStepID(sleepStepID))
+		if err != nil {
+			return nil, err
+		}
+		// Wait for a pending message with no transaction open.
+		timeoutOccurred, err = waiter.wait(deadline)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Consume the message and checkpoint the recv result in a single transaction.
+	// If another executor already checkpointed this step, runAsTxn returns the recorded result.
+	out, err := c.runAsTxn(c, func(ctx context.Context, tx Tx) (any, error) {
+		message, msgSerialization, err := c.systemDB.consumeMessage(ctx, tx, workflowID, topic)
+		if err != nil {
+			return nil, err
+		}
+		// Use the sender's serialization; fall back to the receiver's format for the timeout/no-message case
+		serialization := resolveEncoder(c).Name()
+		if msgSerialization != nil && len(*msgSerialization) > 0 {
+			serialization = *msgSerialization
+		}
+		output := rawStepOutput{value: message, serialization: serialization}
+		if message == nil && timeoutOccurred {
+			return output, newTimeoutError(workflowID, "DBOS.recv", fmt.Sprintf("no message received within %v", timeout))
+		}
+		return output, nil
+	}, WithStepName("DBOS.recv"), WithNextStepID(stepID))
+
+	switch v := out.(type) {
+	case rawStepOutput: // executed now
+		return &recvResult{message: v.value, serialization: v.serialization}, err
+	case stepCheckpointedOutcome: // replayed from a recorded checkpoint
+		message, ok := v.value.(*string)
+		if !ok {
+			return nil, newWorkflowExecutionError(workflowID, fmt.Errorf("recv checkpoint value is not *string, got %T", v.value))
+		}
+		return &recvResult{message: message, serialization: v.serialization}, err
+	case nil:
+		return nil, err
+	default:
+		return nil, newWorkflowUnexpectedResultType(workflowID, "rawStepOutput", fmt.Sprintf("%T", out))
+	}
 }
 
 // Recv receives a message sent to this workflow with type safety.
@@ -2730,17 +2809,6 @@ func SetEvent[P any](ctx DBOSContext, key string, message P, opts ...SetEventOpt
 	return ctx.SetEvent(ctx, key, message, opts...)
 }
 
-type getEventInput struct {
-	TargetWorkflowID string        // Workflow ID to get the event from
-	Key              string        // Event key to retrieve
-	Timeout          time.Duration // Maximum time to wait for the event to be set
-	serialization    string        // fallback serialization format (caller's) for recording when no event is found
-	isInWorkflow     bool          // Whether the caller is inside a workflow (GetEvent is also callable from outside)
-	workflowID       string        // Calling workflow (resolved by the caller from context; empty when outside a workflow)
-	stepID           int           // Step ID for the getEvent, allocated by the caller before any retry
-	sleepStepID      int           // Step ID for the internal timeout sleep, allocated by the caller before any retry
-}
-
 // getEventResult carries the event value along with its serialization format from the workflow_events table.
 type getEventResult struct {
 	value         *string
@@ -2748,25 +2816,119 @@ type getEventResult struct {
 }
 
 func (c *dbosContext) GetEvent(_ DBOSContext, targetWorkflowID, key string, timeout time.Duration) (any, error) {
-	input := getEventInput{
-		TargetWorkflowID: targetWorkflowID,
-		Key:              key,
-		Timeout:          timeout,
-		serialization:    resolveEncoder(c).Name(),
-	}
-	// GetEvent may run inside or outside a workflow. When inside, allocate step IDs.
-	if wfState, ok := c.Value(workflowStateKey).(*workflowState); ok && wfState != nil {
+	// GetEvent may run inside or outside a workflow. When inside, it is checkpointed.
+	wfState, _ := c.Value(workflowStateKey).(*workflowState)
+	isInWorkflow := wfState != nil
+	var workflowID string
+	var stepID, sleepStepID int
+	if isInWorkflow {
 		if wfState.isWithinStep {
 			return nil, newStepExecutionError(wfState.workflowID, "DBOS.getEvent", fmt.Errorf("cannot call GetEvent within a step"))
 		}
-		input.isInWorkflow = true
-		input.workflowID = wfState.workflowID
-		input.stepID = wfState.nextStepID()
-		input.sleepStepID = wfState.nextStepID()
+		workflowID = wfState.workflowID
+		stepID = wfState.nextStepID()
+		sleepStepID = wfState.nextStepID()
+
+		// Early exit when this getEvent already has a checkpoint (recovery, fork),
+		// so replay neither waits nor records a spurious sleep step.
+		recorded, err := retryWithResult(c, func() (*recordedResult, error) {
+			return c.systemDB.checkOperationExecution(WithoutCancel(c), checkOperationExecutionDBInput{
+				workflowID: workflowID,
+				stepID:     stepID,
+				stepName:   "DBOS.getEvent",
+			})
+		}, withRetrierLogger(c.logger))
+		if err != nil {
+			return nil, err
+		}
+		if recorded != nil {
+			return &getEventResult{value: recorded.output, serialization: recorded.serialization}, deserializeWorkflowError(recorded.errStr)
+		}
 	}
-	return retryWithResult(c, func() (*getEventResult, error) {
-		return c.systemDB.getEvent(c, input)
-	}, withRetrierLogger(c.logger))
+
+	// Register as a waiter for this event.
+	waiter, err := c.systemDB.startEventListener(c, targetWorkflowID, key)
+	if err != nil {
+		return nil, err
+	}
+	defer waiter.release()
+
+	var timeoutOccurred bool
+	if !waiter.pending {
+		deadline := time.Now().Add(timeout)
+		if isInWorkflow {
+			// Checkpoint the timeout deadline as a "DBOS.sleep" step before waiting. On
+			// re-execution the recorded deadline is returned, so only the remaining time is waited.
+			deadline, err = runAsTxn(c, func(ctx context.Context, tx Tx) (time.Time, error) {
+				return time.Now().Add(timeout), nil
+			}, WithStepName("DBOS.sleep"), WithNextStepID(sleepStepID))
+			if err != nil {
+				return nil, err
+			}
+		}
+		// Wait for the event with no transaction open.
+		timeoutOccurred, err = waiter.wait(deadline)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Use the event's serialization from the DB; fall back to the caller's format for the timeout/no-event case
+	fallbackSerialization := resolveEncoder(c).Name()
+
+	// If we aren't in a workflow, (attempt to) read and return the event
+	if !isInWorkflow {
+		var value, evtSerialization *string
+		err := retry(c, func() error {
+			var qErr error
+			value, evtSerialization, qErr = c.systemDB.getEventValue(c, nil, targetWorkflowID, key)
+			return qErr
+		}, withRetrierLogger(c.logger))
+		if err != nil {
+			return nil, err
+		}
+		serialization := fallbackSerialization
+		if evtSerialization != nil && len(*evtSerialization) > 0 {
+			serialization = *evtSerialization
+		}
+		if value == nil && timeoutOccurred {
+			return nil, newTimeoutError("", "DBOS.getEvent", fmt.Sprintf("no event found for key '%s' within %v", key, timeout))
+		}
+		return &getEventResult{value: value, serialization: serialization}, nil
+	}
+
+	// Read the event value and checkpoint the getEvent result in a single transaction.
+	// If another executor already checkpointed this step, runAsTxn returns the recorded result.
+	out, err := c.runAsTxn(c, func(ctx context.Context, tx Tx) (any, error) {
+		value, evtSerialization, err := c.systemDB.getEventValue(ctx, tx, targetWorkflowID, key)
+		if err != nil {
+			return nil, err
+		}
+		serialization := fallbackSerialization
+		if evtSerialization != nil && len(*evtSerialization) > 0 {
+			serialization = *evtSerialization
+		}
+		output := rawStepOutput{value: value, serialization: serialization}
+		if value == nil && timeoutOccurred {
+			return output, newTimeoutError(workflowID, "DBOS.getEvent", fmt.Sprintf("no event found for key '%s' within %v", key, timeout))
+		}
+		return output, nil
+	}, WithStepName("DBOS.getEvent"), WithNextStepID(stepID))
+
+	switch v := out.(type) {
+	case rawStepOutput: // executed now
+		return &getEventResult{value: v.value, serialization: v.serialization}, err
+	case stepCheckpointedOutcome: // replayed from a recorded checkpoint
+		value, ok := v.value.(*string)
+		if !ok {
+			return nil, newWorkflowExecutionError(workflowID, fmt.Errorf("getEvent checkpoint value is not *string, got %T", v.value))
+		}
+		return &getEventResult{value: value, serialization: v.serialization}, err
+	case nil:
+		return nil, err
+	default:
+		return nil, newWorkflowUnexpectedResultType(workflowID, "rawStepOutput", fmt.Sprintf("%T", out))
+	}
 }
 
 // GetEvent retrieves a key-value event from a target workflow with type safety.
@@ -3298,15 +3460,27 @@ func (c *dbosContext) Sleep(_ DBOSContext, duration time.Duration) (time.Duratio
 	if wfState.isWithinStep {
 		return 0, newStepExecutionError(wfState.workflowID, "DBOS.sleep", fmt.Errorf("cannot call Sleep within a step"))
 	}
-	input := sleepInput{
-		duration:   duration,
-		skipSleep:  false,
-		workflowID: wfState.workflowID,
-		stepID:     wfState.nextStepID(),
+	// Checkpoint the wakeup time as a "DBOS.sleep" step; on re-execution the
+	// recorded deadline is returned, so only the remaining duration is slept.
+	deadline, err := runAsTxn(c, func(ctx context.Context, tx Tx) (time.Time, error) {
+		return time.Now().Add(duration), nil
+	}, WithStepName("DBOS.sleep"))
+	if err != nil {
+		return 0, err
 	}
-	return retryWithResult(c, func() (time.Duration, error) {
-		return c.systemDB.sleep(c, input)
-	}, withRetrierLogger(c.logger))
+	remainingDuration := max(0, time.Until(deadline))
+
+	// Sleep for the remaining duration, but wake early if the context is cancelled.
+	// If interrupted, return the duration actually slept.
+	sleepStart := time.Now()
+	timer := time.NewTimer(remainingDuration)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-c.Done():
+		return time.Since(sleepStart), c.Err()
+	}
+	return remainingDuration, nil
 }
 
 // Sleep pauses workflow execution for the specified duration.

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -2167,8 +2167,8 @@ func (c *dbosContext) runAsTxn(_ DBOSContext, fn TxnFunc, opts ...StepOption) (a
 		txOpts.IsoLevel = *stepOpts.txIsoLevel
 	}
 	txnRetryOpts := []retryOption{withRetrierLogger(c.logger)}
-	if sysDB, ok := c.systemDB.(*sysDB); ok && sysDB.isCockroachDB {
-		txnRetryOpts = append(txnRetryOpts, withRetryCondition(cockroachDialect{}.IsRetryableTransaction))
+	if sysDB, ok := c.systemDB.(*sysDB); ok {
+		txnRetryOpts = append(txnRetryOpts, withRetryCondition(sysDB.dialect.IsRetryableTransaction))
 	}
 	return retryWithResult(c, func() (any, error) {
 		tx, err := pool.BeginTx(uncancellableCtx, txOpts)
@@ -2633,14 +2633,14 @@ func (c *dbosContext) Recv(_ DBOSContext, topic string, timeout time.Duration) (
 	if !waiter.pending {
 		// Checkpoint the timeout deadline as a "DBOS.sleep" step before waiting. On
 		// re-execution the recorded deadline is returned, so only the remaining time is waited.
-		deadline, err := runAsTxn(c, func(ctx context.Context, tx Tx) (time.Time, error) {
-			return time.Now().Add(timeout), nil
+		deadlineMs, err := runAsTxn(c, func(ctx context.Context, tx Tx) (int64, error) {
+			return time.Now().Add(timeout).UnixMilli(), nil
 		}, WithStepName("DBOS.sleep"), WithNextStepID(sleepStepID))
 		if err != nil {
 			return nil, err
 		}
 		// Wait for a pending message with no transaction open.
-		timeoutOccurred, err = waiter.wait(deadline)
+		timeoutOccurred, err = waiter.wait(time.UnixMilli(deadlineMs))
 		if err != nil {
 			return nil, err
 		}
@@ -2859,12 +2859,13 @@ func (c *dbosContext) GetEvent(_ DBOSContext, targetWorkflowID, key string, time
 		if isInWorkflow {
 			// Checkpoint the timeout deadline as a "DBOS.sleep" step before waiting. On
 			// re-execution the recorded deadline is returned, so only the remaining time is waited.
-			deadline, err = runAsTxn(c, func(ctx context.Context, tx Tx) (time.Time, error) {
-				return time.Now().Add(timeout), nil
+			deadlineMs, txErr := runAsTxn(c, func(ctx context.Context, tx Tx) (int64, error) {
+				return time.Now().Add(timeout).UnixMilli(), nil
 			}, WithStepName("DBOS.sleep"), WithNextStepID(sleepStepID))
-			if err != nil {
-				return nil, err
+			if txErr != nil {
+				return nil, txErr
 			}
+			deadline = time.UnixMilli(deadlineMs)
 		}
 		// Wait for the event with no transaction open.
 		timeoutOccurred, err = waiter.wait(deadline)
@@ -3462,13 +3463,13 @@ func (c *dbosContext) Sleep(_ DBOSContext, duration time.Duration) (time.Duratio
 	}
 	// Checkpoint the wakeup time as a "DBOS.sleep" step; on re-execution the
 	// recorded deadline is returned, so only the remaining duration is slept.
-	deadline, err := runAsTxn(c, func(ctx context.Context, tx Tx) (time.Time, error) {
-		return time.Now().Add(duration), nil
+	deadlineMs, err := runAsTxn(c, func(ctx context.Context, tx Tx) (int64, error) {
+		return time.Now().Add(duration).UnixMilli(), nil
 	}, WithStepName("DBOS.sleep"))
 	if err != nil {
 		return 0, err
 	}
-	remainingDuration := max(0, time.Until(deadline))
+	remainingDuration := max(0, time.Until(time.UnixMilli(deadlineMs)))
 
 	// Sleep for the remaining duration, but wake early if the context is cancelled.
 	// If interrupted, return the duration actually slept.

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -2817,7 +2817,13 @@ type getEventResult struct {
 
 func (c *dbosContext) GetEvent(_ DBOSContext, targetWorkflowID, key string, timeout time.Duration) (any, error) {
 	// GetEvent may run inside or outside a workflow. When inside, it is checkpointed.
-	wfState, _ := c.Value(workflowStateKey).(*workflowState)
+	var wfState *workflowState
+	if v := c.Value(workflowStateKey); v != nil {
+		var ok bool
+		if wfState, ok = v.(*workflowState); !ok {
+			return nil, newStepExecutionError("", "DBOS.getEvent", fmt.Errorf("workflow state in context has unexpected type %T", v))
+		}
+	}
 	isInWorkflow := wfState != nil
 	var workflowID string
 	var stepID, sleepStepID int

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3407,6 +3407,73 @@ func TestSendRecv(t *testing.T) {
 		require.Equal(t, "DBOS.sleep", steps[1].StepName, "expected step 1 to have StepName 'DBOS.sleep'")
 	})
 
+	t.Run("RecvForkReplay", func(t *testing.T) {
+		sendRecvSyncEvent.Clear()
+
+		receiveHandle, err := RunWorkflow(dbosCtx, receiveIdempotencyWorkflow, "fork-replay-topic")
+		require.NoError(t, err, "failed to start receive workflow")
+
+		// Send the message before Recv runs so it is already pending (no sleep step recorded)
+		err = Send(dbosCtx, receiveHandle.GetWorkflowID(), "fork-me", "fork-replay-topic")
+		require.NoError(t, err, "failed to send message")
+		sendRecvSyncEvent.Set()
+
+		result, err := receiveHandle.GetResult()
+		require.NoError(t, err, "failed to get result from receive workflow")
+		require.Equal(t, "fork-me", result)
+
+		originalSteps, err := GetWorkflowSteps(dbosCtx, receiveHandle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps")
+		require.Len(t, originalSteps, 1, "expected only the recv step when the message was already pending")
+
+		// Fork past the recv step: its checkpoint is copied and the recv must replay from it,
+		// without waiting (the recv timeout is 60 minutes) and without recording new steps.
+		start := time.Now()
+		forkedHandle, err := ForkWorkflow[string](dbosCtx, ForkWorkflowInput{
+			OriginalWorkflowID: receiveHandle.GetWorkflowID(),
+			StartStep:          2,
+		})
+		require.NoError(t, err, "failed to fork receive workflow")
+		forkedResult, err := forkedHandle.GetResult()
+		require.NoError(t, err, "failed to get result from forked receive workflow")
+		require.Equal(t, "fork-me", forkedResult, "forked recv should replay the checkpointed message")
+		require.Less(t, time.Since(start), 30*time.Second, "forked recv replay should not wait on the recv timeout")
+
+		forkedSteps, err := GetWorkflowSteps(dbosCtx, forkedHandle.GetWorkflowID())
+		require.NoError(t, err, "failed to get forked workflow steps")
+		require.Len(t, forkedSteps, 1, "recv replay must not record extra steps")
+		require.Equal(t, "DBOS.recv", forkedSteps[0].StepName)
+	})
+
+	t.Run("RecvTimeoutForkReplay", func(t *testing.T) {
+		sendRecvSyncEvent.Set()
+
+		receiveHandle, err := RunWorkflow(dbosCtx, receiveWorkflow, struct {
+			Topic   string
+			Timeout time.Duration
+		}{
+			Topic:   "timeout-fork-topic",
+			Timeout: 1 * time.Second,
+		})
+		require.NoError(t, err, "failed to start receive workflow")
+		_, err = receiveHandle.GetResult()
+		require.Error(t, err, "expected timeout error")
+
+		// Fork past the recv step: the checkpointed timeout error must round-trip through
+		// the recorded errStr with its concrete type and code preserved.
+		forkedHandle, err := ForkWorkflow[string](dbosCtx, ForkWorkflowInput{
+			OriginalWorkflowID: receiveHandle.GetWorkflowID(),
+			StartStep:          2,
+		})
+		require.NoError(t, err, "failed to fork receive workflow")
+		_, err = forkedHandle.GetResult()
+		require.Error(t, err, "expected replayed timeout error")
+		dbosErr, ok := err.(*DBOSError)
+		require.True(t, ok, "expected error to be of type *DBOSError, got %T", err)
+		require.Equal(t, TimeoutError, dbosErr.Code, "expected TimeoutError code")
+		require.Contains(t, err.Error(), "DBOS.recv timed out")
+	})
+
 	t.Run("RecvMustRunInsideWorkflows", func(t *testing.T) {
 		// Attempt to run Recv outside of a workflow context
 		_, err := Recv[string](dbosCtx, "test-topic", 1*time.Second)

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3661,6 +3661,93 @@ func TestSendRecv(t *testing.T) {
 		require.NoError(t, err, "failed to get workflow status")
 		require.Equal(t, WorkflowStatusCancelled, status.Status, "expected workflow status to be WorkflowStatusCancelled")
 	})
+
+	t.Run("ConcurrentRecvSameTopicConflicts", func(t *testing.T) {
+		// A single (destination, topic) may only have one active receiver at a time.
+		// A second concurrent registration must be rejected with a ConflictingIDError
+		// rather than silently sharing/stealing the first receiver's slot.
+		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+		destID := uuid.NewString()
+		topic := "single-receiver-topic"
+
+		waiter1, err := sysDB.startRecvListener(context.Background(), destID, topic)
+		require.NoError(t, err, "first receiver should register")
+		defer waiter1.release()
+
+		_, err = sysDB.startRecvListener(context.Background(), destID, topic)
+		require.Error(t, err, "second concurrent receiver for the same (destination, topic) must be rejected")
+		dbosErr, ok := err.(*DBOSError)
+		require.True(t, ok, "expected *DBOSError, got %T", err)
+		require.Equal(t, ConflictingIDError, dbosErr.Code, "expected ConflictingIDError")
+	})
+}
+
+// TestRecvStepConflict verifies that when two executors concurrently run the same
+// workflow and race to checkpoint the recv step, the loser does not fail: it either
+// replays the winner's checkpoint or loses the record race with a ConflictingIDError
+// that routes through the workflow-level conflict handler and awaits the winner's
+// result. Either way both executions converge on the delivered message.
+//
+// The two executors share one database (a single in-process guard cannot double-run
+// a workflow, so a real second executor is required). PostgreSQL row locking on
+// consumeMessage serializes consumption, making the converged outcome deterministic.
+func TestRecvStepConflict(t *testing.T) {
+	// checkLeaks is off: the two executors' lifetimes overlap, so a per-executor
+	// goroutine leak check would observe the other executor's live goroutines.
+	ctxA := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: false})
+	ctxB := setupDBOS(t, setupDBOSOptions{dropDB: false, checkLeaks: false})
+
+	recvConflictWorkflow := func(ctx DBOSContext, topic string) (string, error) {
+		return Recv[string](ctx, topic, 60*time.Second)
+	}
+	RegisterWorkflow(ctxA, recvConflictWorkflow)
+	RegisterWorkflow(ctxB, recvConflictWorkflow)
+	require.NoError(t, Launch(ctxA))
+	require.NoError(t, Launch(ctxB))
+
+	topic := "recv-step-conflict-topic"
+	workflowID := uuid.NewString()
+
+	// Executor A starts the workflow; it registers as receiver and blocks in wait.
+	handleA, err := RunWorkflow(ctxA, recvConflictWorkflow, topic, WithWorkflowID(workflowID))
+	require.NoError(t, err, "failed to start recv workflow on executor A")
+
+	sysA := ctxA.(*dbosContext).systemDB.(*sysDB)
+	sysB := ctxB.(*dbosContext).systemDB.(*sysDB)
+	payload := fmt.Sprintf("%s::%s", workflowID, topic)
+	require.Eventually(t, func() bool {
+		_, ok := sysA.workflowNotificationsMap.Load(payload)
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "executor A never registered as receiver")
+
+	// Executor B recovers the same workflow: a genuinely concurrent second
+	// execution with its own in-memory receiver map, so it proceeds to wait and
+	// later races A to consume+checkpoint the message.
+	setWorkflowStatusPending(t, ctxA, workflowID)
+	recovered, err := recoverPendingWorkflows(ctxB.(*dbosContext), []string{"local"})
+	require.NoError(t, err, "failed to recover workflow on executor B")
+	require.Len(t, recovered, 1, "expected one recovered handle")
+	require.Equal(t, workflowID, recovered[0].GetWorkflowID())
+
+	// Executor B must actually run the body (register as receiver), not
+	// short-circuit; its separate map confirms a real concurrent execution.
+	require.Eventually(t, func() bool {
+		_, ok := sysB.workflowNotificationsMap.Load(payload)
+		return ok
+	}, 5*time.Second, 10*time.Millisecond, "executor B (recovery) never ran the body")
+
+	// Deliver the message. Exactly one executor consumes and checkpoints it; the
+	// other replays that checkpoint or loses the checkpoint race and awaits. Both
+	// must converge on the delivered value with no permanent failure.
+	require.NoError(t, Send(ctxA, workflowID, "delivered", topic), "failed to send message")
+
+	gotA, err := handleA.GetResult()
+	require.NoError(t, err, "executor A workflow should succeed")
+	require.Equal(t, "delivered", gotA)
+
+	gotB, err := recovered[0].GetResult()
+	require.NoError(t, err, "the concurrent recovery must converge on the result, not fail")
+	require.Equal(t, "delivered", gotB)
 }
 
 // receiveTwiceShortWorkflow receives one message (blocking up to 30s), then attempts a
@@ -3809,6 +3896,21 @@ func getEventForkReplayWorkflow(ctx DBOSContext, input getEventWorkflowInput) (s
 	return GetEvent[string](ctx, input.TargetWorkflowID, input.Key, 60*time.Minute)
 }
 
+// setManyEventsWorkflow sets one event per (key, value) pair, so a single
+// workflow ID can back concurrent getters spread across several keys.
+type setManyEventsInput struct {
+	Values map[string]string
+}
+
+func setManyEventsWorkflow(ctx DBOSContext, input setManyEventsInput) (string, error) {
+	for key, value := range input.Values {
+		if err := SetEvent(ctx, key, value); err != nil {
+			return "", err
+		}
+	}
+	return "many-events-set", nil
+}
+
 func TestSetGetEvent(t *testing.T) {
 	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
 
@@ -3819,6 +3921,7 @@ func TestSetGetEvent(t *testing.T) {
 	RegisterWorkflow(dbosCtx, setEventIdempotencyWorkflow)
 	RegisterWorkflow(dbosCtx, getEventIdempotencyWorkflow)
 	RegisterWorkflow(dbosCtx, getEventForkReplayWorkflow)
+	RegisterWorkflow(dbosCtx, setManyEventsWorkflow)
 
 	Launch(dbosCtx)
 
@@ -4168,56 +4271,64 @@ func TestSetGetEvent(t *testing.T) {
 	})
 
 	t.Run("ConcurrentGetEvent", func(t *testing.T) {
-		// Start the getters before the event is set so they block on the shared
-		// condition variable rather than taking the already-set fast path.
+		// Spread more getters than keys: several getters share each key's condition
+		// variable (within-key concurrency) while distinct keys use independent
+		// condition variables (across-key concurrency). Getters start before the
+		// events are set so they block rather than taking the already-set fast path.
 		setWorkflowID := uuid.NewString()
-		numGoroutines := 5
+		const numKeys = 3
+		const numGoroutines = 12 // > numKeys, so multiple getters land on each key
+		keyFor := func(i int) string { return fmt.Sprintf("concurrent-event-key-%d", i%numKeys) }
+		valueFor := func(key string) string { return "value-for-" + key }
+
+		values := make(map[string]string, numKeys)
+		for k := range numKeys {
+			key := fmt.Sprintf("concurrent-event-key-%d", k)
+			values[key] = valueFor(key)
+		}
+
 		var wg sync.WaitGroup
-		errors := make(chan error, numGoroutines)
+		errs := make(chan error, numGoroutines)
 		wg.Add(numGoroutines)
-		for range numGoroutines {
-			go func() {
+		for i := range numGoroutines {
+			go func(i int) {
 				defer wg.Done()
-				res, err := GetEvent[string](dbosCtx, setWorkflowID, "concurrent-event-key", 30*time.Second)
+				key := keyFor(i)
+				res, err := GetEvent[string](dbosCtx, setWorkflowID, key, 30*time.Second)
 				if err != nil {
-					errors <- fmt.Errorf("failed to get event in goroutine: %v", err)
+					errs <- fmt.Errorf("goroutine %d (key %s): %w", i, key, err)
 					return
 				}
-				if res != "concurrent-event-message" {
-					errors <- fmt.Errorf("expected result in goroutine to be 'concurrent-event-message', got '%s'", res)
-					return
+				if want := valueFor(key); res != want {
+					errs <- fmt.Errorf("goroutine %d (key %s): expected %q, got %q", i, key, want, res)
 				}
-			}()
+			}(i)
 		}
 
-		// Wait until the getters have registered as waiters before setting the event
+		// Wait until every key has a registered waiter before setting the events.
 		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
-		payload := fmt.Sprintf("%s::%s", setWorkflowID, "concurrent-event-key")
 		require.Eventually(t, func() bool {
-			_, ok := sysDB.workflowEventsMap.Load(payload)
-			return ok
-		}, 5*time.Second, 10*time.Millisecond, "getters never registered as event waiters")
+			for k := range numKeys {
+				payload := fmt.Sprintf("%s::%s", setWorkflowID, fmt.Sprintf("concurrent-event-key-%d", k))
+				if _, ok := sysDB.workflowEventsMap.Load(payload); !ok {
+					return false
+				}
+			}
+			return true
+		}, 5*time.Second, 10*time.Millisecond, "not all keys registered event waiters")
 
-		setHandle, err := RunWorkflow(dbosCtx, setEventWorkflow, setEventWorkflowInput{
-			Key:     "concurrent-event-key",
-			Message: "concurrent-event-message",
-		}, WithWorkflowID(setWorkflowID))
-		if err != nil {
-			t.Fatalf("failed to start set event workflow: %v", err)
-		}
+		setHandle, err := RunWorkflow(dbosCtx, setManyEventsWorkflow, setManyEventsInput{Values: values}, WithWorkflowID(setWorkflowID))
+		require.NoError(t, err, "failed to start set-many-events workflow")
 		_, err = setHandle.GetResult()
-		if err != nil {
-			t.Fatalf("failed to get result from set event workflow: %v", err)
-		}
+		require.NoError(t, err, "failed to get result from set-many-events workflow")
 
 		wg.Wait()
-		close(errors)
-
-		// Check for any errors from goroutines
-		for err := range errors {
-			require.FailNow(t, "goroutine error: %v", err)
+		close(errs)
+		for err := range errs {
+			require.FailNow(t, "goroutine error", err)
 		}
 	})
+
 }
 
 // Test workflows and steps for parameter mismatch validation

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3180,23 +3180,6 @@ func receiveIdempotencyWorkflow(ctx DBOSContext, topic string) (string, error) {
 	return msg, nil
 }
 
-func durableRecvSleepWorkflow(ctx DBOSContext, topic string) (string, error) {
-	// First Recv with 2-second timeout (will timeout)
-	msg1, err := Recv[string](ctx, topic, 2*time.Second)
-	if err != nil && !strings.Contains(err.Error(), fmt.Sprintf("DBOS Error %s", TimeoutError)) {
-		return "", fmt.Errorf("unexpected error in first recv: %w", err)
-	}
-
-	// Second Recv with 2-second timeout (will also timeout)
-	msg2, err := Recv[string](ctx, topic, 2*time.Second)
-	if err != nil && !strings.Contains(err.Error(), fmt.Sprintf("DBOS Error %s", TimeoutError)) {
-		return "", fmt.Errorf("unexpected error in second recv: %w", err)
-	}
-
-	// Return result - will be empty strings since both timeout
-	return msg1 + msg2, nil
-}
-
 func stepThatCallsSend(ctx context.Context, input sendWorkflowInput) (string, error) {
 	err := Send(ctx.(DBOSContext), input.DestinationID, "message-from-step", input.Topic)
 	if err != nil {
@@ -3235,7 +3218,6 @@ func TestSendRecv(t *testing.T) {
 	RegisterWorkflow(dbosCtx, receiveStructWorkflow)
 	RegisterWorkflow(dbosCtx, sendIdempotencyWorkflow)
 	RegisterWorkflow(dbosCtx, receiveIdempotencyWorkflow)
-	RegisterWorkflow(dbosCtx, durableRecvSleepWorkflow)
 	RegisterWorkflow(dbosCtx, workflowThatCallsSendInStep)
 	RegisterWorkflow(dbosCtx, recvContextCancelWorkflow)
 
@@ -3823,20 +3805,8 @@ func getEventIdempotencyWorkflow(ctx DBOSContext, input setEventWorkflowInput) (
 	return result, nil
 }
 
-func durableGetEventSleepWorkflow(ctx DBOSContext, targetWorkflowID string) (string, error) {
-	// First GetEvent with 2-second timeout (will timeout)
-	val1, err := GetEvent[string](ctx, targetWorkflowID, "key1", 2*time.Second)
-	if err != nil && !strings.Contains(err.Error(), "timed out") {
-		return "", fmt.Errorf("unexpected error in first getEvent: %w", err)
-	}
-
-	// Second GetEvent with 2-second timeout (will timeout)
-	val2, err := GetEvent[string](ctx, targetWorkflowID, "key2", 2*time.Second)
-	if err != nil && !strings.Contains(err.Error(), "timed out") {
-		return "", fmt.Errorf("unexpected error in second getEvent: %w", err)
-	}
-
-	return val1 + val2, nil
+func getEventForkReplayWorkflow(ctx DBOSContext, input getEventWorkflowInput) (string, error) {
+	return GetEvent[string](ctx, input.TargetWorkflowID, input.Key, 60*time.Minute)
 }
 
 func TestSetGetEvent(t *testing.T) {
@@ -3848,7 +3818,7 @@ func TestSetGetEvent(t *testing.T) {
 	RegisterWorkflow(dbosCtx, setTwoEventsWorkflow)
 	RegisterWorkflow(dbosCtx, setEventIdempotencyWorkflow)
 	RegisterWorkflow(dbosCtx, getEventIdempotencyWorkflow)
-	RegisterWorkflow(dbosCtx, durableGetEventSleepWorkflow)
+	RegisterWorkflow(dbosCtx, getEventForkReplayWorkflow)
 
 	Launch(dbosCtx)
 
@@ -4032,6 +4002,85 @@ func TestSetGetEvent(t *testing.T) {
 		require.Contains(t, err.Error(), "no event found for key 'non-existent-key' within 3s", "expected error message to contain 'no event found for key 'non-existent-key' within 3s'")
 	})
 
+	t.Run("GetEventTimeoutInWorkflow", func(t *testing.T) {
+		// GetEvent waits and times out inside a workflow: the timeout error is
+		// checkpointed on the getEvent step and a sleep step records the deadline.
+		getHandle, err := RunWorkflow(dbosCtx, getEventWorkflow, getEventWorkflowInput{
+			TargetWorkflowID: uuid.NewString(),
+			Key:              "no-such-key",
+		})
+		require.NoError(t, err, "failed to start get event workflow")
+		_, err = getHandle.GetResult()
+		require.Error(t, err, "expected timeout error")
+		dbosErr, ok := err.(*DBOSError)
+		require.True(t, ok, "expected error to be of type *DBOSError, got %T", err)
+		require.Equal(t, TimeoutError, dbosErr.Code, "expected TimeoutError code")
+		require.Contains(t, err.Error(), "no event found for key 'no-such-key'")
+
+		steps, err := GetWorkflowSteps(dbosCtx, getHandle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps")
+		require.Len(t, steps, 2, "expected 2 steps (getEvent that timed out and its sleep), got %d", len(steps))
+		require.Equal(t, "DBOS.getEvent", steps[0].StepName, "expected step 0 to have StepName 'DBOS.getEvent'")
+		require.NotNil(t, steps[0].Error, "expected getEvent step to record the timeout error")
+		require.Contains(t, steps[0].Error.Error(), "no event found for key 'no-such-key'")
+		require.Equal(t, "DBOS.sleep", steps[1].StepName, "expected step 1 to have StepName 'DBOS.sleep'")
+
+		// Fork past both steps: the checkpointed timeout error must round-trip through
+		// the recorded errStr with its concrete type and code preserved.
+		forkedHandle, err := ForkWorkflow[string](dbosCtx, ForkWorkflowInput{
+			OriginalWorkflowID: getHandle.GetWorkflowID(),
+			StartStep:          2,
+		})
+		require.NoError(t, err, "failed to fork get event workflow")
+		_, err = forkedHandle.GetResult()
+		require.Error(t, err, "expected replayed timeout error")
+		dbosErr, ok = err.(*DBOSError)
+		require.True(t, ok, "expected error to be of type *DBOSError, got %T", err)
+		require.Equal(t, TimeoutError, dbosErr.Code, "expected TimeoutError code")
+		require.Contains(t, err.Error(), "no event found for key 'no-such-key'")
+	})
+
+	t.Run("GetEventForkReplay", func(t *testing.T) {
+		setHandle, err := RunWorkflow(dbosCtx, setEventWorkflow, setEventWorkflowInput{
+			Key:     "fork-replay-key",
+			Message: "fork-me",
+		})
+		require.NoError(t, err, "failed to start set event workflow")
+		_, err = setHandle.GetResult()
+		require.NoError(t, err, "failed to get result from set event workflow")
+
+		getHandle, err := RunWorkflow(dbosCtx, getEventForkReplayWorkflow, getEventWorkflowInput{
+			TargetWorkflowID: setHandle.GetWorkflowID(),
+			Key:              "fork-replay-key",
+		})
+		require.NoError(t, err, "failed to start get event workflow")
+		result, err := getHandle.GetResult()
+		require.NoError(t, err, "failed to get result from get event workflow")
+		require.Equal(t, "fork-me", result)
+
+		originalSteps, err := GetWorkflowSteps(dbosCtx, getHandle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps")
+		require.Len(t, originalSteps, 1, "expected only the getEvent step when the event was already set")
+
+		// Fork past the getEvent step: its checkpoint is copied and the getEvent must replay
+		// from it, without waiting (the timeout is 60 minutes) and without recording new steps.
+		start := time.Now()
+		forkedHandle, err := ForkWorkflow[string](dbosCtx, ForkWorkflowInput{
+			OriginalWorkflowID: getHandle.GetWorkflowID(),
+			StartStep:          2,
+		})
+		require.NoError(t, err, "failed to fork get event workflow")
+		forkedResult, err := forkedHandle.GetResult()
+		require.NoError(t, err, "failed to get result from forked get event workflow")
+		require.Equal(t, "fork-me", forkedResult, "forked getEvent should replay the checkpointed value")
+		require.Less(t, time.Since(start), 30*time.Second, "forked getEvent replay should not wait on the timeout")
+
+		forkedSteps, err := GetWorkflowSteps(dbosCtx, forkedHandle.GetWorkflowID())
+		require.NoError(t, err, "failed to get forked workflow steps")
+		require.Len(t, forkedSteps, 1, "getEvent replay must not record extra steps")
+		require.Equal(t, "DBOS.getEvent", forkedSteps[0].StepName)
+	})
+
 	t.Run("SetGetEventMustRunInsideWorkflows", func(t *testing.T) {
 		// Attempt to run SetEvent outside of a workflow context
 		err := SetEvent(dbosCtx, "test-key", "test-message")
@@ -4119,21 +4168,9 @@ func TestSetGetEvent(t *testing.T) {
 	})
 
 	t.Run("ConcurrentGetEvent", func(t *testing.T) {
-		// Set event
-		setHandle, err := RunWorkflow(dbosCtx, setEventWorkflow, setEventWorkflowInput{
-			Key:     "concurrent-event-key",
-			Message: "concurrent-event-message",
-		})
-		if err != nil {
-			t.Fatalf("failed to start set event workflow: %v", err)
-		}
-
-		// Wait for the set event workflow to complete
-		_, err = setHandle.GetResult()
-		if err != nil {
-			t.Fatalf("failed to get result from set event workflow: %v", err)
-		}
-		// Start a few goroutines that'll concurrently get the event
+		// Start the getters before the event is set so they block on the shared
+		// condition variable rather than taking the already-set fast path.
+		setWorkflowID := uuid.NewString()
 		numGoroutines := 5
 		var wg sync.WaitGroup
 		errors := make(chan error, numGoroutines)
@@ -4141,7 +4178,7 @@ func TestSetGetEvent(t *testing.T) {
 		for range numGoroutines {
 			go func() {
 				defer wg.Done()
-				res, err := GetEvent[string](dbosCtx, setHandle.GetWorkflowID(), "concurrent-event-key", 10*time.Second)
+				res, err := GetEvent[string](dbosCtx, setWorkflowID, "concurrent-event-key", 30*time.Second)
 				if err != nil {
 					errors <- fmt.Errorf("failed to get event in goroutine: %v", err)
 					return
@@ -4152,6 +4189,27 @@ func TestSetGetEvent(t *testing.T) {
 				}
 			}()
 		}
+
+		// Wait until the getters have registered as waiters before setting the event
+		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+		payload := fmt.Sprintf("%s::%s", setWorkflowID, "concurrent-event-key")
+		require.Eventually(t, func() bool {
+			_, ok := sysDB.workflowEventsMap.Load(payload)
+			return ok
+		}, 5*time.Second, 10*time.Millisecond, "getters never registered as event waiters")
+
+		setHandle, err := RunWorkflow(dbosCtx, setEventWorkflow, setEventWorkflowInput{
+			Key:     "concurrent-event-key",
+			Message: "concurrent-event-message",
+		}, WithWorkflowID(setWorkflowID))
+		if err != nil {
+			t.Fatalf("failed to start set event workflow: %v", err)
+		}
+		_, err = setHandle.GetResult()
+		if err != nil {
+			t.Fatalf("failed to get result from set event workflow: %v", err)
+		}
+
 		wg.Wait()
 		close(errors)
 


### PR DESCRIPTION
Refactor the special steps `sleep`, `recv` and `getEvent` to use `runAsTxn` logic, avoiding a duplication of the (critical) transactional checkpointing logic. This moves the orchestration of "registering a notification listener" and "consuming a message/event" from the system database to the workflow layer.

Also fix a CV bug in get event and a swallowed conflict error in sleep.