### PR TITLE
Fix a getEvent bug and re-design the notification subscription system

### DIFF
--- a/dbos/sqlite_pool.go
+++ b/dbos/sqlite_pool.go
@@ -166,10 +166,8 @@ func newSqliteSystemDatabase(
 	return &sysDB{
 		pool:                          newSQLPool(db),
 		dialect:                       sqliteDialect{},
-		workflowNotificationsMap:      &sync.Map{},
-		workflowNotificationRepollMap: &sync.Map{},
-		workflowEventsMap:             &sync.Map{},
-		workflowEventsRepollMap:       &sync.Map{},
+		recvNotifier:                  newNotifyRegistry(),
+		eventNotifier:                 newNotifyRegistry(),
 		streamsMap:                    &sync.Map{},
 		notificationLoopDone:          make(chan struct{}),
 		logger:                        logger.With("service", "system_database"),

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -132,18 +132,16 @@ type ExportedWorkflow struct {
 }
 
 type sysDB struct {
-	pool                          Pool
-	dialect                       Dialect
-	notificationLoopDone          chan struct{}
-	workflowNotificationsMap      *sync.Map
-	workflowNotificationRepollMap *sync.Map
-	workflowEventsMap             *sync.Map
-	workflowEventsRepollMap       *sync.Map
-	streamsMap                    *sync.Map
-	logger                        *slog.Logger
-	schema                        string
-	launched                      bool
-	isCockroachDB                 bool
+	pool                 Pool
+	dialect              Dialect
+	notificationLoopDone chan struct{}
+	recvNotifier         *notifyRegistry // recv waiters, keyed by "destinationID::topic"
+	eventNotifier        *notifyRegistry // getEvent waiters, keyed by "targetWorkflowID::key"
+	streamsMap           *sync.Map
+	logger               *slog.Logger
+	schema               string
+	launched             bool
+	isCockroachDB        bool
 }
 
 /*******************************/
@@ -845,17 +843,15 @@ func newSystemDatabase(ctx context.Context, inputs newSystemDatabaseInput) (syst
 	}
 
 	return &sysDB{
-		pool:                          newPgxPool(pool),
-		dialect:                       dialect,
-		workflowNotificationsMap:      &sync.Map{},
-		workflowNotificationRepollMap: &sync.Map{},
-		workflowEventsMap:             &sync.Map{},
-		workflowEventsRepollMap:       &sync.Map{},
-		streamsMap:                    &sync.Map{},
-		notificationLoopDone:          make(chan struct{}),
-		logger:                        logger.With("service", "system_database"),
-		schema:                        databaseSchema,
-		isCockroachDB:                 isCockroach,
+		pool:                 newPgxPool(pool),
+		dialect:              dialect,
+		recvNotifier:         newNotifyRegistry(),
+		eventNotifier:        newNotifyRegistry(),
+		streamsMap:           &sync.Map{},
+		notificationLoopDone: make(chan struct{}),
+		logger:               logger.With("service", "system_database"),
+		schema:               databaseSchema,
+		isCockroachDB:        isCockroach,
 	}, nil
 }
 
@@ -902,8 +898,8 @@ func (s *sysDB) shutdown(ctx context.Context, timeout time.Duration) {
 		}
 	}
 
-	s.workflowNotificationsMap.Clear()
-	s.workflowEventsMap.Clear()
+	s.recvNotifier.clear()
+	s.eventNotifier.clear()
 	s.streamsMap.Clear()
 
 	s.launched = false
@@ -3364,17 +3360,10 @@ func (s *sysDB) notificationListenerLoop(ctx context.Context) {
 					time.Sleep(connectionRetryBackoff.delayFor(retryAttempt + 1))
 					retryAttempt++
 				}
-				// The connection is re-aquired. Signal to all waiters they should poll the database for a potentially missed value.
-				s.workflowNotificationRepollMap.Range(func(key, value any) bool {
-					repollChannel := value.(chan struct{})
-					repollChannel <- struct{}{}
-					return true
-				})
-				s.workflowEventsRepollMap.Range(func(key, value any) bool {
-					repollChannel := value.(chan struct{})
-					repollChannel <- struct{}{}
-					return true
-				})
+				// The connection is re-acquired. Wake all waiters so they re-poll the
+				// database for a value whose notification may have been missed.
+				s.recvNotifier.notifyAll()
+				s.eventNotifier.notifyAll()
 				continue
 			}
 			// Other transient errors. Backoff and continue on same conn
@@ -3391,17 +3380,9 @@ func (s *sysDB) notificationListenerLoop(ctx context.Context) {
 
 		switch n.Channel {
 		case _DBOS_NOTIFICATIONS_CHANNEL:
-			if cond, ok := s.workflowNotificationsMap.Load(n.Payload); ok {
-				cond.(*sync.Cond).L.Lock()
-				cond.(*sync.Cond).Broadcast()
-				cond.(*sync.Cond).L.Unlock()
-			}
+			s.recvNotifier.notify(n.Payload)
 		case _DBOS_WORKFLOW_EVENTS_CHANNEL:
-			if cond, ok := s.workflowEventsMap.Load(n.Payload); ok {
-				cond.(*sync.Cond).L.Lock()
-				cond.(*sync.Cond).Broadcast()
-				cond.(*sync.Cond).L.Unlock()
-			}
+			s.eventNotifier.notify(n.Payload)
 		case _DBOS_STREAMS_CHANNEL:
 			if ch, ok := s.streamsMap.Load(n.Payload); ok {
 				select {
@@ -3438,17 +3419,12 @@ func (s *sysDB) notificationPollerLoop(ctx context.Context) {
 
 func (s *sysDB) pollNotifications(ctx context.Context) {
 	// Iterate through all registered notification payloads
-	s.workflowNotificationsMap.Range(func(key, value any) bool {
-		payload, ok := key.(string)
-		if !ok {
-			return true // Continue to next item
-		}
-
+	for _, payload := range s.recvNotifier.payloads() {
 		// Parse payload: format is "destinationID::topic"
 		parts := strings.SplitN(payload, "::", 2)
 		if len(parts) != 2 {
 			s.logger.Warn("Invalid notification payload format", "payload", payload)
-			return true // Continue to next item
+			continue
 		}
 
 		destinationID := parts[0]
@@ -3460,35 +3436,24 @@ func (s *sysDB) pollNotifications(ctx context.Context) {
 		err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&exists)
 		if err != nil {
 			s.logger.Warn("Failed to poll notification", "payload", payload, "error", err)
-			return true // Continue to next item
+			continue
 		}
 
-		// If notification exists, signal the condition variable
+		// If a notification exists, wake the waiters so they re-check.
 		if exists {
-			if cond, ok := value.(*sync.Cond); ok {
-				cond.L.Lock()
-				cond.Broadcast()
-				cond.L.Unlock()
-			}
+			s.recvNotifier.notify(payload)
 		}
-
-		return true // Continue to next item
-	})
+	}
 }
 
 func (s *sysDB) pollEvents(ctx context.Context) {
 	// Iterate through all registered event payloads
-	s.workflowEventsMap.Range(func(key, value any) bool {
-		payload, ok := key.(string)
-		if !ok {
-			return true // Continue to next item
-		}
-
+	for _, payload := range s.eventNotifier.payloads() {
 		// Parse payload: format is "targetWorkflowID::key"
 		parts := strings.SplitN(payload, "::", 2)
 		if len(parts) != 2 {
 			s.logger.Warn("Invalid event payload format", "payload", payload)
-			return true // Continue to next item
+			continue
 		}
 
 		targetWorkflowID := parts[0]
@@ -3500,20 +3465,14 @@ func (s *sysDB) pollEvents(ctx context.Context) {
 		err := s.pool.QueryRow(ctx, query, targetWorkflowID, eventKey).Scan(&exists)
 		if err != nil {
 			s.logger.Warn("Failed to poll event", "payload", payload, "error", err)
-			return true // Continue to next item
+			continue
 		}
 
-		// If event exists, signal the condition variable
+		// If the event exists, wake the waiters so they re-check.
 		if exists {
-			if cond, ok := value.(*sync.Cond); ok {
-				cond.L.Lock()
-				cond.Broadcast()
-				cond.L.Unlock()
-			}
+			s.eventNotifier.notify(payload)
 		}
-
-		return true // Continue to next item
-	})
+	}
 }
 
 const _DBOS_NULL_TOPIC = "__null__topic__"
@@ -3567,98 +3526,158 @@ func (s *sysDB) send(ctx context.Context, input WorkflowSendInput) error {
 	return nil
 }
 
+// notifier delivers per-payload wake-ups to notification waiters (recv and
+// getEvent).
+type notifyRegistry struct {
+	mu   sync.Mutex
+	subs map[string]map[chan struct{}]struct{} // payload -> set of waiter channels
+}
+
+func newNotifyRegistry() *notifyRegistry {
+	return &notifyRegistry{subs: make(map[string]map[chan struct{}]struct{})}
+}
+
+func (n *notifyRegistry) addLocked(payload string, ch chan struct{}) {
+	set := n.subs[payload]
+	if set == nil {
+		set = make(map[chan struct{}]struct{})
+		n.subs[payload] = set
+	}
+	set[ch] = struct{}{}
+}
+
+// subscribe registers a new waiter for payload and returns its wake channel.
+func (n *notifyRegistry) subscribe(payload string) chan struct{} {
+	ch := make(chan struct{}, 1)
+	n.mu.Lock()
+	n.addLocked(payload, ch)
+	n.mu.Unlock()
+	return ch
+}
+
+// subscribeExclusive registers the sole waiter for payload, returning false if one
+// already exists.
+func (n *notifyRegistry) subscribeExclusive(payload string) (chan struct{}, bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.subs[payload]) > 0 {
+		return nil, false
+	}
+	ch := make(chan struct{}, 1)
+	n.addLocked(payload, ch)
+	return ch, true
+}
+
+// unsubscribe removes a waiter; the payload entry is dropped once its last waiter leaves.
+func (n *notifyRegistry) unsubscribe(payload string, ch chan struct{}) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	set := n.subs[payload]
+	delete(set, ch)
+	if len(set) == 0 {
+		delete(n.subs, payload)
+	}
+}
+
+// notify wakes every waiter for payload.
+func (n *notifyRegistry) notify(payload string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for ch := range n.subs[payload] {
+		select {
+		case ch <- struct{}{}:
+		default: // Do not block (coalesce multiple notifications into one)
+		}
+	}
+}
+
+// notifyAll wakes every waiter regardless of payload; used after a listener
+// reconnect so waiters re-poll for a value whose notification may have been missed.
+func (n *notifyRegistry) notifyAll() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for _, set := range n.subs {
+		for ch := range set {
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+// payloads returns a snapshot of the currently registered payloads (used by the
+// polling fallback to know which rows to check).
+func (n *notifyRegistry) payloads() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	out := make([]string, 0, len(n.subs))
+	for payload := range n.subs {
+		out = append(out, payload)
+	}
+	return out
+}
+
+// has reports whether any waiter is registered for payload.
+func (n *notifyRegistry) has(payload string) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.subs[payload]) > 0
+}
+
+// clear drops all registrations (used on shutdown).
+func (n *notifyRegistry) clear() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.subs = make(map[string]map[chan struct{}]struct{})
+}
+
 // notificationWaiter tracks a waiter registered for a notification (recv message or workflow event).
 type notificationWaiter struct {
 	pending bool                                   // the awaited row already existed at registration time
 	wait    func(deadline time.Time) (bool, error) // block until the row is pending or the deadline passes; true means timeout
-	release func()                                 // unregister the waiter and wake any waiting goroutine; must be called after the result is read (or on abandonment)
+	release func()                                 // unregister the waiter; must be called after the result is read (or on abandonment)
 }
 
-// notificationWait builds the wait closure shared by recv and getEvent: block until a
-// notification arrives (done closed), the deadline passes (returns true), a repoll
-// signal triggers a recheck of the database, or the context is cancelled.
-func (s *sysDB) notificationWait(ctx context.Context, opName, payload string, exists bool, done <-chan struct{}, repollChannel chan struct{}, recheck func() (bool, error)) func(deadline time.Time) (bool, error) {
+func (s *sysDB) notificationWait(ctx context.Context, opName, payload string, ch <-chan struct{}, recheck func() (bool, error)) func(deadline time.Time) (bool, error) {
 	return func(deadline time.Time) (bool, error) {
-		found := exists
-		for !found {
-			select {
-			case <-done:
+		for {
+			found, err := recheck()
+			if err != nil {
+				return false, err
+			}
+			if found {
 				return false, nil
+			}
+			select {
+			case <-ch:
+				// A notification or reconnect repoll fired; loop and re-check.
 			case <-time.After(max(0, time.Until(deadline))):
 				s.logger.Warn(opName+" timeout reached", "payload", payload, "deadline", deadline)
 				return true, nil
-			case <-repollChannel:
-				s.logger.Warn(opName+" polling after repoll channel signal", "payload", payload)
-				// We were instructed to poll again because the connection was disconnected
-				var err error
-				if found, err = recheck(); err != nil {
-					return false, err
-				}
-				// Restart at the beginning of the loop. If the value was found, we'll exit the loop and proceed to reading the value.
-				continue
 			case <-ctx.Done():
 				s.logger.Warn(opName+" context cancelled", "payload", payload, "cause", context.Cause(ctx))
 				return false, ctx.Err()
 			}
 		}
-		return false, nil
 	}
 }
 
 // startRecvListener registers the calling workflow as the sole receiver for
 // (destinationID, topic) and checks whether a message is already pending.
 func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic string) (*notificationWaiter, error) {
-	// First check if there's already a receiver for this workflow/topic to avoid unnecessary database load
+	// A destination/topic may have only one receiver at a time.
 	payload := fmt.Sprintf("%s::%s", destinationID, topic)
-	cond := sync.NewCond(&sync.Mutex{})
-	cond.L.Lock()
-	_, loaded := s.workflowNotificationsMap.LoadOrStore(payload, cond)
-	if loaded {
-		cond.L.Unlock()
+	ch, ok := s.recvNotifier.subscribeExclusive(payload)
+	if !ok {
 		s.logger.Error("Receive already called for workflow", "destination_id", destinationID)
 		return nil, newWorkflowConflictIDError(destinationID)
 	}
-	repollChannel := make(chan struct{}, 1)
-	s.workflowNotificationRepollMap.LoadOrStore(payload, repollChannel)
-	release := func() {
-		// Clean up the condition variable and broadcast to wake up any waiting goroutines.
-		cond.L.Lock()
-		cond.Broadcast()
-		cond.L.Unlock()
-		s.workflowNotificationsMap.Delete(payload)
-		s.workflowNotificationRepollMap.Delete(payload)
-	}
+	release := func() { s.recvNotifier.unsubscribe(payload, ch) }
 
-	// Now check if there is already an unconsumed message available in the database.
-	// If not, the caller will wait for a notification or its deadline.
+	// recheck reports whether an unconsumed message is pending; it is used both for
+	// the initial "already pending?" probe and by the wait loop after each wake.
 	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %snotifications WHERE destination_uuid = $1 AND topic = $2 AND consumed = false)`, s.dialect.SchemaPrefix(s.schema))
-	exists, err := retryWithResult(ctx, func() (bool, error) {
-		var e bool
-		if err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&e); err != nil {
-			return false, fmt.Errorf("failed to check message: %w", err)
-		}
-		return e, nil
-	}, withRetrierLogger(s.logger))
-	if err != nil {
-		cond.L.Unlock()
-		release()
-		return nil, err
-	}
-
-	// Create the waiting goroutine once (only if !exists, so we don't attempt to unlock twice)
-	done := make(chan struct{})
-	if !exists {
-		go func() {
-			// This is the only place we unlock the condition variable if the value did not exist
-			// Because of the Broadcast in release, we'll eventually hit this before the caller returns
-			defer cond.L.Unlock()
-			cond.Wait()
-			close(done)
-		}()
-	} else {
-		cond.L.Unlock()
-	}
-
 	recheck := func() (bool, error) {
 		return retryWithResult(ctx, func() (bool, error) {
 			var found bool
@@ -3668,7 +3687,12 @@ func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic stri
 			return found, nil
 		}, withRetrierLogger(s.logger))
 	}
-	wait := s.notificationWait(ctx, "Recv()", payload, exists, done, repollChannel, recheck)
+	exists, err := recheck()
+	if err != nil {
+		release()
+		return nil, err
+	}
+	wait := s.notificationWait(ctx, "Recv()", payload, ch, recheck)
 
 	return &notificationWaiter{pending: exists, wait: wait, release: release}, nil
 }
@@ -3746,70 +3770,15 @@ func (s *sysDB) setEvent(ctx context.Context, input WorkflowSetEventInput) error
 
 // startEventListener registers the caller as a waiter for the (targetWorkflowID, key)
 // event and checks whether the event is already set. Unlike recv, multiple waiters
-// may listen for the same event and share its condition variable.
+// may listen for the same event; they share one reference-counted notify hub.
 func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key string) (*notificationWaiter, error) {
 	payload := fmt.Sprintf("%s::%s", targetWorkflowID, key)
-	cond := sync.NewCond(&sync.Mutex{})
-	cond.L.Lock()
-	existingCond, loaded := s.workflowEventsMap.LoadOrStore(payload, cond)
-	if loaded {
-		// Reuse the existing condition variable
-		cond.L.Unlock()
-		ec, ok := existingCond.(*sync.Cond)
-		if !ok {
-			return nil, fmt.Errorf("workflow events map holds unexpected %T for %s", existingCond, payload)
-		}
-		cond = ec
-		cond.L.Lock()
-	}
-	release := func() {
-		// Clean up the condition variable and broadcast to wake up any waiting goroutines.
-		cond.L.Lock()
-		cond.Broadcast()
-		cond.L.Unlock()
-		s.workflowEventsMap.Delete(payload)
-		s.workflowEventsRepollMap.Delete(payload)
-	}
-	repollChannel := make(chan struct{}, 1)
-	existingRepoll, _ := s.workflowEventsRepollMap.LoadOrStore(payload, repollChannel)
-	rc, ok := existingRepoll.(chan struct{})
-	if !ok {
-		cond.L.Unlock()
-		release()
-		return nil, fmt.Errorf("workflow events repoll map holds unexpected %T for %s", existingRepoll, payload)
-	}
-	repollChannel = rc
+	ch := s.eventNotifier.subscribe(payload)
+	release := func() { s.eventNotifier.unsubscribe(payload, ch) }
 
-	// Now check if the event already exists in the database.
-	// If not, the caller will wait for a notification or its deadline.
+	// recheck reports whether the event is set; it is used both for the initial
+	// "already set?" probe and by the wait loop after each wake.
 	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %sworkflow_events WHERE workflow_uuid = $1 AND key = $2)`, s.dialect.SchemaPrefix(s.schema))
-	exists, err := retryWithResult(ctx, func() (bool, error) {
-		var e bool
-		if err := s.pool.QueryRow(ctx, query, targetWorkflowID, key).Scan(&e); err != nil {
-			return false, fmt.Errorf("failed to check event: %w", err)
-		}
-		return e, nil
-	}, withRetrierLogger(s.logger))
-	if err != nil {
-		cond.L.Unlock()
-		release()
-		return nil, err
-	}
-
-	// Create the waiting goroutine once (only if !exists, so we don't attempt to unlock twice)
-	done := make(chan struct{})
-	if !exists {
-		go func() {
-			// This is the only place we unlock the condition variable if the value did not exist
-			// Because of the Broadcast in release, we'll eventually hit this before the caller returns
-			defer cond.L.Unlock()
-			cond.Wait()
-			close(done)
-		}()
-	} else {
-		cond.L.Unlock()
-	}
-
 	recheck := func() (bool, error) {
 		return retryWithResult(ctx, func() (bool, error) {
 			var found bool
@@ -3819,7 +3788,12 @@ func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key st
 			return found, nil
 		}, withRetrierLogger(s.logger))
 	}
-	wait := s.notificationWait(ctx, "GetEvent()", payload, exists, done, repollChannel, recheck)
+	exists, err := recheck()
+	if err != nil {
+		release()
+		return nil, err
+	}
+	wait := s.notificationWait(ctx, "GetEvent()", payload, ch, recheck)
 
 	return &notificationWaiter{pending: exists, wait: wait, release: release}, nil
 }

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -3526,7 +3526,7 @@ func (s *sysDB) send(ctx context.Context, input WorkflowSendInput) error {
 	return nil
 }
 
-// notifier delivers per-payload wake-ups to notification waiters (recv and
+// notifyRegistry delivers per-payload wake-ups to notification waiters (recv and
 // getEvent).
 type notifyRegistry struct {
 	mu   sync.Mutex
@@ -3625,6 +3625,13 @@ func (n *notifyRegistry) has(payload string) bool {
 	return len(n.subs[payload]) > 0
 }
 
+// waiterCount reports the number of waiters registered for payload.
+func (n *notifyRegistry) waiterCount(payload string) int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.subs[payload])
+}
+
 // clear drops all registrations (used on shutdown).
 func (n *notifyRegistry) clear() {
 	n.mu.Lock()
@@ -3639,25 +3646,39 @@ type notificationWaiter struct {
 	release func()                                 // unregister the waiter; must be called after the result is read (or on abandonment)
 }
 
-func (s *sysDB) notificationWait(ctx context.Context, opName, payload string, ch <-chan struct{}, recheck func() (bool, error)) func(deadline time.Time) (bool, error) {
+func (s *sysDB) notificationWait(ctx context.Context, opName, payload string, ch <-chan struct{}, recheck func(context.Context) (bool, error)) func(deadline time.Time) (bool, error) {
 	return func(deadline time.Time) (bool, error) {
+		// The caller has already probed and found nothing; any notify since then is
+		// buffered in ch, so wait for a wake before rechecking. The deadline bounds
+		// recheck's retries so a DB outage cannot block past the timeout.
+		waitCtx, cancel := context.WithDeadline(ctx, deadline)
+		defer cancel()
 		for {
-			found, err := recheck()
+			select {
+			case <-ch:
+				// A notification or reconnect repoll fired; re-check.
+			case <-waitCtx.Done():
+				if err := ctx.Err(); err != nil {
+					s.logger.Warn(opName+" context cancelled", "payload", payload, "cause", context.Cause(ctx))
+					return false, err
+				}
+				s.logger.Warn(opName+" timeout reached", "payload", payload, "deadline", deadline)
+				return true, nil
+			}
+			found, err := recheck(waitCtx)
 			if err != nil {
+				if cerr := ctx.Err(); cerr != nil {
+					s.logger.Warn(opName+" context cancelled", "payload", payload, "cause", context.Cause(ctx))
+					return false, cerr
+				}
+				if waitCtx.Err() != nil {
+					s.logger.Warn(opName+" timeout reached", "payload", payload, "deadline", deadline)
+					return true, nil
+				}
 				return false, err
 			}
 			if found {
 				return false, nil
-			}
-			select {
-			case <-ch:
-				// A notification or reconnect repoll fired; loop and re-check.
-			case <-time.After(max(0, time.Until(deadline))):
-				s.logger.Warn(opName+" timeout reached", "payload", payload, "deadline", deadline)
-				return true, nil
-			case <-ctx.Done():
-				s.logger.Warn(opName+" context cancelled", "payload", payload, "cause", context.Cause(ctx))
-				return false, ctx.Err()
 			}
 		}
 	}
@@ -3678,7 +3699,7 @@ func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic stri
 	// recheck reports whether an unconsumed message is pending; it is used both for
 	// the initial "already pending?" probe and by the wait loop after each wake.
 	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %snotifications WHERE destination_uuid = $1 AND topic = $2 AND consumed = false)`, s.dialect.SchemaPrefix(s.schema))
-	recheck := func() (bool, error) {
+	recheck := func(ctx context.Context) (bool, error) {
 		return retryWithResult(ctx, func() (bool, error) {
 			var found bool
 			if err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&found); err != nil {
@@ -3687,7 +3708,7 @@ func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic stri
 			return found, nil
 		}, withRetrierLogger(s.logger))
 	}
-	exists, err := recheck()
+	exists, err := recheck(ctx)
 	if err != nil {
 		release()
 		return nil, err
@@ -3770,7 +3791,7 @@ func (s *sysDB) setEvent(ctx context.Context, input WorkflowSetEventInput) error
 
 // startEventListener registers the caller as a waiter for the (targetWorkflowID, key)
 // event and checks whether the event is already set. Unlike recv, multiple waiters
-// may listen for the same event; they share one reference-counted notify hub.
+// may listen for the same event.
 func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key string) (*notificationWaiter, error) {
 	payload := fmt.Sprintf("%s::%s", targetWorkflowID, key)
 	ch := s.eventNotifier.subscribe(payload)
@@ -3779,7 +3800,7 @@ func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key st
 	// recheck reports whether the event is set; it is used both for the initial
 	// "already set?" probe and by the wait loop after each wake.
 	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %sworkflow_events WHERE workflow_uuid = $1 AND key = $2)`, s.dialect.SchemaPrefix(s.schema))
-	recheck := func() (bool, error) {
+	recheck := func(ctx context.Context) (bool, error) {
 		return retryWithResult(ctx, func() (bool, error) {
 			var found bool
 			if err := s.pool.QueryRow(ctx, query, targetWorkflowID, key).Scan(&found); err != nil {
@@ -3788,7 +3809,7 @@ func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key st
 			return found, nil
 		}, withRetrierLogger(s.logger))
 	}
-	exists, err := recheck()
+	exists, err := recheck(ctx)
 	if err != nil {
 		release()
 		return nil, err

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3731,8 +3731,7 @@ func TestRecvStepConflict(t *testing.T) {
 	// Executor B must actually run the body (register as receiver), not
 	// short-circuit; its separate map confirms a real concurrent execution.
 	require.Eventually(t, func() bool {
-		ok := sysB.recvNotifier.has(payload)
-		return ok
+		return sysB.recvNotifier.has(payload)
 	}, 5*time.Second, 10*time.Millisecond, "executor B (recovery) never ran the body")
 
 	// Deliver the message. Exactly one executor consumes and checkpoints it; the
@@ -4361,8 +4360,7 @@ func TestSetGetEvent(t *testing.T) {
 		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
 		payload := fmt.Sprintf("%s::%s", setWorkflowID, key)
 		require.Eventually(t, func() bool {
-			ok := sysDB.eventNotifier.has(payload)
-			return ok
+			return sysDB.eventNotifier.has(payload)
 		}, 5*time.Second, 10*time.Millisecond, "long waiters never registered")
 
 		// Short waiters register on the same key, then time out and leave.
@@ -4428,8 +4426,7 @@ func TestSetGetEvent(t *testing.T) {
 		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
 		payload := fmt.Sprintf("%s::%s", setWorkflowID, key)
 		require.Eventually(t, func() bool {
-			ok := sysDB.eventNotifier.has(payload)
-			return ok
+			return sysDB.eventNotifier.has(payload)
 		}, 5*time.Second, 10*time.Millisecond, "survivor never registered")
 
 		// A sibling on the same key that gets cancelled while waiting.
@@ -4439,8 +4436,10 @@ func TestSetGetEvent(t *testing.T) {
 			defer close(siblingDone)
 			_, _ = GetEvent[string](cancelCtx, setWorkflowID, key, 30*time.Second)
 		}()
-		// Give the sibling time to register, then cancel it.
-		time.Sleep(200 * time.Millisecond)
+		// Wait until the sibling has actually registered, then cancel it.
+		require.Eventually(t, func() bool {
+			return sysDB.eventNotifier.waiterCount(payload) == 2
+		}, 5*time.Second, 10*time.Millisecond, "sibling never registered")
 		cancel()
 		<-siblingDone
 

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3716,8 +3716,7 @@ func TestRecvStepConflict(t *testing.T) {
 	sysB := ctxB.(*dbosContext).systemDB.(*sysDB)
 	payload := fmt.Sprintf("%s::%s", workflowID, topic)
 	require.Eventually(t, func() bool {
-		_, ok := sysA.workflowNotificationsMap.Load(payload)
-		return ok
+		return sysA.recvNotifier.has(payload)
 	}, 5*time.Second, 10*time.Millisecond, "executor A never registered as receiver")
 
 	// Executor B recovers the same workflow: a genuinely concurrent second
@@ -3732,7 +3731,7 @@ func TestRecvStepConflict(t *testing.T) {
 	// Executor B must actually run the body (register as receiver), not
 	// short-circuit; its separate map confirms a real concurrent execution.
 	require.Eventually(t, func() bool {
-		_, ok := sysB.workflowNotificationsMap.Load(payload)
+		ok := sysB.recvNotifier.has(payload)
 		return ok
 	}, 5*time.Second, 10*time.Millisecond, "executor B (recovery) never ran the body")
 
@@ -4271,10 +4270,10 @@ func TestSetGetEvent(t *testing.T) {
 	})
 
 	t.Run("ConcurrentGetEvent", func(t *testing.T) {
-		// Spread more getters than keys: several getters share each key's condition
-		// variable (within-key concurrency) while distinct keys use independent
-		// condition variables (across-key concurrency). Getters start before the
-		// events are set so they block rather than taking the already-set fast path.
+		// Spread more getters than keys: several getters register on each key
+		// (within-key concurrency) while distinct keys are independent (across-key
+		// concurrency). Getters start before the events are set so they block rather
+		// than taking the already-set fast path.
 		setWorkflowID := uuid.NewString()
 		const numKeys = 3
 		const numGoroutines = 12 // > numKeys, so multiple getters land on each key
@@ -4310,7 +4309,7 @@ func TestSetGetEvent(t *testing.T) {
 		require.Eventually(t, func() bool {
 			for k := range numKeys {
 				payload := fmt.Sprintf("%s::%s", setWorkflowID, fmt.Sprintf("concurrent-event-key-%d", k))
-				if _, ok := sysDB.workflowEventsMap.Load(payload); !ok {
+				if !sysDB.eventNotifier.has(payload) {
 					return false
 				}
 			}
@@ -4329,6 +4328,137 @@ func TestSetGetEvent(t *testing.T) {
 		}
 	})
 
+	t.Run("GetEventMixedTimeoutAndDelivery", func(t *testing.T) {
+		// On a single key, some waiters time out before the event is set and others
+		// block long enough to receive it. A departing waiter must not disturb the
+		// survivors: they must still receive the value once it is set, not return a
+		// premature nil. (Regression test for the per-waiter notify fix.)
+		setWorkflowID := uuid.NewString()
+		key := "mixed-timeout-key"
+		const numLong = 3
+		const numShort = 3
+
+		var longWg, shortWg sync.WaitGroup
+		longErrs := make(chan error, numLong)
+		shortErrs := make(chan error, numShort)
+
+		// Long waiters register first.
+		longWg.Add(numLong)
+		for i := range numLong {
+			go func(i int) {
+				defer longWg.Done()
+				res, err := GetEvent[string](dbosCtx, setWorkflowID, key, 30*time.Second)
+				if err != nil {
+					longErrs <- fmt.Errorf("long waiter %d: %w", i, err)
+					return
+				}
+				if res != "mixed-value" {
+					longErrs <- fmt.Errorf("long waiter %d: expected %q, got %q", i, "mixed-value", res)
+				}
+			}(i)
+		}
+
+		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+		payload := fmt.Sprintf("%s::%s", setWorkflowID, key)
+		require.Eventually(t, func() bool {
+			ok := sysDB.eventNotifier.has(payload)
+			return ok
+		}, 5*time.Second, 10*time.Millisecond, "long waiters never registered")
+
+		// Short waiters register on the same key, then time out and leave.
+		shortWg.Add(numShort)
+		for i := range numShort {
+			go func(i int) {
+				defer shortWg.Done()
+				_, err := GetEvent[string](dbosCtx, setWorkflowID, key, 300*time.Millisecond)
+				if err == nil {
+					shortErrs <- fmt.Errorf("short waiter %d: expected a timeout", i)
+					return
+				}
+				dbosErr, ok := err.(*DBOSError)
+				if !ok || dbosErr.Code != TimeoutError {
+					shortErrs <- fmt.Errorf("short waiter %d: expected TimeoutError, got %v", i, err)
+				}
+			}(i)
+		}
+
+		// Let the short waiters time out and leave before setting the event.
+		shortWg.Wait()
+		close(shortErrs)
+		for err := range shortErrs {
+			require.FailNow(t, "short waiter error", err)
+		}
+
+		setHandle, err := RunWorkflow(dbosCtx, setEventWorkflow, setEventWorkflowInput{
+			Key:     key,
+			Message: "mixed-value",
+		}, WithWorkflowID(setWorkflowID))
+		require.NoError(t, err, "failed to start set event workflow")
+		_, err = setHandle.GetResult()
+		require.NoError(t, err, "failed to get result from set event workflow")
+
+		longWg.Wait()
+		close(longErrs)
+		for err := range longErrs {
+			require.FailNow(t, "long waiter error", err)
+		}
+	})
+
+	t.Run("GetEventSiblingCancellationDoesNotWakeOthers", func(t *testing.T) {
+		// A sibling whose context is cancelled mid-wait must not wake the others into
+		// returning early: the survivor still receives the value once it is set.
+		setWorkflowID := uuid.NewString()
+		key := "cancel-sibling-key"
+
+		var survivorWg sync.WaitGroup
+		survivorErr := make(chan error, 1)
+		survivorWg.Add(1)
+		go func() {
+			defer survivorWg.Done()
+			res, err := GetEvent[string](dbosCtx, setWorkflowID, key, 30*time.Second)
+			if err != nil {
+				survivorErr <- fmt.Errorf("survivor: %w", err)
+				return
+			}
+			if res != "survivor-value" {
+				survivorErr <- fmt.Errorf("survivor: expected %q, got %q", "survivor-value", res)
+			}
+		}()
+
+		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+		payload := fmt.Sprintf("%s::%s", setWorkflowID, key)
+		require.Eventually(t, func() bool {
+			ok := sysDB.eventNotifier.has(payload)
+			return ok
+		}, 5*time.Second, 10*time.Millisecond, "survivor never registered")
+
+		// A sibling on the same key that gets cancelled while waiting.
+		cancelCtx, cancel := WithCancel(dbosCtx)
+		siblingDone := make(chan struct{})
+		go func() {
+			defer close(siblingDone)
+			_, _ = GetEvent[string](cancelCtx, setWorkflowID, key, 30*time.Second)
+		}()
+		// Give the sibling time to register, then cancel it.
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+		<-siblingDone
+
+		// The survivor must still be waiting; setting the event delivers it.
+		setHandle, err := RunWorkflow(dbosCtx, setEventWorkflow, setEventWorkflowInput{
+			Key:     key,
+			Message: "survivor-value",
+		}, WithWorkflowID(setWorkflowID))
+		require.NoError(t, err, "failed to start set event workflow")
+		_, err = setHandle.GetResult()
+		require.NoError(t, err, "failed to get result from set event workflow")
+
+		survivorWg.Wait()
+		close(survivorErr)
+		for err := range survivorErr {
+			require.FailNow(t, "survivor error", err)
+		}
+	})
 }
 
 // Test workflows and steps for parameter mismatch validation


### PR DESCRIPTION
The current implementation for concurrent getEvent relies on a condition variable shared by all consumers to "wake up" when a NOTIFY event happens. On the happy path, the notification listener broadcast on the CV and all waiters wake and read.

However, if a waiter decides to exit earlier than the others (e.g., they have a shorter timeout), they broadcast the CV, which wakes all other waiters, regardless of their timeout. This can result in all waiters exiting with no result ("") and no error. A bit of a corner case that I uncovered while adding tests to #380. (This bug predates #380.)

Further, when the early consumer broadcast, it also clears up the event map, losing the registration for all other waiters.

This PR moves away from this shared CV design and rather leverage channels for the consumers to subscribe to notifications. 1 channel per waiter. The wait loop becomes:
- check for a value's existence,
- if found or error, exit appropriately,
- if not found and no error, select from three channels: 1) a channel signaled by the notication listener 2) a timeout and 3) context cancellation
- the notification listener writes to registered channels when a NOTIFY event arrives from Postgres,
- which brings execution back to the beginning of the loop


We could pool channels per key across all waiters and use close() for signaling, but it is more complicated than it's worth.

Also:
- This design allows us to entirely remove the "repoll" maps, the disconnect recheck use the same mechanism that normal checks
- Though `recv` didn't have the bug (because it only allows a single consumer) I moved it to the same implementation.