### PR TITLE
Queryable schedule names & scheduler direct enqueue

### DIFF
--- a/.github/workflows/chaos-tests.yml
+++ b/.github/workflows/chaos-tests.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
 
     - name: Download dependencies
       run: go mod download

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
 
     - name: Download dependencies
       run: go mod download

--- a/.github/workflows/tests-crdb.yml
+++ b/.github/workflows/tests-crdb.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
 
     - name: Start CockroachDB container
       run: |

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
 
     - name: Download dependencies
       run: go mod download

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
 
     - name: Download dependencies
       run: go mod download

--- a/dbos/client.go
+++ b/dbos/client.go
@@ -40,6 +40,7 @@ type Client interface {
 	ResumeWorkflow(workflowID string, opts ...ResumeWorkflowOption) (WorkflowHandle[any], error)
 	ResumeWorkflows(workflowIDs []string, opts ...ResumeWorkflowOption) ([]WorkflowHandle[any], error)
 	ForkWorkflow(input ForkWorkflowInput) (WorkflowHandle[any], error)
+	ForkWorkflows(input ForkWorkflowsInput) ([]WorkflowHandle[any], error)
 	GetWorkflowSteps(workflowID string, opts ...GetWorkflowStepsOption) ([]StepInfo, error)
 	ClientReadStream(workflowID string, key string, opts ...ReadStreamOption) ([]any, bool, error)
 	ClientReadStreamAsync(workflowID string, key string) (<-chan StreamValue[any], error)
@@ -655,6 +656,29 @@ func ClientForkWorkflow[R any](c Client, input ForkWorkflowInput) (WorkflowHandl
 		return nil, err
 	}
 	return typedClientHandle[R](c, handle), nil
+}
+
+// ForkWorkflows forks a batch of workflows in a single database round-trip.
+// The returned handles are in the same order as input.Workflows.
+func (c *client) ForkWorkflows(input ForkWorkflowsInput) ([]WorkflowHandle[any], error) {
+	return c.dbosCtx.ForkWorkflows(c.dbosCtx, input)
+}
+
+// ClientForkWorkflows forks a batch of workflows and returns typed handles whose
+// GetResult decodes each forked workflow's output into type R.
+func ClientForkWorkflows[R any](c Client, input ForkWorkflowsInput) ([]WorkflowHandle[R], error) {
+	if c == nil {
+		return nil, errors.New("client cannot be nil")
+	}
+	handles, err := c.ForkWorkflows(input)
+	if err != nil {
+		return nil, err
+	}
+	typedHandles := make([]WorkflowHandle[R], len(handles))
+	for i, handle := range handles {
+		typedHandles[i] = typedClientHandle[R](c, handle)
+	}
+	return typedHandles, nil
 }
 
 // GetWorkflowSteps retrieves a workflow's execution steps. Step output is

--- a/dbos/client.go
+++ b/dbos/client.go
@@ -40,9 +40,7 @@ type Client interface {
 	ResumeWorkflow(workflowID string, opts ...ResumeWorkflowOption) (WorkflowHandle[any], error)
 	ResumeWorkflows(workflowIDs []string, opts ...ResumeWorkflowOption) ([]WorkflowHandle[any], error)
 	ForkWorkflow(input ForkWorkflowInput) (WorkflowHandle[any], error)
-	GetWorkflowSteps(workflowID string) ([]StepInfo, error)
-	ClientListWorkflows(opts ...ListWorkflowsOption) ([]WorkflowStatus, error)
-	ClientGetWorkflowSteps(workflowID string, opts ...GetWorkflowStepsOption) ([]StepInfo, error)
+	GetWorkflowSteps(workflowID string, opts ...GetWorkflowStepsOption) ([]StepInfo, error)
 	ClientReadStream(workflowID string, key string, opts ...ReadStreamOption) ([]any, bool, error)
 	ClientReadStreamAsync(workflowID string, key string) (<-chan StreamValue[any], error)
 
@@ -659,20 +657,9 @@ func ClientForkWorkflow[R any](c Client, input ForkWorkflowInput) (WorkflowHandl
 	return typedClientHandle[R](c, handle), nil
 }
 
-// GetWorkflowSteps retrieves the execution steps of a workflow.
-func (c *client) GetWorkflowSteps(workflowID string) ([]StepInfo, error) {
-	return c.dbosCtx.GetWorkflowSteps(c.dbosCtx, workflowID)
-}
-
-// ClientListWorkflows lists workflows. Input and output are NOT loaded or
-// decoded by default. Pass WithLoadInput(true) / WithLoadOutput(true) to opt in.
-func (c *client) ClientListWorkflows(opts ...ListWorkflowsOption) ([]WorkflowStatus, error) {
-	return c.dbosCtx.ListWorkflows(c.dbosCtx, opts...)
-}
-
-// ClientGetWorkflowSteps retrieves a workflow's execution steps. Step output is
+// GetWorkflowSteps retrieves a workflow's execution steps. Step output is
 // NOT loaded or decoded by default. Pass WithStepsLoadOutput(true) to opt in.
-func (c *client) ClientGetWorkflowSteps(workflowID string, opts ...GetWorkflowStepsOption) ([]StepInfo, error) {
+func (c *client) GetWorkflowSteps(workflowID string, opts ...GetWorkflowStepsOption) ([]StepInfo, error) {
 	return c.dbosCtx.GetWorkflowSteps(c.dbosCtx, workflowID, opts...)
 }
 

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -2610,7 +2610,7 @@ func TestClientTypedHandles(t *testing.T) {
 	require.True(t, queueEntriesAreCleanedUp(serverCtx), "expected queue entries to be cleaned up after typed handles test")
 }
 
-// TestClientListAndSteps verifies ClientListWorkflows and ClientGetWorkflowSteps
+// TestClientListAndSteps verifies ListWorkflows and GetWorkflowSteps
 // do NOT load/decode input/output by default, and decode them when explicitly
 // asked via the load options.
 func TestClientListAndSteps(t *testing.T) {
@@ -2651,7 +2651,7 @@ func TestClientListAndSteps(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("ListWorkflowsNoDecodeByDefault", func(t *testing.T) {
-		workflows, err := client.ClientListWorkflows(WithWorkflowIDs([]string{workflowID}))
+		workflows, err := client.ListWorkflows(WithWorkflowIDs([]string{workflowID}))
 		require.NoError(t, err)
 		require.Len(t, workflows, 1)
 		assert.Nil(t, workflows[0].Input, "input must not be loaded by default")
@@ -2659,7 +2659,7 @@ func TestClientListAndSteps(t *testing.T) {
 	})
 
 	t.Run("ListWorkflowsLoadsWhenRequested", func(t *testing.T) {
-		workflows, err := client.ClientListWorkflows(WithWorkflowIDs([]string{workflowID}), WithLoadInput(true), WithLoadOutput(true))
+		workflows, err := client.ListWorkflows(WithWorkflowIDs([]string{workflowID}), WithLoadInput(true), WithLoadOutput(true))
 		require.NoError(t, err)
 		require.Len(t, workflows, 1)
 
@@ -2675,7 +2675,7 @@ func TestClientListAndSteps(t *testing.T) {
 	})
 
 	t.Run("GetWorkflowStepsNoDecodeByDefault", func(t *testing.T) {
-		steps, err := client.ClientGetWorkflowSteps(workflowID)
+		steps, err := client.GetWorkflowSteps(workflowID)
 		require.NoError(t, err)
 		require.Len(t, steps, 1)
 		assert.Equal(t, "GreetStep", steps[0].StepName)
@@ -2683,7 +2683,7 @@ func TestClientListAndSteps(t *testing.T) {
 	})
 
 	t.Run("GetWorkflowStepsLoadsWhenRequested", func(t *testing.T) {
-		steps, err := client.ClientGetWorkflowSteps(workflowID, WithStepsLoadOutput(true))
+		steps, err := client.GetWorkflowSteps(workflowID, WithStepsLoadOutput(true))
 		require.NoError(t, err)
 		require.Len(t, steps, 1)
 		output, ok := steps[0].Output.(string)

--- a/dbos/conductor.go
+++ b/dbos/conductor.go
@@ -771,6 +771,9 @@ func (c *conductor) handleListWorkflowsRequest(data []byte, requestID string) er
 	if len(req.Body.Attributes) > 0 {
 		opts = append(opts, WithFilterAttributes(req.Body.Attributes))
 	}
+	if len(req.Body.ScheduleName) > 0 {
+		opts = append(opts, WithFilterScheduleName(req.Body.ScheduleName.toSlice()...))
+	}
 
 	workflows, err := c.dbosCtx.ListWorkflows(c.dbosCtx, opts...)
 	if err != nil {
@@ -899,6 +902,9 @@ func (c *conductor) handleListQueuedWorkflowsRequest(data []byte, requestID stri
 	}
 	if len(req.Body.Attributes) > 0 {
 		opts = append(opts, WithFilterAttributes(req.Body.Attributes))
+	}
+	if len(req.Body.ScheduleName) > 0 {
+		opts = append(opts, WithFilterScheduleName(req.Body.ScheduleName.toSlice()...))
 	}
 
 	workflows, err := c.dbosCtx.ListWorkflows(c.dbosCtx, opts...)

--- a/dbos/conductor_protocol.go
+++ b/dbos/conductor_protocol.go
@@ -125,6 +125,7 @@ type listWorkflowsConductorRequestBody struct {
 	ExecutorID         stringOrList   `json:"executor_id,omitempty"`
 	QueuesOnly         bool           `json:"queues_only"`
 	Attributes         map[string]any `json:"attributes,omitempty"`
+	ScheduleName       stringOrList   `json:"schedule_name,omitempty"`
 }
 
 // listWorkflowsConductorRequest is sent by the conductor to list workflows
@@ -163,6 +164,7 @@ type listWorkflowsConductorResponseBody struct {
 	DelayUntilEpochMS       *string `json:"DelayUntilEpochMS,omitempty"`
 	CompletedAt             *string `json:"CompletedAt,omitempty"`
 	Attributes              *string `json:"Attributes,omitempty"`
+	ScheduleName            *string `json:"ScheduleName,omitempty"`
 }
 
 // listWorkflowsConductorResponse is sent in response to list workflows requests
@@ -315,6 +317,11 @@ func formatListWorkflowsResponseBody(wf WorkflowStatus) listWorkflowsConductorRe
 			attributesStr := string(attributesJSON)
 			output.Attributes = &attributesStr
 		}
+	}
+
+	// Copy schedule name
+	if wf.ScheduleName != "" {
+		output.ScheduleName = &wf.ScheduleName
 	}
 
 	return output

--- a/dbos/datasource.go
+++ b/dbos/datasource.go
@@ -314,7 +314,7 @@ func (ds *DataSource) recordCompletion(ctx context.Context, q Querier, workflowI
 // exactly once even across crashes and recovery.
 //
 // It must be called from within a workflow. Standard StepOptions apply
-// (WithStepName, WithStepMaxRetries, retry predicate, WithStepTxIsolation).
+// (WithStepName, WithStepMaxRetries, retry predicate).
 //
 // Example:
 //

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -171,6 +171,7 @@ type DBOSContext interface {
 	ResumeWorkflow(_ DBOSContext, workflowID string, opts ...ResumeWorkflowOption) (WorkflowHandle[any], error)       // Resume a cancelled workflow
 	ResumeWorkflows(_ DBOSContext, workflowIDs []string, opts ...ResumeWorkflowOption) ([]WorkflowHandle[any], error) // Resume multiple workflows in a single DB round-trip
 	ForkWorkflow(_ DBOSContext, input ForkWorkflowInput) (WorkflowHandle[any], error)                                 // Fork a workflow from a specific step
+	ForkWorkflows(_ DBOSContext, input ForkWorkflowsInput) ([]WorkflowHandle[any], error)                             // Fork multiple workflows in a single DB round-trip
 	ListWorkflows(_ DBOSContext, opts ...ListWorkflowsOption) ([]WorkflowStatus, error)                               // List workflows based on filtering criteria
 	GetWorkflowSteps(_ DBOSContext, workflowID string, opts ...GetWorkflowStepsOption) ([]StepInfo, error)            // Get the execution steps of a workflow
 	GetWorkflowAggregates(_ DBOSContext, input GetWorkflowAggregatesInput) ([]WorkflowAggregateRow, error)            // Aggregate counts of workflows by one or more grouping columns

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -305,7 +305,7 @@ func TestConfig(t *testing.T) {
 
 		err = sysDB.pool.QueryRow(dbCtx, "SELECT version FROM dbos.dbos_migrations").Scan(&version)
 		require.NoError(t, err)
-		assert.Equal(t, int64(40), version, "migration version should be 40 (after all migrations including the attributes column)")
+		assert.Equal(t, int64(41), version, "migration version should be 41 (after all migrations including the schedule_name column)")
 
 		// Test manual shutdown and recreate
 		Shutdown(ctx, 1*time.Minute)
@@ -603,7 +603,7 @@ func TestCustomSystemDBSchema(t *testing.T) {
 
 		err = sysDB.pool.QueryRow(dbCtx, fmt.Sprintf("SELECT version FROM %s.dbos_migrations", customSchema)).Scan(&version)
 		require.NoError(t, err)
-		assert.Equal(t, int64(40), version, "migration version should be 40 (after all migrations including the attributes column)")
+		assert.Equal(t, int64(41), version, "migration version should be 41 (after all migrations including the schedule_name column)")
 	})
 
 	// Test workflows for exercising Send/Recv and SetEvent/GetEvent

--- a/dbos/migrations/41_add_schedule_name.sql
+++ b/dbos/migrations/41_add_schedule_name.sql
@@ -1,0 +1,8 @@
+-- Migration 41: Add a schedule_name column to workflow_status recording which
+-- named schedule (if any) enqueued the workflow. ADD COLUMN with no default is
+-- catalog-only; the partial index built in the same transaction covers zero
+-- rows (no existing row has a non-NULL schedule_name), so no CONCURRENTLY is
+-- needed. The index supports filtering workflows by schedule name.
+
+ALTER TABLE %s."workflow_status" ADD COLUMN IF NOT EXISTS "schedule_name" TEXT;
+CREATE INDEX IF NOT EXISTS "idx_workflow_status_schedule_name" ON %s."workflow_status" ("schedule_name") WHERE "schedule_name" IS NOT NULL;

--- a/dbos/migrations/sqlite/41_add_schedule_name.sql
+++ b/dbos/migrations/sqlite/41_add_schedule_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workflow_status ADD COLUMN "schedule_name" TEXT;
+CREATE INDEX IF NOT EXISTS "idx_workflow_status_schedule_name" ON "workflow_status" ("schedule_name") WHERE "schedule_name" IS NOT NULL;

--- a/dbos/pgsql_client_test.go
+++ b/dbos/pgsql_client_test.go
@@ -23,28 +23,34 @@ import (
 // Signature: enqueue_workflow(workflow_name, queue_name, positional_args, named_args,
 //
 //	class_name, config_name, workflow_id, app_version, timeout_ms,
-//	deadline_epoch_ms, deduplication_id, priority, queue_partition_key)
+//	deadline_epoch_ms, deduplication_id, priority, queue_partition_key,
+//	authenticated_user, authenticated_roles, delay_until_epoch_ms)
+//
+// authenticated_roles is a JSON-encoded array of strings.
 func callEnqueueWorkflow(ctx context.Context, pool *pgxpool.Pool, schema string, params map[string]any) (string, error) {
 	sanitized := pgx.Identifier{schema}.Sanitize()
-	query := fmt.Sprintf(`SELECT %s.enqueue_workflow($1, $2, $3::json[], $4::json, $5, $6, $7, $8, $9, $10, $11, $12, $13)`, sanitized)
+	query := fmt.Sprintf(`SELECT %s.enqueue_workflow($1, $2, $3::json[], $4::json, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`, sanitized)
 
 	get := func(key string) any { return params[key] }
 
 	var wfID string
 	err := pool.QueryRow(ctx, query,
-		get("workflow_name"),       // $1
-		get("queue_name"),          // $2
-		get("positional_args"),     // $3
-		get("named_args"),          // $4
-		get("class_name"),          // $5
-		get("config_name"),         // $6
-		get("workflow_id"),         // $7
-		get("app_version"),         // $8
-		get("timeout_ms"),          // $9
-		get("deadline_epoch_ms"),   // $10
-		get("deduplication_id"),    // $11
-		get("priority"),            // $12
-		get("queue_partition_key"), // $13
+		get("workflow_name"),        // $1
+		get("queue_name"),           // $2
+		get("positional_args"),      // $3
+		get("named_args"),           // $4
+		get("class_name"),           // $5
+		get("config_name"),          // $6
+		get("workflow_id"),          // $7
+		get("app_version"),          // $8
+		get("timeout_ms"),           // $9
+		get("deadline_epoch_ms"),    // $10
+		get("deduplication_id"),     // $11
+		get("priority"),             // $12
+		get("queue_partition_key"),  // $13
+		get("authenticated_user"),   // $14
+		get("authenticated_roles"),  // $15
+		get("delay_until_epoch_ms"), // $16
 	).Scan(&wfID)
 	return wfID, err
 }
@@ -321,6 +327,78 @@ func TestPgsqlClient(t *testing.T) {
 		result, err := handle.GetResult()
 		require.NoError(t, err)
 		assert.Equal(t, "priority-input", result)
+	})
+
+	t.Run("EnqueueWithAuthMetadata", func(t *testing.T) {
+		wfID := fmt.Sprintf("pgsql-auth-%d", time.Now().UnixNano())
+		roles := []string{"admin", "reader"}
+		rolesJSON, err := json.Marshal(roles)
+		require.NoError(t, err)
+
+		_, err = callEnqueueWorkflow(context.Background(), pool, schema, map[string]any{
+			"workflow_name":       "pgsql_retrieve_test",
+			"queue_name":          queue.Name,
+			"positional_args":     []string{`"auth-input"`},
+			"named_args":          `{}`,
+			"workflow_id":         wfID,
+			"app_version":         serverCtx.GetApplicationVersion(),
+			"authenticated_user":  "alice",
+			"authenticated_roles": string(rolesJSON),
+		})
+		require.NoError(t, err)
+
+		handle, err := RetrieveWorkflow[string](serverCtx, wfID)
+		require.NoError(t, err)
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err)
+		assert.Equal(t, "alice", status.AuthenticatedUser)
+		assert.Equal(t, roles, status.AuthenticatedRoles)
+
+		result, err := handle.GetResult()
+		require.NoError(t, err)
+		assert.Equal(t, "auth-input", result)
+	})
+
+	t.Run("EnqueueWithDelay", func(t *testing.T) {
+		wfID := fmt.Sprintf("pgsql-delay-%d", time.Now().UnixNano())
+		// Far enough in the future that the workflow is not promoted during the test.
+		delayUntil := time.Now().Add(60 * time.Second).UnixMilli()
+
+		_, err := callEnqueueWorkflow(context.Background(), pool, schema, map[string]any{
+			"workflow_name":        "pgsql_retrieve_test",
+			"queue_name":           queue.Name,
+			"positional_args":      []string{`"delay-input"`},
+			"named_args":           `{}`,
+			"workflow_id":          wfID,
+			"app_version":          serverCtx.GetApplicationVersion(),
+			"delay_until_epoch_ms": delayUntil,
+		})
+		require.NoError(t, err)
+
+		handle, err := RetrieveWorkflow[string](serverCtx, wfID)
+		require.NoError(t, err)
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err)
+		assert.Equal(t, WorkflowStatusDelayed, status.Status)
+		assert.Equal(t, delayUntil, status.DelayUntil.UnixMilli())
+
+		require.NoError(t, CancelWorkflow(serverCtx, wfID))
+	})
+
+	t.Run("EnqueueNegativeDelayRejected", func(t *testing.T) {
+		_, err := callEnqueueWorkflow(context.Background(), pool, schema, map[string]any{
+			"workflow_name":        "pgsql_retrieve_test",
+			"queue_name":           queue.Name,
+			"positional_args":      []string{`"negative-delay-input"`},
+			"named_args":           `{}`,
+			"workflow_id":          fmt.Sprintf("pgsql-negative-delay-%d", time.Now().UnixNano()),
+			"app_version":          serverCtx.GetApplicationVersion(),
+			"delay_until_epoch_ms": int64(-1),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delay_until_epoch_ms must be >= 0")
 	})
 
 	t.Run("SendWithTopic", func(t *testing.T) {

--- a/dbos/schedule_test.go
+++ b/dbos/schedule_test.go
@@ -787,3 +787,118 @@ func TestScheduleCronTimezone(t *testing.T) {
 	require.Equal(t, time.January, next.Month())
 	require.Equal(t, 15, next.Day())
 }
+
+func testManualWorkflowForScheduleName(ctx DBOSContext, input string) (string, error) {
+	return "manual", nil
+}
+
+func TestListWorkflowsByScheduleName(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true, schedulerPollingInterval: 100 * time.Millisecond})
+	defer dbosCtx.Shutdown(10 * time.Second)
+
+	RegisterWorkflow(dbosCtx, testWorkflowForSchedule)
+	RegisterWorkflow(dbosCtx, testManualWorkflowForScheduleName)
+
+	require.NoError(t, dbosCtx.Launch())
+
+	// A directly-invoked workflow has no schedule name and is not returned by
+	// the schedule name filter.
+	manualHandle, err := RunWorkflow(dbosCtx, testManualWorkflowForScheduleName, "input")
+	require.NoError(t, err)
+	manualResult, err := manualHandle.GetResult()
+	require.NoError(t, err)
+	require.Equal(t, "manual", manualResult)
+	manualStatus, err := ListWorkflows(dbosCtx, WithWorkflowIDs([]string{manualHandle.GetWorkflowID()}))
+	require.NoError(t, err)
+	require.Len(t, manualStatus, 1)
+	require.Empty(t, manualStatus[0].ScheduleName)
+
+	// Two distinct schedules sharing the same workflow function: ScheduleName is
+	// what distinguishes their runs, since both have the same workflow name.
+	for _, name := range []string{"search-a", "search-b"} {
+		require.NoError(t, CreateSchedule(dbosCtx, testWorkflowForSchedule, CreateScheduleRequest{
+			ScheduleName: name,
+			Schedule:     "0 0 0 * * *", // daily, won't fire during the test
+		}))
+		t.Cleanup(func() { _ = DeleteSchedule(dbosCtx, name) })
+	}
+
+	handleA, err := TriggerSchedule(dbosCtx, "search-a")
+	require.NoError(t, err)
+	handleB, err := TriggerSchedule(dbosCtx, "search-b")
+	require.NoError(t, err)
+	_, err = handleA.GetResult()
+	require.NoError(t, err)
+	_, err = handleB.GetResult()
+	require.NoError(t, err)
+
+	// Filter by a single schedule name
+	runsA, err := ListWorkflows(dbosCtx, WithFilterScheduleName("search-a"))
+	require.NoError(t, err)
+	require.Len(t, runsA, 1)
+	require.Equal(t, handleA.GetWorkflowID(), runsA[0].ID)
+	require.Equal(t, "search-a", runsA[0].ScheduleName)
+
+	// Filter by a list of schedule names
+	runsBoth, err := ListWorkflows(dbosCtx, WithFilterScheduleName("search-a", "search-b"))
+	require.NoError(t, err)
+	require.Len(t, runsBoth, 2)
+	gotIDs := make(map[string]bool, len(runsBoth))
+	for _, wf := range runsBoth {
+		gotIDs[wf.ID] = true
+		require.Contains(t, []string{"search-a", "search-b"}, wf.ScheduleName)
+	}
+	require.True(t, gotIDs[handleA.GetWorkflowID()])
+	require.True(t, gotIDs[handleB.GetWorkflowID()])
+
+	// A schedule name that produced no runs returns nothing
+	neverFired, err := ListWorkflows(dbosCtx, WithFilterScheduleName("never-fired"))
+	require.NoError(t, err)
+	require.Empty(t, neverFired)
+}
+
+func TestScheduleNameSurvivesExportImport(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true, schedulerPollingInterval: 100 * time.Millisecond})
+	defer dbosCtx.Shutdown(10 * time.Second)
+
+	RegisterWorkflow(dbosCtx, testWorkflowForSchedule)
+	require.NoError(t, dbosCtx.Launch())
+
+	require.NoError(t, CreateSchedule(dbosCtx, testWorkflowForSchedule, CreateScheduleRequest{
+		ScheduleName: "export-test",
+		Schedule:     "0 0 0 * * *", // daily, won't fire during the test
+	}))
+	t.Cleanup(func() { _ = DeleteSchedule(dbosCtx, "export-test") })
+
+	handle, err := TriggerSchedule(dbosCtx, "export-test")
+	require.NoError(t, err)
+	_, err = handle.GetResult()
+	require.NoError(t, err)
+	workflowID := handle.GetWorkflowID()
+
+	original, err := ListWorkflows(dbosCtx, WithWorkflowIDs([]string{workflowID}))
+	require.NoError(t, err)
+	require.Len(t, original, 1)
+	require.Equal(t, "export-test", original[0].ScheduleName)
+
+	// Export, delete, then reimport: schedule_name must survive the round-trip.
+	sdb := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+	exported, err := sdb.exportWorkflow(dbosCtx, workflowID, true)
+	require.NoError(t, err)
+	require.NoError(t, DeleteWorkflows(dbosCtx, []string{workflowID}))
+	gone, err := ListWorkflows(dbosCtx, WithWorkflowIDs([]string{workflowID}))
+	require.NoError(t, err)
+	require.Empty(t, gone)
+
+	require.NoError(t, sdb.importWorkflow(dbosCtx, exported))
+	imported, err := ListWorkflows(dbosCtx, WithWorkflowIDs([]string{workflowID}))
+	require.NoError(t, err)
+	require.Len(t, imported, 1)
+	require.Equal(t, "export-test", imported[0].ScheduleName)
+
+	// The reimported run is still found by the schedule name filter.
+	byName, err := ListWorkflows(dbosCtx, WithFilterScheduleName("export-test"))
+	require.NoError(t, err)
+	require.Len(t, byName, 1)
+	require.Equal(t, workflowID, byName[0].ID)
+}

--- a/dbos/schedule_test.go
+++ b/dbos/schedule_test.go
@@ -1,6 +1,7 @@
 package dbos
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -873,4 +874,48 @@ func TestScheduleNameSurvivesExportImport(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, byName, 1)
 	require.Equal(t, workflowID, byName[0].ID)
+}
+
+// A schedule can fire on an executor that does not have the target workflow
+// registered: the tick enqueues by name and name resolution happens at dequeue
+// time on a worker that has the function.
+func TestScheduleFiresWithoutLocalRegistration(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true, schedulerPollingInterval: 100 * time.Millisecond})
+	defer dbosCtx.Shutdown(10 * time.Second)
+	require.NoError(t, dbosCtx.Launch())
+
+	client, err := NewClient(context.Background(), ClientConfig{DatabaseURL: backendDatabaseURL(t)})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Shutdown(30 * time.Second) })
+
+	const scheduleName = "unregistered-workflow-schedule"
+	const workflowName = "workflowRegisteredOnAnotherWorker"
+	const queueName = "queue-listened-elsewhere"
+	require.NoError(t, client.CreateSchedule(ClientScheduleInput{
+		ScheduleName: scheduleName,
+		WorkflowName: workflowName,
+		Schedule:     "*/1 * * * * *",
+		QueueName:    queueName,
+	}))
+	t.Cleanup(func() { _ = client.DeleteSchedule(scheduleName) })
+
+	var enqueued WorkflowStatus
+	require.Eventually(t, func() bool {
+		wfs, err := ListWorkflows(dbosCtx, WithWorkflowIDPrefix("sched-"+scheduleName+"-"))
+		if err != nil || len(wfs) == 0 {
+			return false
+		}
+		enqueued = wfs[0]
+		return true
+	}, 15*time.Second, 100*time.Millisecond, "tick should enqueue even though the workflow is not registered locally")
+
+	require.Equal(t, workflowName, enqueued.Name)
+	require.Equal(t, queueName, enqueued.QueueName)
+	require.Equal(t, scheduleName, enqueued.ScheduleName)
+	require.Equal(t, WorkflowStatusEnqueued, enqueued.Status)
+
+	sched, err := client.GetSchedule(scheduleName)
+	require.NoError(t, err)
+	require.NotNil(t, sched)
+	require.NotNil(t, sched.LastFiredAt, "last_fired_at should be updated after the tick")
 }

--- a/dbos/schedule_test.go
+++ b/dbos/schedule_test.go
@@ -572,6 +572,47 @@ func TestTriggerSchedule(t *testing.T) {
 	require.Equal(t, ctxValue, got.Context, "Context should match the schedule's configured context")
 	require.False(t, got.ScheduledTime.Before(beforeTrigger.Add(-time.Second)), "ScheduledTime should be at or after the trigger call")
 	require.False(t, got.ScheduledTime.After(afterTrigger.Add(time.Second)), "ScheduledTime should be at or before the trigger call returns")
+
+	// A second schedule sharing the same workflow function: ScheduleName is what
+	// distinguishes their runs, since both have the same workflow name.
+	err = CreateSchedule(dbosCtx, testCapturingScheduledWorkflow, CreateScheduleRequest{
+		ScheduleName: "trigger-schedule-b",
+		Schedule:     "0 0 * * * *",
+	}, WithScheduleContext(ctxValue))
+	require.NoError(t, err)
+	handleB, err := TriggerSchedule(dbosCtx, "trigger-schedule-b")
+	require.NoError(t, err)
+	_, err = handleB.GetResult()
+	require.NoError(t, err)
+
+	// Filter by a single schedule name: contains that schedule's run, tagged with
+	// its name, and excludes the other schedule's run. (Assert on membership, not
+	// exact counts, so a cron tick firing mid-test cannot flake the assertions.)
+	runsA, err := ListWorkflows(dbosCtx, WithFilterScheduleName("trigger-schedule"))
+	require.NoError(t, err)
+	idsA := make(map[string]bool, len(runsA))
+	for _, wf := range runsA {
+		require.Equal(t, "trigger-schedule", wf.ScheduleName)
+		idsA[wf.ID] = true
+	}
+	require.True(t, idsA[workflowID], "triggered run should match its schedule name filter")
+	require.False(t, idsA[handleB.GetWorkflowID()], "other schedule's run must not match")
+
+	// Filter by a list of schedule names matches runs from both.
+	runsBoth, err := ListWorkflows(dbosCtx, WithFilterScheduleName("trigger-schedule", "trigger-schedule-b"))
+	require.NoError(t, err)
+	idsBoth := make(map[string]bool, len(runsBoth))
+	for _, wf := range runsBoth {
+		require.Contains(t, []string{"trigger-schedule", "trigger-schedule-b"}, wf.ScheduleName)
+		idsBoth[wf.ID] = true
+	}
+	require.True(t, idsBoth[workflowID])
+	require.True(t, idsBoth[handleB.GetWorkflowID()])
+
+	// A schedule name that produced no runs returns nothing.
+	neverFired, err := ListWorkflows(dbosCtx, WithFilterScheduleName("never-fired"))
+	require.NoError(t, err)
+	require.Empty(t, neverFired)
 }
 
 func TestScheduleWithOptions(t *testing.T) {
@@ -786,75 +827,6 @@ func TestScheduleCronTimezone(t *testing.T) {
 	require.Equal(t, 2025, next.Year())
 	require.Equal(t, time.January, next.Month())
 	require.Equal(t, 15, next.Day())
-}
-
-func testManualWorkflowForScheduleName(ctx DBOSContext, input string) (string, error) {
-	return "manual", nil
-}
-
-func TestListWorkflowsByScheduleName(t *testing.T) {
-	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true, schedulerPollingInterval: 100 * time.Millisecond})
-	defer dbosCtx.Shutdown(10 * time.Second)
-
-	RegisterWorkflow(dbosCtx, testWorkflowForSchedule)
-	RegisterWorkflow(dbosCtx, testManualWorkflowForScheduleName)
-
-	require.NoError(t, dbosCtx.Launch())
-
-	// A directly-invoked workflow has no schedule name and is not returned by
-	// the schedule name filter.
-	manualHandle, err := RunWorkflow(dbosCtx, testManualWorkflowForScheduleName, "input")
-	require.NoError(t, err)
-	manualResult, err := manualHandle.GetResult()
-	require.NoError(t, err)
-	require.Equal(t, "manual", manualResult)
-	manualStatus, err := ListWorkflows(dbosCtx, WithWorkflowIDs([]string{manualHandle.GetWorkflowID()}))
-	require.NoError(t, err)
-	require.Len(t, manualStatus, 1)
-	require.Empty(t, manualStatus[0].ScheduleName)
-
-	// Two distinct schedules sharing the same workflow function: ScheduleName is
-	// what distinguishes their runs, since both have the same workflow name.
-	for _, name := range []string{"search-a", "search-b"} {
-		require.NoError(t, CreateSchedule(dbosCtx, testWorkflowForSchedule, CreateScheduleRequest{
-			ScheduleName: name,
-			Schedule:     "0 0 0 * * *", // daily, won't fire during the test
-		}))
-		t.Cleanup(func() { _ = DeleteSchedule(dbosCtx, name) })
-	}
-
-	handleA, err := TriggerSchedule(dbosCtx, "search-a")
-	require.NoError(t, err)
-	handleB, err := TriggerSchedule(dbosCtx, "search-b")
-	require.NoError(t, err)
-	_, err = handleA.GetResult()
-	require.NoError(t, err)
-	_, err = handleB.GetResult()
-	require.NoError(t, err)
-
-	// Filter by a single schedule name
-	runsA, err := ListWorkflows(dbosCtx, WithFilterScheduleName("search-a"))
-	require.NoError(t, err)
-	require.Len(t, runsA, 1)
-	require.Equal(t, handleA.GetWorkflowID(), runsA[0].ID)
-	require.Equal(t, "search-a", runsA[0].ScheduleName)
-
-	// Filter by a list of schedule names
-	runsBoth, err := ListWorkflows(dbosCtx, WithFilterScheduleName("search-a", "search-b"))
-	require.NoError(t, err)
-	require.Len(t, runsBoth, 2)
-	gotIDs := make(map[string]bool, len(runsBoth))
-	for _, wf := range runsBoth {
-		gotIDs[wf.ID] = true
-		require.Contains(t, []string{"search-a", "search-b"}, wf.ScheduleName)
-	}
-	require.True(t, gotIDs[handleA.GetWorkflowID()])
-	require.True(t, gotIDs[handleB.GetWorkflowID()])
-
-	// A schedule name that produced no runs returns nothing
-	neverFired, err := ListWorkflows(dbosCtx, WithFilterScheduleName("never-fired"))
-	require.NoError(t, err)
-	require.Empty(t, neverFired)
 }
 
 func TestScheduleNameSurvivesExportImport(t *testing.T) {

--- a/dbos/scheduler.go
+++ b/dbos/scheduler.go
@@ -137,22 +137,14 @@ func (c *dbosContext) addScheduleCronEntry(
 	return assigned, nil
 }
 
-// wraps the registry's type-erased workflow wrapper into a ScheduledWorkflowFunc
-// that also checks if the schedule already fired for this interval
-func (c *dbosContext) buildDBScheduleFunc(schedule WorkflowSchedule) (ScheduledWorkflowFunc, error) {
-	fqn, ok := c.workflowCustomNametoFQN.Load(schedule.WorkflowName)
-	if !ok {
-		return nil, fmt.Errorf("workflow not found: %s", schedule.WorkflowName)
+// buildDBScheduleFunc returns a ScheduledWorkflowFunc that enqueues the
+// schedule's workflow by name, client-style. The workflow does not need to be
+// registered on this executor: name -> FQN resolution happens at dequeue time
+// on a worker that has the function.
+func (c *dbosContext) buildDBScheduleFunc(schedule WorkflowSchedule) ScheduledWorkflowFunc {
+	if _, ok := c.workflowCustomNametoFQN.Load(schedule.WorkflowName); !ok {
+		c.logger.Debug("scheduled workflow not registered on this executor; ticks will enqueue by name", "schedule", schedule.ScheduleName, "workflow", schedule.WorkflowName)
 	}
-	value, ok := c.workflowRegistry.Load(fqn)
-	if !ok {
-		return nil, fmt.Errorf("workflow not found: %s", schedule.WorkflowName)
-	}
-	entry, ok := value.(WorkflowRegistryEntry)
-	if !ok {
-		return nil, fmt.Errorf("invalid workflow registry entry for: %s", schedule.WorkflowName)
-	}
-	wrappedFn := entry.wrappedFunction
 	scheduleName := schedule.ScheduleName
 	queueName := schedule.QueueName
 	if queueName == "" {
@@ -175,47 +167,67 @@ func (c *dbosContext) buildDBScheduleFunc(schedule WorkflowSchedule) (ScheduledW
 			return nil, nil
 		}
 
-		// The registry wrapper expects encoded inputs, so encode the ScheduledWorkflowInput, using the DBOS Context serializer, before invoking it.
 		ser := resolveEncoder(ctx)
 		encodedInput, err := ser.Encode(input)
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode scheduled workflow input: %w", err)
 		}
 
-		opts := []WorkflowOption{
-			WithWorkflowID(wfID),
-			WithQueue(queueName),
-			withWorkflowName(entry.FQN),
-			withScheduleName(scheduleName),
-		}
 		// Scheduled workflows always run against the latest registered application version, so a stale executor does not pick them up after a new deploy.
+		// If lookup fails, leave the version unset: NULL rows are only dequeued by executors on the latest version.
+		var appVersion string
 		latest, err := retryWithResult(c, func() (*VersionInfo, error) {
 			return c.systemDB.getLatestApplicationVersion(c, nil)
 		}, withRetrierLogger(c.logger))
 		if err != nil {
 			c.logger.Error("failed to fetch latest application version for scheduled workflow", "schedule", scheduleName, "workflow_id", wfID, "error", err)
 		} else if latest != nil {
-			opts = append(opts, WithApplicationVersion(latest.Name))
+			appVersion = latest.Name
 		}
-		result, runErr := wrappedFn(ctx, encodedInput, ser.Name(), opts...)
+
+		status := WorkflowStatus{
+			Name:               schedule.WorkflowName,
+			ClassName:          schedule.WorkflowClassName,
+			ApplicationVersion: appVersion,
+			ApplicationID:      c.GetApplicationID(),
+			ExecutorID:         c.GetExecutorID(),
+			Status:             WorkflowStatusEnqueued,
+			ID:                 wfID,
+			CreatedAt:          time.Now(),
+			Input:              encodedInput,
+			QueueName:          queueName,
+			Serialization:      ser.Name(),
+			ScheduleName:       scheduleName,
+		}
 
 		uncancellableCtx := WithoutCancel(c)
+		if err := retry(c, func() error {
+			tx, err := c.systemDB.(*sysDB).pool.BeginTx(uncancellableCtx, TxOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to begin transaction: %w", err)
+			}
+			defer tx.Rollback(uncancellableCtx)
+			if _, err := c.systemDB.insertWorkflowStatus(uncancellableCtx, insertWorkflowStatusDBInput{status: status, tx: tx}); err != nil {
+				return err
+			}
+			return tx.Commit(uncancellableCtx)
+		}, withRetrierLogger(c.logger)); err != nil {
+			c.logger.Error("failed to enqueue scheduled workflow", "schedule", scheduleName, "workflow_id", wfID, "error", err)
+			return nil, err
+		}
+
 		if err := retry(c, func() error {
 			return c.systemDB.updateScheduleLastFiredAt(uncancellableCtx, scheduleName, time.Now())
 		}, withRetrierLogger(c.logger)); err != nil {
 			c.logger.Error("failed to update schedule last fired time after retries", "schedule", scheduleName, "error", err)
 		}
 
-		return result, runErr
-	}, nil
+		return nil, nil
+	}
 }
 
 func (c *dbosContext) addDBScheduleToScheduler(schedule WorkflowSchedule) {
-	fn, err := c.buildDBScheduleFunc(schedule)
-	if err != nil {
-		c.logger.Error("failed to get workflow for schedule", "schedule", schedule.ScheduleName, "error", err)
-		return
-	}
+	fn := c.buildDBScheduleFunc(schedule)
 
 	spec := schedule.Schedule
 	if schedule.CronTimezone != "" {

--- a/dbos/scheduler.go
+++ b/dbos/scheduler.go
@@ -186,6 +186,7 @@ func (c *dbosContext) buildDBScheduleFunc(schedule WorkflowSchedule) (ScheduledW
 			WithWorkflowID(wfID),
 			WithQueue(queueName),
 			withWorkflowName(entry.FQN),
+			withScheduleName(scheduleName),
 		}
 		// Scheduled workflows always run against the latest registered application version, so a stale executor does not pick them up after a new deploy.
 		latest, err := retryWithResult(c, func() (*VersionInfo, error) {

--- a/dbos/sqlite_migrations.go
+++ b/dbos/sqlite_migrations.go
@@ -122,6 +122,9 @@ var sqliteMigration37SQL string
 //go:embed migrations/sqlite/40_add_attributes.sql
 var sqliteMigration40SQL string
 
+//go:embed migrations/sqlite/41_add_schedule_name.sql
+var sqliteMigration41SQL string
+
 // buildSqliteMigrations returns the SQLite migration list. Versions mirror pg
 // numbering (matching Python's sqlite_migrations); pg migrations 10, 14, 20,
 // 38, and 39 have no SQLite counterpart and are omitted.
@@ -162,6 +165,7 @@ func buildSqliteMigrations() []migrationFile {
 		{version: 36, sql: sqliteMigration36SQL},
 		{version: 37, sql: sqliteMigration37SQL},
 		{version: 40, sql: sqliteMigration40SQL},
+		{version: 41, sql: sqliteMigration41SQL},
 	}
 }
 

--- a/dbos/sqlite_pool.go
+++ b/dbos/sqlite_pool.go
@@ -166,10 +166,8 @@ func newSqliteSystemDatabase(
 	return &sysDB{
 		pool:                          newSQLPool(db),
 		dialect:                       sqliteDialect{},
-		workflowNotificationsMap:      &sync.Map{},
-		workflowNotificationRepollMap: &sync.Map{},
-		workflowEventsMap:             &sync.Map{},
-		workflowEventsRepollMap:       &sync.Map{},
+		recvNotifier:                  newNotifyRegistry(),
+		eventNotifier:                 newNotifyRegistry(),
 		streamsMap:                    &sync.Map{},
 		notificationLoopDone:          make(chan struct{}),
 		logger:                        logger.With("service", "system_database"),

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -320,6 +320,9 @@ var migration39SQL string
 //go:embed migrations/40_add_attributes.sql
 var migration40SQL string
 
+//go:embed migrations/41_add_schedule_name.sql
+var migration41SQL string
+
 type migrationFile struct {
 	version int64
 	sql     string
@@ -444,6 +447,7 @@ func buildMigrations(schema string, isCockroach bool) []migrationFile {
 		{version: 38, sql: migration38SQLProcessed},
 		{version: 39, sql: migration39SQLProcessed},
 		{version: 40, sql: fmt.Sprintf(migration40SQL, sanitizedSchema, sanitizedSchema)},
+		{version: 41, sql: fmt.Sprintf(migration41SQL, sanitizedSchema, sanitizedSchema)},
 	}
 }
 
@@ -998,6 +1002,11 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
 		attributesJSON = &attributesStr
 	}
 
+	var scheduleName *string
+	if len(input.status.ScheduleName) > 0 {
+		scheduleName = &input.status.ScheduleName
+	}
+
 	query := s.renderSQL(`INSERT INTO %sworkflow_status (
         workflow_uuid,
         status,
@@ -1024,17 +1033,18 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
         config_name,
         serialization,
         delay_until_epoch_ms,
-        attributes
-    ) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
+        attributes,
+        schedule_name
+    ) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
     ON CONFLICT (workflow_uuid)
         DO UPDATE SET
 			recovery_attempts = CASE
-                WHEN EXCLUDED.status NOT IN ($27, $28) THEN workflow_status.recovery_attempts + $29
+                WHEN EXCLUDED.status NOT IN ($28, $29) THEN workflow_status.recovery_attempts + $30
                 ELSE workflow_status.recovery_attempts
             END,
             updated_at = EXCLUDED.updated_at,
             executor_id = CASE
-                WHEN EXCLUDED.status IN ($27, $28) THEN workflow_status.executor_id
+                WHEN EXCLUDED.status IN ($28, $29) THEN workflow_status.executor_id
                 ELSE EXCLUDED.executor_id
             END
         RETURNING recovery_attempts, status, name, queue_name, queue_partition_key, workflow_timeout_ms, workflow_deadline_epoch_ms, owner_xid`, s.dialect.SchemaPrefix(s.schema))
@@ -1082,6 +1092,7 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
 		input.status.Serialization,
 		delayUntilEpochMs,
 		attributesJSON,
+		scheduleName,
 		WorkflowStatusEnqueued,
 		WorkflowStatusDelayed,
 		recoveryIncrement,
@@ -1180,6 +1191,7 @@ type listWorkflowsDBInput struct {
 	wasForkedFrom      *bool
 	hasParent          *bool
 	attributes         map[string]any
+	scheduleName       []string
 	limit              *int
 	offset             *int
 	sortDesc           bool
@@ -1199,7 +1211,7 @@ func (s *sysDB) listWorkflows(ctx context.Context, input listWorkflowsDBInput) (
 		"recovery_attempts", "queue_name", "workflow_timeout_ms", "workflow_deadline_epoch_ms", "started_at_epoch_ms",
 		"deduplication_id", "priority", "queue_partition_key", "forked_from", "parent_workflow_id",
 		"serialization", "delay_until_epoch_ms", "was_forked_from", "completed_at", "class_name", "config_name",
-		"attributes",
+		"attributes", "schedule_name",
 	}
 
 	if input.loadOutput {
@@ -1253,6 +1265,9 @@ func (s *sysDB) listWorkflows(ctx context.Context, input listWorkflowsDBInput) (
 	}
 	if len(input.deduplicationID) > 0 {
 		qb.addWhereAny("deduplication_id", input.deduplicationID)
+	}
+	if len(input.scheduleName) > 0 {
+		qb.addWhereAny("schedule_name", input.scheduleName)
 	}
 	if !input.completedAfter.IsZero() {
 		qb.addWhereGreaterEqual("completed_at", input.completedAfter.UnixMilli())
@@ -1361,6 +1376,7 @@ func (s *sysDB) listWorkflows(ctx context.Context, input listWorkflowsDBInput) (
 		var completedAtMs *int64
 		var className *string
 		var attributesJSON *string
+		var scheduleName *string
 
 		// Build scan arguments dynamically based on loaded columns.
 		scanArgs := []any{
@@ -1370,7 +1386,7 @@ func (s *sysDB) listWorkflows(ctx context.Context, input listWorkflowsDBInput) (
 			&wf.Attempts, &queueName, &timeoutMs,
 			&deadlineMs, &startedAtMs, &deduplicationID, &wf.Priority, &queuePartitionKey, &forkedFrom, &parentWorkflowID,
 			&serialization, &delayUntilEpochMs, &wf.WasForkedFrom, &completedAtMs, &className, &wf.ConfigName,
-			&attributesJSON,
+			&attributesJSON, &scheduleName,
 		}
 
 		if input.loadOutput {
@@ -1440,6 +1456,10 @@ func (s *sysDB) listWorkflows(ctx context.Context, input listWorkflowsDBInput) (
 			if err := json.Unmarshal([]byte(*attributesJSON), &wf.Attributes); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal attributes: %w", err)
 			}
+		}
+
+		if scheduleName != nil && len(*scheduleName) > 0 {
+			wf.ScheduleName = *scheduleName
 		}
 
 		// Convert milliseconds to time.Time
@@ -5076,6 +5096,7 @@ func (s *sysDB) backfillSchedule(ctx context.Context, input backfillScheduleDBIn
 			Input:              encodedInput,
 			Serialization:      ser.Name(),
 			ApplicationVersion: backfillAppVersion,
+			ScheduleName:       input.ScheduleName,
 		}
 		if _, err := s.insertWorkflowStatus(ctx, insertWorkflowStatusDBInput{status: status, tx: tx}); err != nil {
 			return nil, fmt.Errorf("failed to enqueue backfill workflow %s: %w", workflowID, err)
@@ -5161,6 +5182,7 @@ func (s *sysDB) triggerSchedule(ctx context.Context, scheduleName string) (strin
 		Input:              encodedInput,
 		Serialization:      ser.Name(),
 		ApplicationVersion: triggerAppVersion,
+		ScheduleName:       scheduleName,
 	}
 
 	if _, err := s.insertWorkflowStatus(ctx, insertWorkflowStatusDBInput{status: status, tx: tx}); err != nil {
@@ -5641,7 +5663,7 @@ func (s *sysDB) exportWorkflow(ctx context.Context, workflowID string, exportChi
 				class_name, config_name, recovery_attempts, queue_name, workflow_timeout_ms,
 				workflow_deadline_epoch_ms, started_at_epoch_ms, deduplication_id, inputs, priority,
 				queue_partition_key, forked_from, parent_workflow_id, delay_until_epoch_ms, serialization,
-				was_forked_from
+				was_forked_from, rate_limited, completed_at, attributes, schedule_name
 			FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
 
 		row := tx.QueryRow(ctx, statusQuery, wfID)
@@ -5656,7 +5678,9 @@ func (s *sysDB) exportWorkflow(ctx context.Context, workflowID string, exportChi
 			priority                                                     *int
 			delayUntilEpochMs                                            *int64
 			serialization                                                *string
-			wasForkedFrom                                                *bool
+			wasForkedFrom, rateLimited                                   *bool
+			completedAt                                                  *int64
+			attributes, wfScheduleName                                   *string
 		)
 		err := row.Scan(
 			&wfUUID, &status, &name, &authUser, &assumedRole, &authRoles,
@@ -5664,7 +5688,7 @@ func (s *sysDB) exportWorkflow(ctx context.Context, workflowID string, exportChi
 			&className, &configName, &recoveryAttempts, &queueName, &workflowTimeoutMs,
 			&workflowDeadlineEpochMs, &startedAtEpochMs, &dedupID, &inputs, &priority,
 			&queuePartitionKey, &forkedFrom, &parentWorkflowID, &delayUntilEpochMs, &serialization,
-			&wasForkedFrom,
+			&wasForkedFrom, &rateLimited, &completedAt, &attributes, &wfScheduleName,
 		)
 		if err != nil {
 			if err == pgx.ErrNoRows {
@@ -5703,6 +5727,10 @@ func (s *sysDB) exportWorkflow(ctx context.Context, workflowID string, exportChi
 			"delay_until_epoch_ms":       delayUntilEpochMs,
 			"serialization":              serialization,
 			"was_forked_from":            wasForkedFrom,
+			"rate_limited":               rateLimited,
+			"completed_at":               completedAt,
+			"attributes":                 attributes,
+			"schedule_name":              wfScheduleName,
 		}
 
 		// Export operation_outputs
@@ -5875,22 +5903,27 @@ func (s *sysDB) importWorkflow(ctx context.Context, workflows []ExportedWorkflow
 				class_name, config_name, recovery_attempts, queue_name, workflow_timeout_ms,
 				workflow_deadline_epoch_ms, started_at_epoch_ms, deduplication_id, inputs, priority,
 				queue_partition_key, forked_from, parent_workflow_id, delay_until_epoch_ms, serialization,
-				was_forked_from
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29)`,
+				was_forked_from, rate_limited, completed_at, attributes, schedule_name
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33)`,
 			s.dialect.SchemaPrefix(s.schema))
 
-		// was_forked_from is NOT NULL; default it to false for payloads exported
-		// before this field was included (older exports, or ones from an SDK that
-		// omits it), so importing them doesn't violate the constraint.
-		wasForkedFrom := false
-		switch v := status["was_forked_from"].(type) {
-		case bool:
-			wasForkedFrom = v
-		case *bool:
-			if v != nil {
-				wasForkedFrom = *v
+		// was_forked_from and rate_limited are NOT NULL; default them to false
+		// for payloads exported before these fields were included (older exports,
+		// or ones from an SDK that omits them), so importing them doesn't violate
+		// the constraint.
+		boolOrFalse := func(v any) bool {
+			switch b := v.(type) {
+			case bool:
+				return b
+			case *bool:
+				if b != nil {
+					return *b
+				}
 			}
+			return false
 		}
+		wasForkedFrom := boolOrFalse(status["was_forked_from"])
+		rateLimited := boolOrFalse(status["rate_limited"])
 
 		_, err := tx.Exec(ctx, insertStatusQuery,
 			status["workflow_uuid"], status["status"], status["name"],
@@ -5902,6 +5935,7 @@ func (s *sysDB) importWorkflow(ctx context.Context, workflows []ExportedWorkflow
 			status["deduplication_id"], status["inputs"], status["priority"],
 			status["queue_partition_key"], status["forked_from"], status["parent_workflow_id"],
 			status["delay_until_epoch_ms"], status["serialization"], wasForkedFrom,
+			rateLimited, status["completed_at"], status["attributes"], status["schedule_name"],
 		)
 		if err != nil {
 			return fmt.Errorf("failed to import workflow_status: %w", err)

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -132,18 +132,16 @@ type ExportedWorkflow struct {
 }
 
 type sysDB struct {
-	pool                          Pool
-	dialect                       Dialect
-	notificationLoopDone          chan struct{}
-	workflowNotificationsMap      *sync.Map
-	workflowNotificationRepollMap *sync.Map
-	workflowEventsMap             *sync.Map
-	workflowEventsRepollMap       *sync.Map
-	streamsMap                    *sync.Map
-	logger                        *slog.Logger
-	schema                        string
-	launched                      bool
-	isCockroachDB                 bool
+	pool                 Pool
+	dialect              Dialect
+	notificationLoopDone chan struct{}
+	recvNotifier         *notifyRegistry // recv waiters, keyed by "destinationID::topic"
+	eventNotifier        *notifyRegistry // getEvent waiters, keyed by "targetWorkflowID::key"
+	streamsMap           *sync.Map
+	logger               *slog.Logger
+	schema               string
+	launched             bool
+	isCockroachDB        bool
 }
 
 /*******************************/
@@ -845,17 +843,15 @@ func newSystemDatabase(ctx context.Context, inputs newSystemDatabaseInput) (syst
 	}
 
 	return &sysDB{
-		pool:                          newPgxPool(pool),
-		dialect:                       dialect,
-		workflowNotificationsMap:      &sync.Map{},
-		workflowNotificationRepollMap: &sync.Map{},
-		workflowEventsMap:             &sync.Map{},
-		workflowEventsRepollMap:       &sync.Map{},
-		streamsMap:                    &sync.Map{},
-		notificationLoopDone:          make(chan struct{}),
-		logger:                        logger.With("service", "system_database"),
-		schema:                        databaseSchema,
-		isCockroachDB:                 isCockroach,
+		pool:                 newPgxPool(pool),
+		dialect:              dialect,
+		recvNotifier:         newNotifyRegistry(),
+		eventNotifier:        newNotifyRegistry(),
+		streamsMap:           &sync.Map{},
+		notificationLoopDone: make(chan struct{}),
+		logger:               logger.With("service", "system_database"),
+		schema:               databaseSchema,
+		isCockroachDB:        isCockroach,
 	}, nil
 }
 
@@ -902,8 +898,8 @@ func (s *sysDB) shutdown(ctx context.Context, timeout time.Duration) {
 		}
 	}
 
-	s.workflowNotificationsMap.Clear()
-	s.workflowEventsMap.Clear()
+	s.recvNotifier.clear()
+	s.eventNotifier.clear()
 	s.streamsMap.Clear()
 
 	s.launched = false
@@ -3364,17 +3360,10 @@ func (s *sysDB) notificationListenerLoop(ctx context.Context) {
 					time.Sleep(connectionRetryBackoff.delayFor(retryAttempt + 1))
 					retryAttempt++
 				}
-				// The connection is re-aquired. Signal to all waiters they should poll the database for a potentially missed value.
-				s.workflowNotificationRepollMap.Range(func(key, value any) bool {
-					repollChannel := value.(chan struct{})
-					repollChannel <- struct{}{}
-					return true
-				})
-				s.workflowEventsRepollMap.Range(func(key, value any) bool {
-					repollChannel := value.(chan struct{})
-					repollChannel <- struct{}{}
-					return true
-				})
+				// The connection is re-acquired. Wake all waiters so they re-poll the
+				// database for a value whose notification may have been missed.
+				s.recvNotifier.notifyAll()
+				s.eventNotifier.notifyAll()
 				continue
 			}
 			// Other transient errors. Backoff and continue on same conn
@@ -3391,17 +3380,9 @@ func (s *sysDB) notificationListenerLoop(ctx context.Context) {
 
 		switch n.Channel {
 		case _DBOS_NOTIFICATIONS_CHANNEL:
-			if cond, ok := s.workflowNotificationsMap.Load(n.Payload); ok {
-				cond.(*sync.Cond).L.Lock()
-				cond.(*sync.Cond).Broadcast()
-				cond.(*sync.Cond).L.Unlock()
-			}
+			s.recvNotifier.notify(n.Payload)
 		case _DBOS_WORKFLOW_EVENTS_CHANNEL:
-			if cond, ok := s.workflowEventsMap.Load(n.Payload); ok {
-				cond.(*sync.Cond).L.Lock()
-				cond.(*sync.Cond).Broadcast()
-				cond.(*sync.Cond).L.Unlock()
-			}
+			s.eventNotifier.notify(n.Payload)
 		case _DBOS_STREAMS_CHANNEL:
 			if ch, ok := s.streamsMap.Load(n.Payload); ok {
 				select {
@@ -3438,17 +3419,12 @@ func (s *sysDB) notificationPollerLoop(ctx context.Context) {
 
 func (s *sysDB) pollNotifications(ctx context.Context) {
 	// Iterate through all registered notification payloads
-	s.workflowNotificationsMap.Range(func(key, value any) bool {
-		payload, ok := key.(string)
-		if !ok {
-			return true // Continue to next item
-		}
-
+	for _, payload := range s.recvNotifier.payloads() {
 		// Parse payload: format is "destinationID::topic"
 		parts := strings.SplitN(payload, "::", 2)
 		if len(parts) != 2 {
 			s.logger.Warn("Invalid notification payload format", "payload", payload)
-			return true // Continue to next item
+			continue
 		}
 
 		destinationID := parts[0]
@@ -3460,35 +3436,24 @@ func (s *sysDB) pollNotifications(ctx context.Context) {
 		err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&exists)
 		if err != nil {
 			s.logger.Warn("Failed to poll notification", "payload", payload, "error", err)
-			return true // Continue to next item
+			continue
 		}
 
-		// If notification exists, signal the condition variable
+		// If a notification exists, wake the waiters so they re-check.
 		if exists {
-			if cond, ok := value.(*sync.Cond); ok {
-				cond.L.Lock()
-				cond.Broadcast()
-				cond.L.Unlock()
-			}
+			s.recvNotifier.notify(payload)
 		}
-
-		return true // Continue to next item
-	})
+	}
 }
 
 func (s *sysDB) pollEvents(ctx context.Context) {
 	// Iterate through all registered event payloads
-	s.workflowEventsMap.Range(func(key, value any) bool {
-		payload, ok := key.(string)
-		if !ok {
-			return true // Continue to next item
-		}
-
+	for _, payload := range s.eventNotifier.payloads() {
 		// Parse payload: format is "targetWorkflowID::key"
 		parts := strings.SplitN(payload, "::", 2)
 		if len(parts) != 2 {
 			s.logger.Warn("Invalid event payload format", "payload", payload)
-			return true // Continue to next item
+			continue
 		}
 
 		targetWorkflowID := parts[0]
@@ -3500,20 +3465,14 @@ func (s *sysDB) pollEvents(ctx context.Context) {
 		err := s.pool.QueryRow(ctx, query, targetWorkflowID, eventKey).Scan(&exists)
 		if err != nil {
 			s.logger.Warn("Failed to poll event", "payload", payload, "error", err)
-			return true // Continue to next item
+			continue
 		}
 
-		// If event exists, signal the condition variable
+		// If the event exists, wake the waiters so they re-check.
 		if exists {
-			if cond, ok := value.(*sync.Cond); ok {
-				cond.L.Lock()
-				cond.Broadcast()
-				cond.L.Unlock()
-			}
+			s.eventNotifier.notify(payload)
 		}
-
-		return true // Continue to next item
-	})
+	}
 }
 
 const _DBOS_NULL_TOPIC = "__null__topic__"
@@ -3567,98 +3526,158 @@ func (s *sysDB) send(ctx context.Context, input WorkflowSendInput) error {
 	return nil
 }
 
+// notifier delivers per-payload wake-ups to notification waiters (recv and
+// getEvent).
+type notifyRegistry struct {
+	mu   sync.Mutex
+	subs map[string]map[chan struct{}]struct{} // payload -> set of waiter channels
+}
+
+func newNotifyRegistry() *notifyRegistry {
+	return &notifyRegistry{subs: make(map[string]map[chan struct{}]struct{})}
+}
+
+func (n *notifyRegistry) addLocked(payload string, ch chan struct{}) {
+	set := n.subs[payload]
+	if set == nil {
+		set = make(map[chan struct{}]struct{})
+		n.subs[payload] = set
+	}
+	set[ch] = struct{}{}
+}
+
+// subscribe registers a new waiter for payload and returns its wake channel.
+func (n *notifyRegistry) subscribe(payload string) chan struct{} {
+	ch := make(chan struct{}, 1)
+	n.mu.Lock()
+	n.addLocked(payload, ch)
+	n.mu.Unlock()
+	return ch
+}
+
+// subscribeExclusive registers the sole waiter for payload, returning false if one
+// already exists.
+func (n *notifyRegistry) subscribeExclusive(payload string) (chan struct{}, bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.subs[payload]) > 0 {
+		return nil, false
+	}
+	ch := make(chan struct{}, 1)
+	n.addLocked(payload, ch)
+	return ch, true
+}
+
+// unsubscribe removes a waiter; the payload entry is dropped once its last waiter leaves.
+func (n *notifyRegistry) unsubscribe(payload string, ch chan struct{}) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	set := n.subs[payload]
+	delete(set, ch)
+	if len(set) == 0 {
+		delete(n.subs, payload)
+	}
+}
+
+// notify wakes every waiter for payload.
+func (n *notifyRegistry) notify(payload string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for ch := range n.subs[payload] {
+		select {
+		case ch <- struct{}{}:
+		default: // Do not block (coalesce multiple notifications into one)
+		}
+	}
+}
+
+// notifyAll wakes every waiter regardless of payload; used after a listener
+// reconnect so waiters re-poll for a value whose notification may have been missed.
+func (n *notifyRegistry) notifyAll() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for _, set := range n.subs {
+		for ch := range set {
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+// payloads returns a snapshot of the currently registered payloads (used by the
+// polling fallback to know which rows to check).
+func (n *notifyRegistry) payloads() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	out := make([]string, 0, len(n.subs))
+	for payload := range n.subs {
+		out = append(out, payload)
+	}
+	return out
+}
+
+// has reports whether any waiter is registered for payload.
+func (n *notifyRegistry) has(payload string) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.subs[payload]) > 0
+}
+
+// clear drops all registrations (used on shutdown).
+func (n *notifyRegistry) clear() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.subs = make(map[string]map[chan struct{}]struct{})
+}
+
 // notificationWaiter tracks a waiter registered for a notification (recv message or workflow event).
 type notificationWaiter struct {
 	pending bool                                   // the awaited row already existed at registration time
 	wait    func(deadline time.Time) (bool, error) // block until the row is pending or the deadline passes; true means timeout
-	release func()                                 // unregister the waiter and wake any waiting goroutine; must be called after the result is read (or on abandonment)
+	release func()                                 // unregister the waiter; must be called after the result is read (or on abandonment)
 }
 
-// notificationWait builds the wait closure shared by recv and getEvent: block until a
-// notification arrives (done closed), the deadline passes (returns true), a repoll
-// signal triggers a recheck of the database, or the context is cancelled.
-func (s *sysDB) notificationWait(ctx context.Context, opName, payload string, exists bool, done <-chan struct{}, repollChannel chan struct{}, recheck func() (bool, error)) func(deadline time.Time) (bool, error) {
+func (s *sysDB) notificationWait(ctx context.Context, opName, payload string, ch <-chan struct{}, recheck func() (bool, error)) func(deadline time.Time) (bool, error) {
 	return func(deadline time.Time) (bool, error) {
-		found := exists
-		for !found {
-			select {
-			case <-done:
+		for {
+			found, err := recheck()
+			if err != nil {
+				return false, err
+			}
+			if found {
 				return false, nil
+			}
+			select {
+			case <-ch:
+				// A notification or reconnect repoll fired; loop and re-check.
 			case <-time.After(max(0, time.Until(deadline))):
 				s.logger.Warn(opName+" timeout reached", "payload", payload, "deadline", deadline)
 				return true, nil
-			case <-repollChannel:
-				s.logger.Warn(opName+" polling after repoll channel signal", "payload", payload)
-				// We were instructed to poll again because the connection was disconnected
-				var err error
-				if found, err = recheck(); err != nil {
-					return false, err
-				}
-				// Restart at the beginning of the loop. If the value was found, we'll exit the loop and proceed to reading the value.
-				continue
 			case <-ctx.Done():
 				s.logger.Warn(opName+" context cancelled", "payload", payload, "cause", context.Cause(ctx))
 				return false, ctx.Err()
 			}
 		}
-		return false, nil
 	}
 }
 
 // startRecvListener registers the calling workflow as the sole receiver for
 // (destinationID, topic) and checks whether a message is already pending.
 func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic string) (*notificationWaiter, error) {
-	// First check if there's already a receiver for this workflow/topic to avoid unnecessary database load
+	// A destination/topic may have only one receiver at a time.
 	payload := fmt.Sprintf("%s::%s", destinationID, topic)
-	cond := sync.NewCond(&sync.Mutex{})
-	cond.L.Lock()
-	_, loaded := s.workflowNotificationsMap.LoadOrStore(payload, cond)
-	if loaded {
-		cond.L.Unlock()
+	ch, ok := s.recvNotifier.subscribeExclusive(payload)
+	if !ok {
 		s.logger.Error("Receive already called for workflow", "destination_id", destinationID)
 		return nil, newWorkflowConflictIDError(destinationID)
 	}
-	repollChannel := make(chan struct{}, 1)
-	s.workflowNotificationRepollMap.LoadOrStore(payload, repollChannel)
-	release := func() {
-		// Clean up the condition variable and broadcast to wake up any waiting goroutines.
-		cond.L.Lock()
-		cond.Broadcast()
-		cond.L.Unlock()
-		s.workflowNotificationsMap.Delete(payload)
-		s.workflowNotificationRepollMap.Delete(payload)
-	}
+	release := func() { s.recvNotifier.unsubscribe(payload, ch) }
 
-	// Now check if there is already an unconsumed message available in the database.
-	// If not, the caller will wait for a notification or its deadline.
+	// recheck reports whether an unconsumed message is pending; it is used both for
+	// the initial "already pending?" probe and by the wait loop after each wake.
 	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %snotifications WHERE destination_uuid = $1 AND topic = $2 AND consumed = false)`, s.dialect.SchemaPrefix(s.schema))
-	exists, err := retryWithResult(ctx, func() (bool, error) {
-		var e bool
-		if err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&e); err != nil {
-			return false, fmt.Errorf("failed to check message: %w", err)
-		}
-		return e, nil
-	}, withRetrierLogger(s.logger))
-	if err != nil {
-		cond.L.Unlock()
-		release()
-		return nil, err
-	}
-
-	// Create the waiting goroutine once (only if !exists, so we don't attempt to unlock twice)
-	done := make(chan struct{})
-	if !exists {
-		go func() {
-			// This is the only place we unlock the condition variable if the value did not exist
-			// Because of the Broadcast in release, we'll eventually hit this before the caller returns
-			defer cond.L.Unlock()
-			cond.Wait()
-			close(done)
-		}()
-	} else {
-		cond.L.Unlock()
-	}
-
 	recheck := func() (bool, error) {
 		return retryWithResult(ctx, func() (bool, error) {
 			var found bool
@@ -3668,7 +3687,12 @@ func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic stri
 			return found, nil
 		}, withRetrierLogger(s.logger))
 	}
-	wait := s.notificationWait(ctx, "Recv()", payload, exists, done, repollChannel, recheck)
+	exists, err := recheck()
+	if err != nil {
+		release()
+		return nil, err
+	}
+	wait := s.notificationWait(ctx, "Recv()", payload, ch, recheck)
 
 	return &notificationWaiter{pending: exists, wait: wait, release: release}, nil
 }
@@ -3746,70 +3770,15 @@ func (s *sysDB) setEvent(ctx context.Context, input WorkflowSetEventInput) error
 
 // startEventListener registers the caller as a waiter for the (targetWorkflowID, key)
 // event and checks whether the event is already set. Unlike recv, multiple waiters
-// may listen for the same event and share its condition variable.
+// may listen for the same event; they share one reference-counted notify hub.
 func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key string) (*notificationWaiter, error) {
 	payload := fmt.Sprintf("%s::%s", targetWorkflowID, key)
-	cond := sync.NewCond(&sync.Mutex{})
-	cond.L.Lock()
-	existingCond, loaded := s.workflowEventsMap.LoadOrStore(payload, cond)
-	if loaded {
-		// Reuse the existing condition variable
-		cond.L.Unlock()
-		ec, ok := existingCond.(*sync.Cond)
-		if !ok {
-			return nil, fmt.Errorf("workflow events map holds unexpected %T for %s", existingCond, payload)
-		}
-		cond = ec
-		cond.L.Lock()
-	}
-	release := func() {
-		// Clean up the condition variable and broadcast to wake up any waiting goroutines.
-		cond.L.Lock()
-		cond.Broadcast()
-		cond.L.Unlock()
-		s.workflowEventsMap.Delete(payload)
-		s.workflowEventsRepollMap.Delete(payload)
-	}
-	repollChannel := make(chan struct{}, 1)
-	existingRepoll, _ := s.workflowEventsRepollMap.LoadOrStore(payload, repollChannel)
-	rc, ok := existingRepoll.(chan struct{})
-	if !ok {
-		cond.L.Unlock()
-		release()
-		return nil, fmt.Errorf("workflow events repoll map holds unexpected %T for %s", existingRepoll, payload)
-	}
-	repollChannel = rc
+	ch := s.eventNotifier.subscribe(payload)
+	release := func() { s.eventNotifier.unsubscribe(payload, ch) }
 
-	// Now check if the event already exists in the database.
-	// If not, the caller will wait for a notification or its deadline.
+	// recheck reports whether the event is set; it is used both for the initial
+	// "already set?" probe and by the wait loop after each wake.
 	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %sworkflow_events WHERE workflow_uuid = $1 AND key = $2)`, s.dialect.SchemaPrefix(s.schema))
-	exists, err := retryWithResult(ctx, func() (bool, error) {
-		var e bool
-		if err := s.pool.QueryRow(ctx, query, targetWorkflowID, key).Scan(&e); err != nil {
-			return false, fmt.Errorf("failed to check event: %w", err)
-		}
-		return e, nil
-	}, withRetrierLogger(s.logger))
-	if err != nil {
-		cond.L.Unlock()
-		release()
-		return nil, err
-	}
-
-	// Create the waiting goroutine once (only if !exists, so we don't attempt to unlock twice)
-	done := make(chan struct{})
-	if !exists {
-		go func() {
-			// This is the only place we unlock the condition variable if the value did not exist
-			// Because of the Broadcast in release, we'll eventually hit this before the caller returns
-			defer cond.L.Unlock()
-			cond.Wait()
-			close(done)
-		}()
-	} else {
-		cond.L.Unlock()
-	}
-
 	recheck := func() (bool, error) {
 		return retryWithResult(ctx, func() (bool, error) {
 			var found bool
@@ -3819,7 +3788,12 @@ func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key st
 			return found, nil
 		}, withRetrierLogger(s.logger))
 	}
-	wait := s.notificationWait(ctx, "GetEvent()", payload, exists, done, repollChannel, recheck)
+	exists, err := recheck()
+	if err != nil {
+		release()
+		return nil, err
+	}
+	wait := s.notificationWait(ctx, "GetEvent()", payload, ch, recheck)
 
 	return &notificationWaiter{pending: exists, wait: wait, release: release}, nil
 }

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -3526,7 +3526,7 @@ func (s *sysDB) send(ctx context.Context, input WorkflowSendInput) error {
 	return nil
 }
 
-// notifier delivers per-payload wake-ups to notification waiters (recv and
+// notifyRegistry delivers per-payload wake-ups to notification waiters (recv and
 // getEvent).
 type notifyRegistry struct {
 	mu   sync.Mutex
@@ -3625,6 +3625,13 @@ func (n *notifyRegistry) has(payload string) bool {
 	return len(n.subs[payload]) > 0
 }
 
+// waiterCount reports the number of waiters registered for payload.
+func (n *notifyRegistry) waiterCount(payload string) int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.subs[payload])
+}
+
 // clear drops all registrations (used on shutdown).
 func (n *notifyRegistry) clear() {
 	n.mu.Lock()
@@ -3639,25 +3646,39 @@ type notificationWaiter struct {
 	release func()                                 // unregister the waiter; must be called after the result is read (or on abandonment)
 }
 
-func (s *sysDB) notificationWait(ctx context.Context, opName, payload string, ch <-chan struct{}, recheck func() (bool, error)) func(deadline time.Time) (bool, error) {
+func (s *sysDB) notificationWait(ctx context.Context, opName, payload string, ch <-chan struct{}, recheck func(context.Context) (bool, error)) func(deadline time.Time) (bool, error) {
 	return func(deadline time.Time) (bool, error) {
+		// The caller has already probed and found nothing; any notify since then is
+		// buffered in ch, so wait for a wake before rechecking. The deadline bounds
+		// recheck's retries so a DB outage cannot block past the timeout.
+		waitCtx, cancel := context.WithDeadline(ctx, deadline)
+		defer cancel()
 		for {
-			found, err := recheck()
+			select {
+			case <-ch:
+				// A notification or reconnect repoll fired; re-check.
+			case <-waitCtx.Done():
+				if err := ctx.Err(); err != nil {
+					s.logger.Warn(opName+" context cancelled", "payload", payload, "cause", context.Cause(ctx))
+					return false, err
+				}
+				s.logger.Warn(opName+" timeout reached", "payload", payload, "deadline", deadline)
+				return true, nil
+			}
+			found, err := recheck(waitCtx)
 			if err != nil {
+				if cerr := ctx.Err(); cerr != nil {
+					s.logger.Warn(opName+" context cancelled", "payload", payload, "cause", context.Cause(ctx))
+					return false, cerr
+				}
+				if waitCtx.Err() != nil {
+					s.logger.Warn(opName+" timeout reached", "payload", payload, "deadline", deadline)
+					return true, nil
+				}
 				return false, err
 			}
 			if found {
 				return false, nil
-			}
-			select {
-			case <-ch:
-				// A notification or reconnect repoll fired; loop and re-check.
-			case <-time.After(max(0, time.Until(deadline))):
-				s.logger.Warn(opName+" timeout reached", "payload", payload, "deadline", deadline)
-				return true, nil
-			case <-ctx.Done():
-				s.logger.Warn(opName+" context cancelled", "payload", payload, "cause", context.Cause(ctx))
-				return false, ctx.Err()
 			}
 		}
 	}
@@ -3678,7 +3699,7 @@ func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic stri
 	// recheck reports whether an unconsumed message is pending; it is used both for
 	// the initial "already pending?" probe and by the wait loop after each wake.
 	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %snotifications WHERE destination_uuid = $1 AND topic = $2 AND consumed = false)`, s.dialect.SchemaPrefix(s.schema))
-	recheck := func() (bool, error) {
+	recheck := func(ctx context.Context) (bool, error) {
 		return retryWithResult(ctx, func() (bool, error) {
 			var found bool
 			if err := s.pool.QueryRow(ctx, query, destinationID, topic).Scan(&found); err != nil {
@@ -3687,7 +3708,7 @@ func (s *sysDB) startRecvListener(ctx context.Context, destinationID, topic stri
 			return found, nil
 		}, withRetrierLogger(s.logger))
 	}
-	exists, err := recheck()
+	exists, err := recheck(ctx)
 	if err != nil {
 		release()
 		return nil, err
@@ -3770,7 +3791,7 @@ func (s *sysDB) setEvent(ctx context.Context, input WorkflowSetEventInput) error
 
 // startEventListener registers the caller as a waiter for the (targetWorkflowID, key)
 // event and checks whether the event is already set. Unlike recv, multiple waiters
-// may listen for the same event; they share one reference-counted notify hub.
+// may listen for the same event.
 func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key string) (*notificationWaiter, error) {
 	payload := fmt.Sprintf("%s::%s", targetWorkflowID, key)
 	ch := s.eventNotifier.subscribe(payload)
@@ -3779,7 +3800,7 @@ func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key st
 	// recheck reports whether the event is set; it is used both for the initial
 	// "already set?" probe and by the wait loop after each wake.
 	query := s.renderSQL(`SELECT EXISTS (SELECT 1 FROM %sworkflow_events WHERE workflow_uuid = $1 AND key = $2)`, s.dialect.SchemaPrefix(s.schema))
-	recheck := func() (bool, error) {
+	recheck := func(ctx context.Context) (bool, error) {
 		return retryWithResult(ctx, func() (bool, error) {
 			var found bool
 			if err := s.pool.QueryRow(ctx, query, targetWorkflowID, key).Scan(&found); err != nil {
@@ -3788,7 +3809,7 @@ func (s *sysDB) startEventListener(ctx context.Context, targetWorkflowID, key st
 			return found, nil
 		}, withRetrierLogger(s.logger))
 	}
-	exists, err := recheck()
+	exists, err := recheck(ctx)
 	if err != nil {
 		release()
 		return nil, err

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -873,7 +873,6 @@ type workflowOptions struct {
 	QueuePartitionKey   string
 	DelayDuration       time.Duration
 	WorkflowAttributes  map[string]any
-	scheduleName        string
 	alreadyEncodedInput bool
 	isDequeue           bool
 	isRecovery          bool
@@ -975,14 +974,6 @@ func withWorkflowName(name string) WorkflowOption {
 		if p.WorkflowName == "" {
 			p.WorkflowName = name
 		}
-	}
-}
-
-// An internal option used by the persistent scheduler to record which named
-// schedule enqueued the workflow.
-func withScheduleName(name string) WorkflowOption {
-	return func(p *workflowOptions) {
-		p.scheduleName = name
 	}
 }
 
@@ -1393,7 +1384,6 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 		QueuePartitionKey:  params.QueuePartitionKey,
 		DelayUntil:         delayUntil,
 		Attributes:         params.WorkflowAttributes,
-		ScheduleName:       params.scheduleName,
 		Serialization: func() string {
 			if params.isPortableWorkflow {
 				return PortableSerializerName

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -4190,22 +4190,69 @@ type ForkWorkflowInput struct {
 	QueuePartitionKey  string // Optional: Partition key when enqueueing the forked workflow onto a partitioned queue
 }
 
+// ForkWorkflowSpec describes a single workflow to fork within a batch.
+// OriginalWorkflowID is required. Other fields are optional.
+type ForkWorkflowSpec struct {
+	OriginalWorkflowID string // Required: The UUID of the original workflow to fork from
+	ForkedWorkflowID   string // Optional: Custom workflow ID for the forked workflow (auto-generated if empty)
+	StartStep          uint   // Optional: Step to start the forked workflow from (default: 0)
+}
+
+// ForkWorkflowsInput holds configuration parameters for forking a batch of
+// workflows in a single database round-trip. Workflows is required. The
+// ApplicationVersion, QueueName, and QueuePartitionKey fields apply to every
+// forked workflow in the batch.
+type ForkWorkflowsInput struct {
+	Workflows          []ForkWorkflowSpec // Required: The workflows to fork
+	ApplicationVersion string             // Optional: Application version for the forked workflows (inherits from originals if empty)
+	QueueName          string             // Optional: Queue to enqueue the forked workflows on (defaults to the internal queue)
+	QueuePartitionKey  string             // Optional: Partition key when enqueueing the forked workflows onto a partitioned queue
+}
+
 func (c *dbosContext) ForkWorkflow(_ DBOSContext, input ForkWorkflowInput) (WorkflowHandle[any], error) {
-	if input.OriginalWorkflowID == "" {
-		return nil, errors.New("original workflow ID cannot be empty")
+	handles, err := c.ForkWorkflows(c, ForkWorkflowsInput{
+		Workflows: []ForkWorkflowSpec{{
+			OriginalWorkflowID: input.OriginalWorkflowID,
+			ForkedWorkflowID:   input.ForkedWorkflowID,
+			StartStep:          input.StartStep,
+		}},
+		ApplicationVersion: input.ApplicationVersion,
+		QueueName:          input.QueueName,
+		QueuePartitionKey:  input.QueuePartitionKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return handles[0], nil
+}
+
+func (c *dbosContext) ForkWorkflows(_ DBOSContext, input ForkWorkflowsInput) ([]WorkflowHandle[any], error) {
+	if len(input.Workflows) == 0 {
+		return nil, errors.New("at least one workflow to fork is required")
 	}
 	if input.QueuePartitionKey != "" && input.QueueName == "" {
 		return nil, errors.New("queue partition key requires a queue name")
 	}
 
-	// Create input for system database
-	if input.StartStep > uint(math.MaxInt) {
-		return nil, fmt.Errorf("start step too large: %d", input.StartStep)
+	// Build the system database input, validating each workflow spec.
+	originalWorkflowIDs := make([]string, len(input.Workflows))
+	forkedWorkflowIDs := make([]string, len(input.Workflows))
+	startSteps := make([]int, len(input.Workflows))
+	for i, wf := range input.Workflows {
+		if wf.OriginalWorkflowID == "" {
+			return nil, errors.New("original workflow ID cannot be empty")
+		}
+		if wf.StartStep > uint(math.MaxInt) {
+			return nil, fmt.Errorf("start step too large: %d", wf.StartStep)
+		}
+		originalWorkflowIDs[i] = wf.OriginalWorkflowID
+		forkedWorkflowIDs[i] = wf.ForkedWorkflowID
+		startSteps[i] = int(wf.StartStep)
 	}
 	dbInput := forkWorkflowsDBInput{
-		originalWorkflowIDs: []string{input.OriginalWorkflowID},
-		forkedWorkflowIDs:   []string{input.ForkedWorkflowID},
-		startSteps:          []int{int(input.StartStep)},
+		originalWorkflowIDs: originalWorkflowIDs,
+		forkedWorkflowIDs:   forkedWorkflowIDs,
+		startSteps:          startSteps,
 		applicationVersion:  input.ApplicationVersion,
 		queueName:           input.QueueName,
 		queuePartitionKey:   input.QueuePartitionKey,
@@ -4214,31 +4261,31 @@ func (c *dbosContext) ForkWorkflow(_ DBOSContext, input ForkWorkflowInput) (Work
 	// Call system database method
 	workflowState, ok := c.Value(workflowStateKey).(*workflowState)
 	isWithinWorkflow := ok && workflowState != nil
-	forkSingle := func(ctx context.Context) (string, error) {
-		forkedWorkflowIDs, err := c.systemDB.forkWorkflows(ctx, dbInput)
-		if err != nil {
-			return "", err
-		}
-		return forkedWorkflowIDs[0], nil
+	forkBatch := func(ctx context.Context) ([]string, error) {
+		return c.systemDB.forkWorkflows(ctx, dbInput)
 	}
-	var forkedWorkflowID string
+	var forkedIDs []string
 	var err error
 	if isWithinWorkflow {
-		forkedWorkflowID, err = runAsTxn(c, func(ctx context.Context, tx Tx) (string, error) {
+		forkedIDs, err = runAsTxn(c, func(ctx context.Context, tx Tx) ([]string, error) {
 			dbInput.tx = tx
-			return forkSingle(ctx)
+			return forkBatch(ctx)
 		}, WithStepName("DBOS.forkWorkflow"))
 	} else {
 		uncancellableCtx := WithoutCancel(c)
-		forkedWorkflowID, err = retryWithResult(c, func() (string, error) {
-			return forkSingle(uncancellableCtx)
+		forkedIDs, err = retryWithResult(c, func() ([]string, error) {
+			return forkBatch(uncancellableCtx)
 		}, withRetrierLogger(c.logger))
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	return newWorkflowPollingHandle[any](c, forkedWorkflowID), nil
+	handles := make([]WorkflowHandle[any], len(forkedIDs))
+	for i, id := range forkedIDs {
+		handles[i] = newWorkflowPollingHandle[any](c, id)
+	}
+	return handles, nil
 }
 
 // ForkWorkflow creates a new workflow instance by copying an existing workflow from a specific step.
@@ -4289,6 +4336,40 @@ func ForkWorkflow[R any](ctx DBOSContext, input ForkWorkflowInput) (WorkflowHand
 		return nil, err
 	}
 	return newWorkflowPollingHandle[R](ctx, handle.GetWorkflowID()), nil
+}
+
+// ForkWorkflows forks a batch of workflows in a single database round-trip.
+// Each forked workflow gets a new UUID (unless a custom ForkedWorkflowID is
+// provided) and executes from its specified StartStep, reusing the operation
+// outputs of steps 0 to StartStep-1 copied from the original workflow.
+//
+// The returned handles are in the same order as input.Workflows.
+//
+// Example usage:
+//
+//	handles, err := dbos.ForkWorkflows[MyResultType](ctx, dbos.ForkWorkflowsInput{
+//	    Workflows: []dbos.ForkWorkflowSpec{
+//	        {OriginalWorkflowID: "wf-1", StartStep: 5},
+//	        {OriginalWorkflowID: "wf-2"},
+//	    },
+//	})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func ForkWorkflows[R any](ctx DBOSContext, input ForkWorkflowsInput) ([]WorkflowHandle[R], error) {
+	if ctx == nil {
+		return nil, errors.New("ctx cannot be nil")
+	}
+
+	handles, err := ctx.ForkWorkflows(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	typedHandles := make([]WorkflowHandle[R], len(handles))
+	for i, handle := range handles {
+		typedHandles[i] = newWorkflowPollingHandle[R](ctx, handle.GetWorkflowID())
+	}
+	return typedHandles, nil
 }
 
 // listWorkflowsOptions holds configuration parameters for listing workflows

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -66,6 +66,7 @@ type WorkflowStatus struct {
 	Serialization      string             `json:"serialization,omitempty"`       // Serialization format used for inputs/outputs (e.g., "DBOS_JSON", "portable_json")
 	DelayUntil         time.Time          `json:"delay_until,omitempty"`         // The time before which the workflow should not be dequeued
 	Attributes         map[string]any     `json:"attributes,omitempty"`          // Custom key-value attributes attached to the workflow at creation
+	ScheduleName       string             `json:"schedule_name,omitempty"`       // Name of the schedule that enqueued this workflow (if any)
 }
 
 // workflowState holds the runtime state for a workflow execution
@@ -872,6 +873,7 @@ type workflowOptions struct {
 	QueuePartitionKey   string
 	DelayDuration       time.Duration
 	WorkflowAttributes  map[string]any
+	scheduleName        string
 	alreadyEncodedInput bool
 	isDequeue           bool
 	isRecovery          bool
@@ -973,6 +975,14 @@ func withWorkflowName(name string) WorkflowOption {
 		if p.WorkflowName == "" {
 			p.WorkflowName = name
 		}
+	}
+}
+
+// An internal option used by the persistent scheduler to record which named
+// schedule enqueued the workflow.
+func withScheduleName(name string) WorkflowOption {
+	return func(p *workflowOptions) {
+		p.scheduleName = name
 	}
 }
 
@@ -1383,6 +1393,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 		QueuePartitionKey:  params.QueuePartitionKey,
 		DelayUntil:         delayUntil,
 		Attributes:         params.WorkflowAttributes,
+		ScheduleName:       params.scheduleName,
 		Serialization: func() string {
 			if params.isPortableWorkflow {
 				return PortableSerializerName
@@ -4318,6 +4329,7 @@ type listWorkflowsOptions struct {
 	wasForkedFrom    *bool
 	hasParent        *bool
 	attributes       map[string]any
+	scheduleName     []string
 }
 
 // ListWorkflowsOption is a functional option for configuring workflow listing parameters.
@@ -4508,6 +4520,14 @@ func WithFilterAttributes(attributes map[string]any) ListWorkflowsOption {
 	}
 }
 
+// WithFilterScheduleName filters workflows by the name(s) of the schedule that
+// enqueued them. Only workflows enqueued by a named schedule match.
+func WithFilterScheduleName(scheduleName ...string) ListWorkflowsOption {
+	return func(p *listWorkflowsOptions) {
+		p.scheduleName = scheduleName
+	}
+}
+
 func (c *dbosContext) ListWorkflows(_ DBOSContext, opts ...ListWorkflowsOption) ([]WorkflowStatus, error) {
 	// Initialize parameters with defaults
 	loadInput := true
@@ -4559,6 +4579,7 @@ func (c *dbosContext) ListWorkflows(_ DBOSContext, opts ...ListWorkflowsOption) 
 		wasForkedFrom:      params.wasForkedFrom,
 		hasParent:          params.hasParent,
 		attributes:         params.attributes,
+		scheduleName:       params.scheduleName,
 	}
 
 	// Call the context method to list workflows

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3731,8 +3731,7 @@ func TestRecvStepConflict(t *testing.T) {
 	// Executor B must actually run the body (register as receiver), not
 	// short-circuit; its separate map confirms a real concurrent execution.
 	require.Eventually(t, func() bool {
-		ok := sysB.recvNotifier.has(payload)
-		return ok
+		return sysB.recvNotifier.has(payload)
 	}, 5*time.Second, 10*time.Millisecond, "executor B (recovery) never ran the body")
 
 	// Deliver the message. Exactly one executor consumes and checkpoints it; the
@@ -4361,8 +4360,7 @@ func TestSetGetEvent(t *testing.T) {
 		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
 		payload := fmt.Sprintf("%s::%s", setWorkflowID, key)
 		require.Eventually(t, func() bool {
-			ok := sysDB.eventNotifier.has(payload)
-			return ok
+			return sysDB.eventNotifier.has(payload)
 		}, 5*time.Second, 10*time.Millisecond, "long waiters never registered")
 
 		// Short waiters register on the same key, then time out and leave.
@@ -4428,8 +4426,7 @@ func TestSetGetEvent(t *testing.T) {
 		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
 		payload := fmt.Sprintf("%s::%s", setWorkflowID, key)
 		require.Eventually(t, func() bool {
-			ok := sysDB.eventNotifier.has(payload)
-			return ok
+			return sysDB.eventNotifier.has(payload)
 		}, 5*time.Second, 10*time.Millisecond, "survivor never registered")
 
 		// A sibling on the same key that gets cancelled while waiting.
@@ -4439,8 +4436,10 @@ func TestSetGetEvent(t *testing.T) {
 			defer close(siblingDone)
 			_, _ = GetEvent[string](cancelCtx, setWorkflowID, key, 30*time.Second)
 		}()
-		// Give the sibling time to register, then cancel it.
-		time.Sleep(200 * time.Millisecond)
+		// Wait until the sibling has actually registered, then cancel it.
+		require.Eventually(t, func() bool {
+			return sysDB.eventNotifier.waiterCount(payload) == 2
+		}, 5*time.Second, 10*time.Millisecond, "sibling never registered")
 		cancel()
 		<-siblingDone
 

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -8762,6 +8762,52 @@ func TestFork(t *testing.T) {
 			awaitForks(forkedIDs)
 		})
 
+		t.Run("PublicAPI", func(t *testing.T) {
+			// Exercise the public batch fork API end-to-end, including a custom
+			// forked ID, mixed start steps, and an auto-generated ID.
+			customID := "public-forked-" + uuid.NewString()
+			handles, err := ForkWorkflows[int](dbosCtx, ForkWorkflowsInput{
+				Workflows: []ForkWorkflowSpec{
+					{OriginalWorkflowID: originalIDs[0], ForkedWorkflowID: customID, StartStep: 2},
+					{OriginalWorkflowID: originalIDs[1], StartStep: 1},
+					{OriginalWorkflowID: originalIDs[2]},
+				},
+			})
+			require.NoError(t, err)
+			require.Len(t, handles, 3)
+			// Handles are returned in the same order as the input specs.
+			require.Equal(t, customID, handles[0].GetWorkflowID())
+			require.NotEmpty(t, handles[1].GetWorkflowID())
+
+			forkedIDs := make([]string, len(handles))
+			for i, h := range handles {
+				res, err := h.GetResult()
+				require.NoError(t, err)
+				require.Equal(t, 6, res)
+				forkedIDs[i] = h.GetWorkflowID()
+			}
+			awaitForks(forkedIDs)
+
+			t.Run("Validation", func(t *testing.T) {
+				_, err := ForkWorkflows[int](nil, ForkWorkflowsInput{})
+				require.ErrorContains(t, err, "ctx cannot be nil")
+
+				_, err = ForkWorkflows[int](dbosCtx, ForkWorkflowsInput{})
+				require.ErrorContains(t, err, "at least one workflow")
+
+				_, err = ForkWorkflows[int](dbosCtx, ForkWorkflowsInput{
+					Workflows: []ForkWorkflowSpec{{OriginalWorkflowID: ""}},
+				})
+				require.ErrorContains(t, err, "original workflow ID cannot be empty")
+
+				_, err = ForkWorkflows[int](dbosCtx, ForkWorkflowsInput{
+					Workflows:         []ForkWorkflowSpec{{OriginalWorkflowID: originalIDs[0]}},
+					QueuePartitionKey: "pk",
+				})
+				require.ErrorContains(t, err, "queue partition key requires a queue name")
+			})
+		})
+
 		t.Run("Validation", func(t *testing.T) {
 			// Empty input is a no-op
 			forkedIDs, err := sysDB.forkWorkflows(dbosCtx, forkWorkflowsDBInput{})

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -8231,6 +8231,9 @@ func TestWorkflowAttributes(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, childStatuses, 1)
 		assert.Nil(t, childStatuses[0].Attributes)
+		// Workflows not enqueued by a named schedule have no schedule name and
+		// are never returned by the schedule name filter.
+		assert.Empty(t, childStatuses[0].ScheduleName)
 
 		// Workflows started without the option have no attributes
 		plainHandle, err := RunWorkflow(dbosCtx, attrParentWorkflow, "")

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3716,8 +3716,7 @@ func TestRecvStepConflict(t *testing.T) {
 	sysB := ctxB.(*dbosContext).systemDB.(*sysDB)
 	payload := fmt.Sprintf("%s::%s", workflowID, topic)
 	require.Eventually(t, func() bool {
-		_, ok := sysA.workflowNotificationsMap.Load(payload)
-		return ok
+		return sysA.recvNotifier.has(payload)
 	}, 5*time.Second, 10*time.Millisecond, "executor A never registered as receiver")
 
 	// Executor B recovers the same workflow: a genuinely concurrent second
@@ -3732,7 +3731,7 @@ func TestRecvStepConflict(t *testing.T) {
 	// Executor B must actually run the body (register as receiver), not
 	// short-circuit; its separate map confirms a real concurrent execution.
 	require.Eventually(t, func() bool {
-		_, ok := sysB.workflowNotificationsMap.Load(payload)
+		ok := sysB.recvNotifier.has(payload)
 		return ok
 	}, 5*time.Second, 10*time.Millisecond, "executor B (recovery) never ran the body")
 
@@ -4271,10 +4270,10 @@ func TestSetGetEvent(t *testing.T) {
 	})
 
 	t.Run("ConcurrentGetEvent", func(t *testing.T) {
-		// Spread more getters than keys: several getters share each key's condition
-		// variable (within-key concurrency) while distinct keys use independent
-		// condition variables (across-key concurrency). Getters start before the
-		// events are set so they block rather than taking the already-set fast path.
+		// Spread more getters than keys: several getters register on each key
+		// (within-key concurrency) while distinct keys are independent (across-key
+		// concurrency). Getters start before the events are set so they block rather
+		// than taking the already-set fast path.
 		setWorkflowID := uuid.NewString()
 		const numKeys = 3
 		const numGoroutines = 12 // > numKeys, so multiple getters land on each key
@@ -4310,7 +4309,7 @@ func TestSetGetEvent(t *testing.T) {
 		require.Eventually(t, func() bool {
 			for k := range numKeys {
 				payload := fmt.Sprintf("%s::%s", setWorkflowID, fmt.Sprintf("concurrent-event-key-%d", k))
-				if _, ok := sysDB.workflowEventsMap.Load(payload); !ok {
+				if !sysDB.eventNotifier.has(payload) {
 					return false
 				}
 			}
@@ -4329,6 +4328,137 @@ func TestSetGetEvent(t *testing.T) {
 		}
 	})
 
+	t.Run("GetEventMixedTimeoutAndDelivery", func(t *testing.T) {
+		// On a single key, some waiters time out before the event is set and others
+		// block long enough to receive it. A departing waiter must not disturb the
+		// survivors: they must still receive the value once it is set, not return a
+		// premature nil. (Regression test for the per-waiter notify fix.)
+		setWorkflowID := uuid.NewString()
+		key := "mixed-timeout-key"
+		const numLong = 3
+		const numShort = 3
+
+		var longWg, shortWg sync.WaitGroup
+		longErrs := make(chan error, numLong)
+		shortErrs := make(chan error, numShort)
+
+		// Long waiters register first.
+		longWg.Add(numLong)
+		for i := range numLong {
+			go func(i int) {
+				defer longWg.Done()
+				res, err := GetEvent[string](dbosCtx, setWorkflowID, key, 30*time.Second)
+				if err != nil {
+					longErrs <- fmt.Errorf("long waiter %d: %w", i, err)
+					return
+				}
+				if res != "mixed-value" {
+					longErrs <- fmt.Errorf("long waiter %d: expected %q, got %q", i, "mixed-value", res)
+				}
+			}(i)
+		}
+
+		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+		payload := fmt.Sprintf("%s::%s", setWorkflowID, key)
+		require.Eventually(t, func() bool {
+			ok := sysDB.eventNotifier.has(payload)
+			return ok
+		}, 5*time.Second, 10*time.Millisecond, "long waiters never registered")
+
+		// Short waiters register on the same key, then time out and leave.
+		shortWg.Add(numShort)
+		for i := range numShort {
+			go func(i int) {
+				defer shortWg.Done()
+				_, err := GetEvent[string](dbosCtx, setWorkflowID, key, 300*time.Millisecond)
+				if err == nil {
+					shortErrs <- fmt.Errorf("short waiter %d: expected a timeout", i)
+					return
+				}
+				dbosErr, ok := err.(*DBOSError)
+				if !ok || dbosErr.Code != TimeoutError {
+					shortErrs <- fmt.Errorf("short waiter %d: expected TimeoutError, got %v", i, err)
+				}
+			}(i)
+		}
+
+		// Let the short waiters time out and leave before setting the event.
+		shortWg.Wait()
+		close(shortErrs)
+		for err := range shortErrs {
+			require.FailNow(t, "short waiter error", err)
+		}
+
+		setHandle, err := RunWorkflow(dbosCtx, setEventWorkflow, setEventWorkflowInput{
+			Key:     key,
+			Message: "mixed-value",
+		}, WithWorkflowID(setWorkflowID))
+		require.NoError(t, err, "failed to start set event workflow")
+		_, err = setHandle.GetResult()
+		require.NoError(t, err, "failed to get result from set event workflow")
+
+		longWg.Wait()
+		close(longErrs)
+		for err := range longErrs {
+			require.FailNow(t, "long waiter error", err)
+		}
+	})
+
+	t.Run("GetEventSiblingCancellationDoesNotWakeOthers", func(t *testing.T) {
+		// A sibling whose context is cancelled mid-wait must not wake the others into
+		// returning early: the survivor still receives the value once it is set.
+		setWorkflowID := uuid.NewString()
+		key := "cancel-sibling-key"
+
+		var survivorWg sync.WaitGroup
+		survivorErr := make(chan error, 1)
+		survivorWg.Add(1)
+		go func() {
+			defer survivorWg.Done()
+			res, err := GetEvent[string](dbosCtx, setWorkflowID, key, 30*time.Second)
+			if err != nil {
+				survivorErr <- fmt.Errorf("survivor: %w", err)
+				return
+			}
+			if res != "survivor-value" {
+				survivorErr <- fmt.Errorf("survivor: expected %q, got %q", "survivor-value", res)
+			}
+		}()
+
+		sysDB := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+		payload := fmt.Sprintf("%s::%s", setWorkflowID, key)
+		require.Eventually(t, func() bool {
+			ok := sysDB.eventNotifier.has(payload)
+			return ok
+		}, 5*time.Second, 10*time.Millisecond, "survivor never registered")
+
+		// A sibling on the same key that gets cancelled while waiting.
+		cancelCtx, cancel := WithCancel(dbosCtx)
+		siblingDone := make(chan struct{})
+		go func() {
+			defer close(siblingDone)
+			_, _ = GetEvent[string](cancelCtx, setWorkflowID, key, 30*time.Second)
+		}()
+		// Give the sibling time to register, then cancel it.
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+		<-siblingDone
+
+		// The survivor must still be waiting; setting the event delivers it.
+		setHandle, err := RunWorkflow(dbosCtx, setEventWorkflow, setEventWorkflowInput{
+			Key:     key,
+			Message: "survivor-value",
+		}, WithWorkflowID(setWorkflowID))
+		require.NoError(t, err, "failed to start set event workflow")
+		_, err = setHandle.GetResult()
+		require.NoError(t, err, "failed to get result from set event workflow")
+
+		survivorWg.Wait()
+		close(survivorErr)
+		for err := range survivorErr {
+			require.FailNow(t, "survivor error", err)
+		}
+	})
 }
 
 // Test workflows and steps for parameter mismatch validation

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dbos-inc/dbos-transact-golang
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	github.com/containerd/errdefs v1.0.0

--- a/integration/mocks_test.go
+++ b/integration/mocks_test.go
@@ -477,10 +477,10 @@ func TestClientTypedHelpersWithMock(t *testing.T) {
 		t.Fatalf("ClientForkWorkflow handle GetResult = (%d, %v), want (11, nil)", res, err)
 	}
 
-	// ClientListWorkflows is an interface method, so it mocks directly.
-	mockClient.On("ClientListWorkflows", mock.Anything).Return([]dbos.WorkflowStatus{{ID: "wf-ret"}}, nil).Once()
-	list, err := mockClient.ClientListWorkflows()
+	// ListWorkflows is an interface method, so it mocks directly.
+	mockClient.On("ListWorkflows", mock.Anything).Return([]dbos.WorkflowStatus{{ID: "wf-ret"}}, nil).Once()
+	list, err := mockClient.ListWorkflows()
 	if err != nil || len(list) != 1 || list[0].ID != "wf-ret" {
-		t.Fatalf("ClientListWorkflows = (%v, %v), want one status with ID wf-ret", list, err)
+		t.Fatalf("ListWorkflows = (%v, %v), want one status with ID wf-ret", list, err)
 	}
 }


### PR DESCRIPTION
- Queryable schedule names
- have the scheduler enqueue directly to the database (instead of calling `RunWorkflow` with the actual registered function.) This enables a scheduler to start a workflow even if not registered on this executor.
- remove duplicate client methods
- add public APIs for bulk forking
- update pl/pgsql enqueue_workflow test for new parameters

Closes #381