### PR TITLE
Fix step cancellation outcome

### DIFF
--- a/.github/workflows/cancellation-chaos-tests.yml
+++ b/.github/workflows/cancellation-chaos-tests.yml
@@ -1,0 +1,40 @@
+name: Run Cancellation Chaos Tests
+on:
+    schedule:
+        # Runs every 3 hours on the half hour
+        - cron: '30 */3 * * *'
+    push:
+      branches:
+        - main
+    pull_request:
+      types:
+        - ready_for_review
+        - opened
+        - reopened
+        - synchronize
+    workflow_dispatch:
+
+jobs:
+  cancellation-chaos-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Setup Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.25.12'
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Run cancellation chaos tests
+      run: go vet ./... && go test -v -race -timeout 30m -count=1 -run 'TestCancellationChaos' ./...
+      working-directory: ./chaos_tests
+      env:
+        PGPASSWORD: a!b@c$d()e*_,/:;=?@ff[]22
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chaos-tests.yml
+++ b/.github/workflows/chaos-tests.yml
@@ -37,7 +37,7 @@ jobs:
       run: go install gotest.tools/gotestsum@latest
 
     - name: Run chaos tests
-      run: go vet ./... && go test -v -race -timeout 60m -count=1 ./...
+      run: go vet ./... && go test -v -race -timeout 60m -count=1 -skip 'TestCancellationChaos' ./...
       working-directory: ./chaos_tests
       env:
         PGPASSWORD: a!b@c$d()e*_,/:;=?@ff[]22

--- a/chaos_tests/cancellation_chaos_test.go
+++ b/chaos_tests/cancellation_chaos_test.go
@@ -119,7 +119,7 @@ func TestCancellationChaos(t *testing.T) {
 			return fmt.Errorf("start workflow: %w", err)
 		}
 
-		const maxCancels = 3
+		const maxCancels = 10
 		cancels := 0
 		// Exec counts of the steps recorded before the last resume: these
 		// replay and must never execute again.

--- a/chaos_tests/cancellation_chaos_test.go
+++ b/chaos_tests/cancellation_chaos_test.go
@@ -1,0 +1,211 @@
+package chaos_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dbos-inc/dbos-transact-golang/dbos"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCancellationChaos exercises durable execution under randomly-timed
+// context cancellation: a workflow with a random number of sequential steps is
+// cancelled at a random point across up to maxCancels rounds. Across every subsequent
+// round, steps recorded before a resume never execute again. The final round
+// completes with the correct result and every step recorded exactly once.
+//
+// The first execution runs under a per-lifecycle cancellable context and is
+// cancelled by cancelling that context. Resumed executions derive their
+// context from the DBOS root context, unreachable from the enqueuer, so later
+// rounds cancel through the CancelWorkflow API, which takes effect at the next
+// step boundary and lets the in-flight step checkpoint.
+func TestCancellationChaos(t *testing.T) {
+	dbosCtx := setupDBOS(t)
+
+	const stepDuration = 20 * time.Millisecond
+
+	// Per-workflow step execution counts, keyed by workflow ID. The entry is
+	// stored before the workflow starts and survives across resume rounds.
+	var execCounts sync.Map
+
+	workflow := func(ctx dbos.DBOSContext, numSteps int) (int, error) {
+		wfID, err := dbos.GetWorkflowID(ctx)
+		if err != nil {
+			return 0, err
+		}
+		v, ok := execCounts.Load(wfID)
+		if !ok {
+			return 0, fmt.Errorf("no exec counts for workflow %s", wfID)
+		}
+		counts := v.([]atomic.Int64)
+		sum := 0
+		for i := range numSteps {
+			out, err := dbos.RunAsStep(ctx, func(stepCtx context.Context) (int, error) {
+				counts[i].Add(1)
+				select {
+				case <-stepCtx.Done():
+					return 0, stepCtx.Err()
+				case <-time.After(stepDuration):
+					return i, nil
+				}
+			}, dbos.WithStepName(fmt.Sprintf("step-%d", i)))
+			if err != nil {
+				return 0, err
+			}
+			sum += out
+		}
+		return sum, nil
+	}
+	dbos.RegisterWorkflow(dbosCtx, workflow, dbos.WithWorkflowName("CancellationChaos"))
+
+	require.NoError(t, dbos.Launch(dbosCtx))
+
+	isCancellationErr := func(err error) bool {
+		return errors.Is(err, context.Canceled) ||
+			errors.Is(err, &dbos.DBOSError{Code: dbos.WorkflowCancelled}) ||
+			errors.Is(err, &dbos.DBOSError{Code: dbos.AwaitedWorkflowCancelled})
+	}
+
+	// Recorded steps must be unique and form a contiguous prefix 0..k-1.
+	checkPrefix := func(steps []dbos.StepInfo, numSteps int) error {
+		seen := make([]bool, numSteps)
+		for _, s := range steps {
+			if s.StepID < 0 || s.StepID >= numSteps || seen[s.StepID] {
+				return fmt.Errorf("invalid or duplicate recorded step ID %d (numSteps=%d)", s.StepID, numSteps)
+			}
+			seen[s.StepID] = true
+		}
+		for i := range len(steps) {
+			if !seen[i] {
+				return fmt.Errorf("recorded steps are not a contiguous prefix: %d steps recorded but step %d missing", len(steps), i)
+			}
+		}
+		return nil
+	}
+
+	lifecycle := func(rng *rand.Rand) error {
+		numSteps := 2 + rng.IntN(4)
+		wantSum := numSteps * (numSteps - 1) / 2
+		wfID := uuid.NewString()
+		counts := make([]atomic.Int64, numSteps)
+		execCounts.Store(wfID, counts)
+		defer execCounts.Delete(wfID)
+
+		cancelCtx, cancelFunc := dbos.WithCancel(dbosCtx)
+		defer cancelFunc()
+
+		handle, err := dbos.RunWorkflow(cancelCtx, workflow, numSteps, dbos.WithWorkflowID(wfID))
+		if err != nil {
+			return fmt.Errorf("start workflow: %w", err)
+		}
+
+		const maxCancels = 3
+		cancels := 0
+		// Exec counts of the steps recorded before the last resume: these
+		// replay and must never execute again.
+		replayed := make(map[int]int64)
+		for round := 0; ; round++ {
+			if cancels < maxCancels && rng.Float64() < 0.7 {
+				cancels++
+				time.Sleep(time.Duration(rng.IntN(numSteps)) * stepDuration)
+				if round == 0 {
+					cancelFunc()
+				} else if err := dbos.CancelWorkflow(dbosCtx, wfID); err != nil {
+					return fmt.Errorf("cancel workflow: %w", err)
+				}
+			}
+
+			result, err := handle.GetResult()
+
+			// An API cancel takes effect at the next step boundary, so GetResult
+			// can return while the last step is still finishing (and
+			// checkpointing). Wait it out before inspecting counts and steps,
+			// and before resuming, so the next round doesn't race the tail.
+			time.Sleep(2 * stepDuration)
+
+			for id, count := range replayed {
+				if got := counts[id].Load(); got != count {
+					return fmt.Errorf("step %d re-executed after being recorded: %d -> %d executions", id, count, got)
+				}
+			}
+
+			steps, stepsErr := dbos.GetWorkflowSteps(dbosCtx, wfID)
+			if stepsErr != nil {
+				return fmt.Errorf("get workflow steps: %w", stepsErr)
+			}
+			if prefixErr := checkPrefix(steps, numSteps); prefixErr != nil {
+				return prefixErr
+			}
+
+			if err == nil {
+				if result != wantSum {
+					return fmt.Errorf("unexpected result %d, want %d", result, wantSum)
+				}
+				if len(steps) != numSteps {
+					return fmt.Errorf("expected all %d steps recorded, got %d", numSteps, len(steps))
+				}
+				return nil
+			}
+
+			if !isCancellationErr(err) {
+				return fmt.Errorf("expected cancellation error, got: %v", err)
+			}
+			status, statusErr := handle.GetStatus()
+			if statusErr != nil {
+				return fmt.Errorf("get status after cancel: %w", statusErr)
+			}
+			if status.Status != dbos.WorkflowStatusCancelled {
+				return fmt.Errorf("expected status CANCELLED after cancel, got %s", status.Status)
+			}
+
+			replayed = make(map[int]int64, len(steps))
+			for _, s := range steps {
+				replayed[s.StepID] = counts[s.StepID].Load()
+			}
+			if handle, err = dbos.ResumeWorkflow[int](dbosCtx, wfID); err != nil {
+				return fmt.Errorf("resume cancelled workflow: %w", err)
+			}
+		}
+	}
+
+	seed := uint64(time.Now().UnixNano())
+	if s := os.Getenv("CHAOS_SEED"); s != "" {
+		parsed, err := strconv.ParseUint(s, 10, 64)
+		require.NoError(t, err, "invalid CHAOS_SEED")
+		seed = parsed
+	}
+	t.Logf("cancellation chaos seed: %d", seed)
+
+	const numWorkers = 10
+	const lifecyclesPerWorker = 30
+
+	errs := make(chan error, numWorkers)
+	var wg sync.WaitGroup
+	for w := range numWorkers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rng := rand.New(rand.NewPCG(seed, uint64(w)))
+			for i := range lifecyclesPerWorker {
+				if err := lifecycle(rng); err != nil {
+					errs <- fmt.Errorf("worker %d lifecycle %d: %w", w, i, err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}

--- a/chaos_tests/cancellation_chaos_test.go
+++ b/chaos_tests/cancellation_chaos_test.go
@@ -33,20 +33,30 @@ func TestCancellationChaos(t *testing.T) {
 
 	const stepDuration = 20 * time.Millisecond
 
-	// Per-workflow step execution counts, keyed by workflow ID. The entry is
-	// stored before the workflow starts and survives across resume rounds.
-	var execCounts sync.Map
+	// Per-workflow trackers, keyed by workflow ID. The entry is stored before
+	// the workflow starts and survives across resume rounds. counts holds
+	// per-step execution counts; active gauges in-flight instances of the
+	// workflow function, whose frame brackets every step execution and
+	// checkpoint, so active == 0 means no step activity can follow.
+	type wfTracker struct {
+		counts []atomic.Int64
+		active atomic.Int64
+	}
+	var trackers sync.Map
 
 	workflow := func(ctx dbos.DBOSContext, numSteps int) (int, error) {
 		wfID, err := dbos.GetWorkflowID(ctx)
 		if err != nil {
 			return 0, err
 		}
-		v, ok := execCounts.Load(wfID)
+		v, ok := trackers.Load(wfID)
 		if !ok {
-			return 0, fmt.Errorf("no exec counts for workflow %s", wfID)
+			return 0, fmt.Errorf("no tracker for workflow %s", wfID)
 		}
-		counts := v.([]atomic.Int64)
+		tracker := v.(*wfTracker)
+		tracker.active.Add(1)
+		defer tracker.active.Add(-1)
+		counts := tracker.counts
 		sum := 0
 		for i := range numSteps {
 			out, err := dbos.RunAsStep(ctx, func(stepCtx context.Context) (int, error) {
@@ -96,9 +106,10 @@ func TestCancellationChaos(t *testing.T) {
 		numSteps := 2 + rng.IntN(4)
 		wantSum := numSteps * (numSteps - 1) / 2
 		wfID := uuid.NewString()
-		counts := make([]atomic.Int64, numSteps)
-		execCounts.Store(wfID, counts)
-		defer execCounts.Delete(wfID)
+		tracker := &wfTracker{counts: make([]atomic.Int64, numSteps)}
+		counts := tracker.counts
+		trackers.Store(wfID, tracker)
+		defer trackers.Delete(wfID)
 
 		cancelCtx, cancelFunc := dbos.WithCancel(dbosCtx)
 		defer cancelFunc()
@@ -127,10 +138,26 @@ func TestCancellationChaos(t *testing.T) {
 			result, err := handle.GetResult()
 
 			// An API cancel takes effect at the next step boundary, so GetResult
-			// can return while the last step is still finishing (and
-			// checkpointing). Wait it out before inspecting counts and steps,
-			// and before resuming, so the next round doesn't race the tail.
-			time.Sleep(2 * stepDuration)
+			// can return while the workflow function is still finishing (and
+			// checkpointing) its current step. Wait for every in-flight instance
+			// to return before inspecting counts and steps, and before resuming,
+			// so the next round doesn't race the tail. Then require a quiet
+			// window: an instance dequeued just before the cancel registers in
+			// the gauge only once its function starts, and it must observe the
+			// CANCELLED status (and exit) before we flip it back with a resume.
+			for deadline := time.Now().Add(30 * time.Second); ; {
+				if time.Now().After(deadline) {
+					return fmt.Errorf("timed out waiting for in-flight workflow instances to exit")
+				}
+				if tracker.active.Load() != 0 {
+					time.Sleep(stepDuration / 4)
+					continue
+				}
+				time.Sleep(2 * stepDuration)
+				if tracker.active.Load() == 0 {
+					break
+				}
+			}
 
 			for id, count := range replayed {
 				if got := counts[id].Load(); got != count {

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -1096,10 +1096,19 @@ func TestListWorkflows(t *testing.T) {
 		// Record start time for filtering tests
 		testStartTime := time.Now()
 
+		// Boundary between the test-batch-* and test-other-* workflows, observed
+		// rather than derived from the sleep cadence below: enqueue latency (notably
+		// on CockroachDB) makes wall-clock arithmetic unreliable.
+		var firstHalfTime time.Time
+
 		// Start 10 workflows at 100ms intervals with different patterns
 		for i := range 10 {
 			var workflowID string
 			var handle WorkflowHandle[string]
+
+			if i == 5 {
+				firstHalfTime = time.Now()
+			}
 
 			if i < 5 {
 				// First 5 workflows: use prefix "test-batch-" and succeed
@@ -1221,8 +1230,7 @@ func TestListWorkflows(t *testing.T) {
 			assert.Equal(t, WorkflowStatusError, wf.Status, "workflow %s has unexpected status", wf.ID)
 		}
 
-		// Test 6: Filter by time range - first 5 workflows (start to start+500ms)
-		firstHalfTime := testStartTime.Add(500 * time.Millisecond)
+		// Test 6: Filter by time range - the 5 test-batch-* workflows
 		firstHalfWorkflows, err := client.ListWorkflows(
 			WithWorkflowIDPrefix("test-"),
 			WithEndTime(firstHalfTime))

--- a/dbos/client_test.go
+++ b/dbos/client_test.go
@@ -1108,6 +1108,9 @@ func TestListWorkflows(t *testing.T) {
 
 			if i == 5 {
 				firstHalfTime = time.Now()
+				// created_at is stored at millisecond resolution and WithEndTime is
+				// inclusive: keep test-other-5's stamp out of the boundary's tick.
+				time.Sleep(5 * time.Millisecond)
 			}
 
 			if i < 5 {

--- a/dbos/datasource.go
+++ b/dbos/datasource.go
@@ -519,6 +519,10 @@ func (c *dbosContext) RunAsTransaction(dbosCtx DBOSContext, ds *DataSource, fn T
 	// OUTER: the user-facing step retry policy (maxRetries + predicate).
 	stepOutput, stepError := executeStepWithRetry(c, stepState.workflowID, stepOpts, runTxnResilient)
 
+	if stepInterruptedByCancellation(stepState, stepError) {
+		return stepOutput, newWorkflowCancelledError(stepState.workflowID, stepError)
+	}
+
 	// txn2: checkpoint the outcome into the system database.
 	encodedStepOutput, serErr := ser.Encode(stepOutput)
 	if serErr != nil {

--- a/dbos/datasource_test.go
+++ b/dbos/datasource_test.go
@@ -453,6 +453,75 @@ func TestRunAsTransaction(t *testing.T) {
 		require.Equal(t, 1, ub.countRows(t, fmt.Sprintf(`SELECT count(*) FROM %s`, ub.completionTable())))
 	})
 
+	t.Run("CancelledTransactionNotCheckpointed", func(t *testing.T) {
+		// A transaction interrupted by workflow cancellation must not checkpoint
+		// its cancellation error — in the user DB or the system DB — so resume
+		// re-executes it instead of replaying the error.
+		ctx := setupDBOS(t, setupDBOSOptions{dropDB: true})
+		ub := openUserBackend(t)
+		ds := ub.register(t, ctx, "app")
+
+		var attempts atomic.Int32
+		started := NewEvent()
+		wf := func(dctx DBOSContext, _ string) (string, error) {
+			return RunAsTransaction(dctx, ds, func(c context.Context, tx Tx) (string, error) {
+				if attempts.Add(1) == 1 {
+					started.Set()
+					<-c.Done()
+					return "", c.Err()
+				}
+				if _, err := tx.Exec(c, ub.rw(`INSERT INTO kv (k, v) VALUES ($1, $2)`), "k1", "v1"); err != nil {
+					return "", err
+				}
+				return "completed", nil
+			})
+		}
+		RegisterWorkflow(ctx, wf)
+		require.NoError(t, Launch(ctx))
+		ub.createAppTable(t)
+
+		cancelCtx, cancelFunc := WithCancel(ctx)
+		defer cancelFunc()
+		wfID := uuid.NewString()
+		handle, err := RunWorkflow(cancelCtx, wf, "", WithWorkflowID(wfID))
+		require.NoError(t, err)
+
+		started.Wait()
+		cancelFunc()
+
+		_, err = handle.GetResult()
+		require.Error(t, err, "expected error from cancelled workflow")
+		require.True(t, errors.Is(err, &DBOSError{Code: WorkflowCancelled}), "expected WorkflowCancelled error, got: %v", err)
+
+		require.Eventually(t, func() bool {
+			status, err := handle.GetStatus()
+			require.NoError(t, err)
+			return status.Status == WorkflowStatusCancelled
+		}, 5*time.Second, 100*time.Millisecond, "workflow did not reach cancelled status in time")
+
+		// Neither database recorded the interrupted transaction.
+		steps, err := GetWorkflowSteps(ctx, wfID)
+		require.NoError(t, err)
+		require.Len(t, steps, 0, "transaction interrupted by cancellation must not be checkpointed in the system DB")
+		require.Equal(t, 0, ub.countRows(t,
+			fmt.Sprintf(`SELECT count(*) FROM %s WHERE workflow_id = $1`, ub.completionTable()), wfID),
+			"transaction interrupted by cancellation must not be recorded in the user DB")
+
+		resumedHandle, err := ResumeWorkflow[string](ctx, wfID)
+		require.NoError(t, err)
+		res, err := resumedHandle.GetResult()
+		require.NoError(t, err, "resumed workflow should complete successfully")
+		require.Equal(t, "completed", res)
+		require.EqualValues(t, 2, attempts.Load(), "expected the transaction to re-execute on resume")
+
+		require.Equal(t, "v1", ub.queryString(t, `SELECT v FROM kv WHERE k = 'k1'`))
+		require.Equal(t, 1, ub.countRows(t,
+			fmt.Sprintf(`SELECT count(*) FROM %s WHERE workflow_id = $1`, ub.completionTable()), wfID))
+		steps, err = GetWorkflowSteps(ctx, wfID)
+		require.NoError(t, err)
+		require.Len(t, steps, 1, "expected the re-executed transaction to be checkpointed")
+	})
+
 	t.Run("Layer1ReplayOnRecovery", func(t *testing.T) {
 		ctx := setupDBOS(t, setupDBOSOptions{dropDB: true})
 		ub := openUserBackend(t)

--- a/dbos/debouncer_test.go
+++ b/dbos/debouncer_test.go
@@ -272,13 +272,9 @@ func TestDebouncer(t *testing.T) {
 		require.NoError(t, err, "failed to find debouncer workflow in operation_outputs")
 		require.NotEmpty(t, debouncerWorkflowID, "debouncer workflow ID should not be empty")
 
-		err = dbosCtxInstance.systemDB.updateWorkflowOutcome(context.Background(), updateWorkflowOutcomeDBInput{
-			workflowID: debouncerWorkflowID,
-			status:     WorkflowStatusPending,
-			output:     nil,
-			tx:         nil,
-		})
-		require.NoError(t, err, "failed to update workflow status to PENDING")
+		// updateWorkflowOutcome refuses to overwrite terminal rows, so reset the
+		// completed debouncer workflow with the raw-SQL test helper instead.
+		setWorkflowStatusPending(t, dbosCtx, debouncerWorkflowID)
 
 		cleared, err := dbosCtxInstance.systemDB.clearQueueAssignment(context.Background(), debouncerWorkflowID)
 		require.NoError(t, err, "failed to clear queue assignment")

--- a/dbos/errors.go
+++ b/dbos/errors.go
@@ -163,18 +163,14 @@ func newAwaitedWorkflowCancelledError(workflowID string) *DBOSError {
 	}
 }
 
-func newAwaitedWorkflowMaxStepRetriesExceeded(workflowID string) *DBOSError {
+// newWorkflowCancelledError wraps the cancellation cause (e.g. the context error that
+// interrupted a step), so errors.Is still matches context.Canceled / context.DeadlineExceeded.
+func newWorkflowCancelledError(workflowID string, cause error) *DBOSError {
 	return &DBOSError{
-		Message:    fmt.Sprintf("Awaited workflow %s has exceeded the maximum number of step retries", workflowID),
-		Code:       MaxStepRetriesExceeded,
+		Message:    fmt.Sprintf("Workflow %s was cancelled", workflowID),
+		Code:       WorkflowCancelled,
 		WorkflowID: workflowID,
-	}
-}
-
-func newWorkflowCancelledError(workflowID string) *DBOSError {
-	return &DBOSError{
-		Message: fmt.Sprintf("Workflow %s was cancelled", workflowID),
-		Code:    WorkflowCancelled,
+		wrappedErr: cause,
 	}
 }
 

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1551,8 +1551,7 @@ func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowO
 	}
 	if rowsAffected == 0 {
 		// The guarded UPDATE matched no rows: the workflow is already terminal. Re-read
-		// the status (only on this rare no-op path) and, if it is CANCELLED, report it
-		// so the caller does not complete a cancelled workflow.
+		// the status (only on this rare no-op path) and, if it is CANCELLED, report it.
 		statusQuery := s.renderSQL(`SELECT status FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
 		var currentStatus WorkflowStatusType
 		if err := runner.QueryRow(ctx, statusQuery, input.workflowID).Scan(&currentStatus); err != nil {

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1525,23 +1525,45 @@ type updateWorkflowOutcomeDBInput struct {
 	tx         Tx
 }
 
-// updateWorkflowOutcome updates the status, output, and error of a workflow
-// Note that transitions from CANCELLED to SUCCESS or ERROR are forbidden
+// updateWorkflowOutcome records a workflow's terminal outcome, but never overwrites a
+// row that is already terminal. If the write is refused because the workflow is
+// CANCELLED (e.g. it was cancelled during its final step), returns a WorkflowCancelled
+// error so the caller ends the workflow as cancelled rather than completing it.
+// This mirrors update_workflow_outcome / #recordWorkflowOutcome in the other SDKs.
 func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowOutcomeDBInput) error {
 	query := s.renderSQL(`UPDATE %sworkflow_status
 			  SET status = $1, output = $2, error = $3, updated_at = $4, completed_at = $4, deduplication_id = NULL
-			  WHERE workflow_uuid = $5 AND NOT (status = $6 AND CAST($1 AS TEXT) IN ($7, $8))`, s.dialect.SchemaPrefix(s.schema))
+			  WHERE workflow_uuid = $5 AND status NOT IN ($6, $7, $8)`, s.dialect.SchemaPrefix(s.schema))
 
-	// input.output is already a *string from the database layer
-	var err error
+	var runner Querier = s.pool
 	if input.tx != nil {
-		_, err = input.tx.Exec(ctx, query, input.status, input.output, input.errStr, time.Now().UnixMilli(), input.workflowID, WorkflowStatusCancelled, WorkflowStatusSuccess, WorkflowStatusError)
-	} else {
-		_, err = s.pool.Exec(ctx, query, input.status, input.output, input.errStr, time.Now().UnixMilli(), input.workflowID, WorkflowStatusCancelled, WorkflowStatusSuccess, WorkflowStatusError)
+		runner = input.tx
 	}
 
+	// input.output is already a *string from the database layer
+	res, err := runner.Exec(ctx, query, input.status, input.output, input.errStr, time.Now().UnixMilli(), input.workflowID, WorkflowStatusCancelled, WorkflowStatusSuccess, WorkflowStatusError)
 	if err != nil {
 		return fmt.Errorf("failed to update workflow status: %w", err)
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check workflow status update: %w", err)
+	}
+	if rowsAffected == 0 {
+		// The guarded UPDATE matched no rows: the workflow is already terminal. Re-read
+		// the status (only on this rare no-op path) and, if it is CANCELLED, report it
+		// so the caller does not complete a cancelled workflow.
+		statusQuery := s.renderSQL(`SELECT status FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
+		var currentStatus WorkflowStatusType
+		if err := runner.QueryRow(ctx, statusQuery, input.workflowID).Scan(&currentStatus); err != nil {
+			if errors.Is(err, ErrNoRows) {
+				return nil
+			}
+			return fmt.Errorf("failed to read workflow status after refused outcome update: %w", err)
+		}
+		if currentStatus == WorkflowStatusCancelled {
+			return newWorkflowCancelledError(input.workflowID, nil)
+		}
 	}
 	return nil
 }

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -2638,7 +2638,7 @@ func (s *sysDB) checkOperationExecution(ctx context.Context, input checkOperatio
 
 	// If the workflow is cancelled, raise the exception
 	if workflowStatus == WorkflowStatusCancelled {
-		return nil, newWorkflowCancelledError(input.workflowID)
+		return nil, newWorkflowCancelledError(input.workflowID, errors.New("workflow status is CANCELLED"))
 	}
 
 	// Execute second query to get operation outputs

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1525,15 +1525,14 @@ type updateWorkflowOutcomeDBInput struct {
 	tx         Tx
 }
 
-// updateWorkflowOutcome records a workflow's terminal outcome, but never overwrites a
-// row that is already terminal. If the write is refused because the workflow is
-// CANCELLED (e.g. it was cancelled during its final step), returns a WorkflowCancelled
-// error so the caller ends the workflow as cancelled rather than completing it.
-// This mirrors update_workflow_outcome / #recordWorkflowOutcome in the other SDKs.
+// updateWorkflowOutcome records a workflow's terminal outcome. Only a PENDING row can
+// receive an outcome: any other status means the run was superseded (already terminal,
+// re-enqueued by a resume, ...). If the write is refused for any reason other than the workflow having
+// completed (SUCCESS/ERROR), returns a WorkflowCancelled error.
 func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowOutcomeDBInput) error {
 	query := s.renderSQL(`UPDATE %sworkflow_status
 			  SET status = $1, output = $2, error = $3, updated_at = $4, completed_at = $4, deduplication_id = NULL
-			  WHERE workflow_uuid = $5 AND status NOT IN ($6, $7, $8)`, s.dialect.SchemaPrefix(s.schema))
+			  WHERE workflow_uuid = $5 AND status = $6`, s.dialect.SchemaPrefix(s.schema))
 
 	var runner Querier = s.pool
 	if input.tx != nil {
@@ -1541,7 +1540,7 @@ func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowO
 	}
 
 	// input.output is already a *string from the database layer
-	res, err := runner.Exec(ctx, query, input.status, input.output, input.errStr, time.Now().UnixMilli(), input.workflowID, WorkflowStatusCancelled, WorkflowStatusSuccess, WorkflowStatusError)
+	res, err := runner.Exec(ctx, query, input.status, input.output, input.errStr, time.Now().UnixMilli(), input.workflowID, WorkflowStatusPending)
 	if err != nil {
 		return fmt.Errorf("failed to update workflow status: %w", err)
 	}
@@ -1550,8 +1549,10 @@ func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowO
 		return fmt.Errorf("failed to check workflow status update: %w", err)
 	}
 	if rowsAffected == 0 {
-		// The guarded UPDATE matched no rows: the workflow is already terminal. Re-read
-		// the status (only on this rare no-op path) and, if it is CANCELLED, report it.
+		// The guarded UPDATE matched no rows. Re-read the status (only on this rare
+		// no-op path): if the workflow completed (SUCCESS/ERROR) the refusal is a
+		// no-op; otherwise the run was cancelled or superseded and is reported as
+		// cancelled to the caller.
 		statusQuery := s.renderSQL(`SELECT status FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
 		var currentStatus WorkflowStatusType
 		if err := runner.QueryRow(ctx, statusQuery, input.workflowID).Scan(&currentStatus); err != nil {
@@ -1560,7 +1561,7 @@ func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowO
 			}
 			return fmt.Errorf("failed to read workflow status after refused outcome update: %w", err)
 		}
-		if currentStatus == WorkflowStatusCancelled {
+		if currentStatus != WorkflowStatusSuccess && currentStatus != WorkflowStatusError {
 			return newWorkflowCancelledError(input.workflowID, nil)
 		}
 	}

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -2638,7 +2638,7 @@ func (s *sysDB) checkOperationExecution(ctx context.Context, input checkOperatio
 
 	// If the workflow is cancelled, raise the exception
 	if workflowStatus == WorkflowStatusCancelled {
-		return nil, newWorkflowCancelledError(input.workflowID, errors.New("workflow status is CANCELLED"))
+		return nil, newWorkflowCancelledError(input.workflowID, nil)
 	}
 
 	// Execute second query to get operation outputs

--- a/dbos/utils_test.go
+++ b/dbos/utils_test.go
@@ -197,18 +197,22 @@ type setupDBOSOptions struct {
 	checkLeaks               bool
 	serializer               Serializer[any]
 	schedulerPollingInterval time.Duration
+	databaseURL              string // share another test's database (sqlite URLs are per-*testing.T otherwise)
 }
 
 /* Test database setup */
 func setupDBOS(t *testing.T, opts setupDBOSOptions) DBOSContext {
 	t.Helper()
 
-	if opts.dropDB && useSqliteBackend() {
-		testDBURLs.Delete(t)
-	}
-	databaseURL := backendDatabaseURL(t)
-	if opts.dropDB && !useSqliteBackend() {
-		resetTestDatabase(t, databaseURL)
+	databaseURL := opts.databaseURL
+	if databaseURL == "" {
+		if opts.dropDB && useSqliteBackend() {
+			testDBURLs.Delete(t)
+		}
+		databaseURL = backendDatabaseURL(t)
+		if opts.dropDB && !useSqliteBackend() {
+			resetTestDatabase(t, databaseURL)
+		}
 	}
 
 	config := Config{

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -1588,6 +1589,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 	go func() {
 		defer c.workflowsWg.Done()
 
+		removeActive := func() {}
 		if c.activeWorkflowIDs != nil {
 			entry := activeWorkflowEntry{}
 			if insertStatusResult.queueName != nil {
@@ -1600,8 +1602,10 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 			if loaded { // This should never happen, but if it does, we need to log it
 				c.logger.Error("UNREACHABLE: workflow already running on this context", "workflow_id", workflowID)
 			}
-			defer c.activeWorkflowIDs.Delete(workflowID)
+			var removeOnce sync.Once
+			removeActive = func() { removeOnce.Do(func() { c.activeWorkflowIDs.Delete(workflowID) }) }
 		}
+		defer removeActive()
 
 		var result any
 		var err error
@@ -1671,6 +1675,10 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 			if err != nil {
 				serializedErr = serializeWorkflowError(err, resolveEncoder(workflowCtx).Name())
 			}
+			// Remove from the active set before the outcome becomes durable: once it is
+			// visible, a resume→dequeue can re-dispatch this workflow to this executor,
+			// and a stale entry would make it skip the run, stranding the row PENDING.
+			removeActive()
 			recordErr := retry(c, func() error {
 				return c.systemDB.updateWorkflowOutcome(uncancellableCtx, updateWorkflowOutcomeDBInput{
 					workflowID: workflowID,

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -98,6 +98,9 @@ type workflowOutcome[R any] struct {
 	err           error
 	needsDecoding bool   // true if result came from awaitWorkflowResult (ID conflict path) and needs decoding
 	serialization string // serialization format of the encoded result (only used when needsDecoding is true)
+	// cancelled reports that the workflow settled in CANCELLED. A cancelled workflow is
+	// resumable, so its outcome is not final and an awaiting parent must not checkpoint it.
+	cancelled bool
 }
 
 type stepCheckpointedOutcome struct {
@@ -318,6 +321,11 @@ func (h *workflowHandle[R]) processOutcome(outcome workflowOutcome[R], startTime
 		if stepInterruptedByCancellation(workflowState, outcome.err) {
 			return *new(R), newWorkflowCancelledError(workflowState.workflowID, outcome.err)
 		}
+		// A cancelled child can be resumed, so its outcome is not final: don't
+		// checkpoint it, or the parent would replay the cancellation forever.
+		if outcome.cancelled {
+			return *new(R), newAwaitedWorkflowCancelledError(h.workflowID)
+		}
 		ser := resolveEncoder(h.dbosContext)
 		encodedOutput, encErr := ser.Encode(decodedResult)
 		if encErr != nil {
@@ -398,7 +406,7 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 	// cancelled interrupts the getResult step: don't checkpoint it, so resume
 	// re-executes the await.
 	if isWithinWorkflow && stepInterruptedByCancellation(workflowState, err) {
-		return *new(R), newAwaitedWorkflowCancelledError(h.workflowID)
+		return *new(R), newWorkflowCancelledError(workflowState.workflowID, err)
 	}
 
 	// Deserialize the result directly into the target type
@@ -421,7 +429,8 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 		}
 
 		// If we are calling GetResult inside a workflow, record the result as a step result
-		if isWithinWorkflow {
+		// Only record if we got the workflow result (no cancel, no dlq, no raw awaitWorkflowResult error)
+		if isWithinWorkflow && awaitErr == nil {
 			recordGetResultInput := recordOperationResultDBInput{
 				workflowID:      workflowState.workflowID,
 				childWorkflowID: h.workflowID,
@@ -1122,8 +1131,9 @@ func RunWorkflow[P any, R any](ctx DBOSContext, fn Workflow[P, R], input P, opts
 			// Handle nil results - nil cannot be type-asserted to any interface
 			if outcome.result == nil {
 				typedOutcomeChan <- workflowOutcome[R]{
-					result: typedResult,
-					err:    resultErr,
+					result:    typedResult,
+					err:       resultErr,
+					cancelled: outcome.cancelled,
 				}
 				return
 			}
@@ -1131,8 +1141,9 @@ func RunWorkflow[P any, R any](ctx DBOSContext, fn Workflow[P, R], input P, opts
 			// Check if this is a mocked path
 			if _, ok := handle.dbosContext.(*dbosContext); !ok {
 				typedOutcomeChan <- workflowOutcome[R]{
-					result: outcome.result.(R),
-					err:    resultErr,
+					result:    outcome.result.(R),
+					err:       resultErr,
+					cancelled: outcome.cancelled,
 				}
 				return
 			}
@@ -1164,8 +1175,9 @@ func RunWorkflow[P any, R any](ctx DBOSContext, fn Workflow[P, R], input P, opts
 			}
 
 			typedOutcomeChan <- workflowOutcome[R]{
-				result: typedResult,
-				err:    resultErr,
+				result:    typedResult,
+				err:       resultErr,
+				cancelled: outcome.cancelled,
 			}
 		}()
 
@@ -1593,6 +1605,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 
 		var result any
 		var err error
+		cancelled := false
 
 		result, err = fn(workflowCtx, input)
 
@@ -1613,7 +1626,8 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 				ser = awaitOut.serialization
 			}
 			// Keep the encoded result - decoding will happen in RunWorkflow[P,R] when we know the target type
-			outcomeChan <- workflowOutcome[any]{result: encodedResult, err: err, needsDecoding: true, serialization: ser}
+			outcomeChan <- workflowOutcome[any]{result: encodedResult, err: err, needsDecoding: true, serialization: ser,
+				cancelled: errors.Is(err, &DBOSError{Code: AwaitedWorkflowCancelled})}
 			close(outcomeChan)
 			return
 		} else {
@@ -1642,6 +1656,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 				// context cancellation. Mark it CANCELLED, not ERROR, so it can be resumed.
 				status = WorkflowStatusCancelled
 			}
+			cancelled = status == WorkflowStatusCancelled
 
 			// Serialize the output before recording
 			encodedOutput, serErr := resolveEncoder(workflowCtx).Encode(result)
@@ -1671,7 +1686,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 				return
 			}
 		}
-		outcomeChan <- workflowOutcome[any]{result: result, err: err}
+		outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: cancelled}
 		close(outcomeChan)
 	}()
 

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -76,10 +76,10 @@ type workflowState struct {
 	isWithinStep        bool
 	isWithinTransaction bool
 	isPortableWorkflow  bool
-	// auth identity carried so child workflows can inherit it automatically
-	authenticatedUser  string
-	assumedRole        string
-	authenticatedRoles []string
+	authenticatedUser   string
+	assumedRole         string
+	authenticatedRoles  []string
+	workflowCtx         context.Context
 }
 
 // nextStepID returns the next step ID and increments the counter
@@ -244,15 +244,18 @@ func checkGetResultExecution[R any](dbosCtx context.Context) (R, bool, error) {
 	}
 	if recordedOutputs != nil {
 		workflowState.nextStepID()
-		decoder, err := resolveDecoder[R](recordedOutputs.serialization, dbosCtx.(*dbosContext).serializer)
-		if err != nil {
-			return *new(R), false, fmt.Errorf("failed to resolve decoder: %w", err)
+		var decodedOutput R
+		if recordedOutputs.output != nil {
+			decoder, err := resolveDecoder[R](recordedOutputs.serialization, dbosCtx.(*dbosContext).serializer)
+			if err != nil {
+				return *new(R), false, fmt.Errorf("failed to resolve decoder: %w", err)
+			}
+			decodedOutput, err = decoder.Decode(recordedOutputs.output)
+			if err != nil {
+				return *new(R), false, fmt.Errorf("failed to decode operation result: %w", err)
+			}
 		}
-		decodedOutput, err := decoder.Decode(recordedOutputs.output)
-		if err != nil {
-			return *new(R), false, fmt.Errorf("failed to decode operation result: %w", err)
-		}
-		return decodedOutput, true, nil
+		return decodedOutput, true, deserializeWorkflowError(recordedOutputs.errStr)
 	}
 	return *new(R), false, nil
 }
@@ -308,6 +311,12 @@ func (h *workflowHandle[R]) processOutcome(outcome workflowOutcome[R], startTime
 	if isWithinWorkflow {
 		if _, ok := h.dbosContext.(*dbosContext); !ok {
 			return *new(R), newWorkflowExecutionError(workflowState.workflowID, fmt.Errorf("invalid DBOSContext: expected *dbosContext"))
+		}
+		// A cancellation outcome delivered while the awaiting workflow is itself
+		// cancelled interrupts the getResult step: don't checkpoint it, so resume
+		// re-executes the await.
+		if stepInterruptedByCancellation(workflowState, outcome.err) {
+			return *new(R), newWorkflowCancelledError(workflowState.workflowID, outcome.err)
 		}
 		ser := resolveEncoder(h.dbosContext)
 		encodedOutput, encErr := ser.Encode(decodedResult)
@@ -383,6 +392,15 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 		err = deserializeWorkflowError(awaitResult.errStr)
 	}
 
+	workflowState, ok := h.dbosContext.Value(workflowStateKey).(*workflowState)
+	isWithinWorkflow := ok && workflowState != nil
+	// A cancellation outcome delivered while the awaiting workflow is itself
+	// cancelled interrupts the getResult step: don't checkpoint it, so resume
+	// re-executes the await.
+	if isWithinWorkflow && stepInterruptedByCancellation(workflowState, err) {
+		return *new(R), newAwaitedWorkflowCancelledError(h.workflowID)
+	}
+
 	// Deserialize the result directly into the target type
 	var typedResult R
 	var encodedStr *string
@@ -403,8 +421,6 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 		}
 
 		// If we are calling GetResult inside a workflow, record the result as a step result
-		workflowState, ok := h.dbosContext.Value(workflowStateKey).(*workflowState)
-		isWithinWorkflow := ok && workflowState != nil
 		if isWithinWorkflow {
 			recordGetResultInput := recordOperationResultDBInput{
 				workflowID:      workflowState.workflowID,
@@ -1552,6 +1568,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 		}
 		stopFunc = context.AfterFunc(workflowCtx, workflowCancelFunction)
 	}
+	wfState.workflowCtx = workflowCtx
 
 	// Run the function in a goroutine
 	outcomeChan := make(chan workflowOutcome[any], 1)
@@ -1620,6 +1637,10 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 					// cancelled by the time the workflow returned.
 					status = WorkflowStatusCancelled
 				}
+			} else if workflowCtx.Err() != nil && isCancellationError(err) {
+				// No durable deadline (no AfterFunc): the workflow was interrupted by
+				// context cancellation. Mark it CANCELLED, not ERROR, so it can be resumed.
+				status = WorkflowStatusCancelled
 			}
 
 			// Serialize the output before recording
@@ -1874,6 +1895,7 @@ func prepareStepExecution(c *dbosContext, opts []StepOption) (*preparedStep, err
 		workflowID:   wfState.workflowID,
 		stepID:       stepID,
 		isWithinStep: true,
+		workflowCtx:  wfState.workflowCtx,
 	}
 	return &preparedStep{WorkflowID: wfState.workflowID, StepOpts: stepOpts, StepState: &stepState, IsWithinStep: false}, nil
 }
@@ -1933,6 +1955,18 @@ func executeStepWithRetry(c *dbosContext, workflowID string, stepOpts *stepOptio
 	return stepOutput, stepError
 }
 
+func isCancellationError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, &DBOSError{Code: WorkflowCancelled}) || errors.Is(err, &DBOSError{Code: AwaitedWorkflowCancelled})
+}
+
+func stepInterruptedByCancellation(stepState *workflowState, stepError error) bool {
+	if stepState.workflowCtx == nil || stepState.workflowCtx.Err() == nil {
+		return false
+	}
+	return isCancellationError(stepError)
+}
+
 // RunAsStep executes a function as a durable step within a workflow.
 // Steps provide at-least-once execution guarantees and automatic retry capabilities.
 // If a step has already been executed (e.g., during workflow recovery), its recorded
@@ -1976,6 +2010,14 @@ func executeStepWithRetry(c *dbosContext, workflowID string, stepOpts *stepOptio
 // Note that the function passed to RunAsStep must accept a context.Context as its first parameter
 // and this context *must* be the one specified in the function's signature (not the context passed to RunAsStep).
 // Under the hood, DBOS uses the provided context to manage durable execution.
+//
+// Context cancellation: if the workflow's context is cancelled while the step is running,
+// the step's outcome is not checkpointed and RunAsStep returns a *DBOSError with code
+// WorkflowCancelled, wrapping the underlying context error. The workflow should return
+// promptly: it is marked CANCELLED and, when resumed, re-executes the interrupted step.
+// Do not swallow this error to run further durable work — replay after resume would diverge.
+// By contrast, cancelling a context that wraps only the step (e.g. a per-step timeout)
+// records the step's error as its durable outcome and the workflow continues normally.
 func RunAsStep[R any](ctx DBOSContext, fn Step[R], opts ...StepOption) (R, error) {
 	if ctx == nil {
 		return *new(R), newStepExecutionError("", "", fmt.Errorf("ctx cannot be nil"))
@@ -2045,6 +2087,10 @@ func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, opts ...StepOption) 
 		}
 		return fn(stepCtx)
 	})
+
+	if stepInterruptedByCancellation(stepState, stepError) {
+		return stepOutput, newWorkflowCancelledError(stepState.workflowID, stepError)
+	}
 
 	// Serialize step output before recording
 	ser := resolveEncoder(c)
@@ -2209,6 +2255,10 @@ func (c *dbosContext) runAsTxn(_ DBOSContext, fn TxnFunc, opts ...StepOption) (a
 			}
 			return output, nil
 		})
+
+		if stepInterruptedByCancellation(stepState, stepError) {
+			return stepOutput, newWorkflowCancelledError(stepState.workflowID, stepError)
+		}
 
 		txnSer := resolveEncoder(c)
 		serialization := txnSer.Name()

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -99,8 +99,8 @@ type workflowOutcome[R any] struct {
 	err           error
 	needsDecoding bool   // true if result came from awaitWorkflowResult (ID conflict path) and needs decoding
 	serialization string // serialization format of the encoded result (only used when needsDecoding is true)
-	// cancelled reports that the workflow settled in CANCELLED. A cancelled workflow is
-	// resumable, so its outcome is not final and an awaiting parent must not checkpoint it.
+	// cancelled reports that the workflow settled in CANCELLED. An awaiting parent
+	// records it as an AwaitedWorkflowCancelled outcome for its getResult step.
 	cancelled bool
 }
 
@@ -322,10 +322,12 @@ func (h *workflowHandle[R]) processOutcome(outcome workflowOutcome[R], startTime
 		if stepInterruptedByCancellation(workflowState, outcome.err) {
 			return *new(R), newWorkflowCancelledError(workflowState.workflowID, outcome.err)
 		}
-		// A cancelled child can be resumed, so its outcome is not final: don't
-		// checkpoint it, or the parent would replay the cancellation forever.
+		// A cancelled child is a terminal outcome for the awaiting parent: checkpoint
+		// it like any other child error so replay is deterministic, matching the
+		// other SDKs. Resuming the child later does not change what the parent saw.
 		if outcome.cancelled {
-			return *new(R), newAwaitedWorkflowCancelledError(h.workflowID)
+			decodedResult = *new(R)
+			outcome.err = newAwaitedWorkflowCancelledError(h.workflowID)
 		}
 		ser := resolveEncoder(h.dbosContext)
 		encodedOutput, encErr := ser.Encode(decodedResult)
@@ -410,6 +412,11 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 		return *new(R), newWorkflowCancelledError(workflowState.workflowID, err)
 	}
 
+	// A cancelled child is a terminal outcome for the awaiting parent: checkpoint
+	// it like any other child error so replay is deterministic.
+	// Resuming the child later does not change what the parent saw.
+	childCancelled := errors.Is(awaitErr, &DBOSError{Code: AwaitedWorkflowCancelled})
+
 	// Deserialize the result directly into the target type
 	var typedResult R
 	var encodedStr *string
@@ -428,33 +435,40 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 		if deserErr != nil {
 			return *new(R), fmt.Errorf("failed to deserialize workflow result: %w", deserErr)
 		}
-
-		// If we are calling GetResult inside a workflow, record the result as a step result
-		// Only record if we got the workflow result (no cancel, no dlq, no raw awaitWorkflowResult error)
-		if isWithinWorkflow && awaitErr == nil {
-			recordGetResultInput := recordOperationResultDBInput{
-				workflowID:      workflowState.workflowID,
-				childWorkflowID: h.workflowID,
-				stepID:          workflowState.nextStepID(),
-				output:          encodedStr,
-				errStr:          awaitResult.errStr,
-				startedAt:       startTime,
-				completedAt:     completedTime,
-				stepName:        "DBOS.getResult",
-				serialization:   storedSerialization,
-			}
-			uncancellableCtx := context.WithoutCancel(h.dbosContext)
-			recordResultErr := retry(h.dbosContext, func() error {
-				return h.dbosContext.(*dbosContext).systemDB.recordOperationResult(uncancellableCtx, recordGetResultInput)
-			}, withRetrierLogger(h.dbosContext.(*dbosContext).logger))
-			if recordResultErr != nil {
-				h.dbosContext.(*dbosContext).logger.Error("failed to record get result", "error", recordResultErr)
-				return *new(R), newWorkflowExecutionError(workflowState.workflowID, fmt.Errorf("recording child workflow result: %w", recordResultErr))
-			}
-		}
-		return typedResult, err
 	}
-	return *new(R), err
+
+	// If we are calling GetResult inside a workflow, record the outcome as a step
+	// result: either the workflow result proper (no dlq, no raw awaitWorkflowResult
+	// error) or the child's cancellation.
+	if isWithinWorkflow && (childCancelled || (awaitErr == nil && encodedStr != nil)) {
+		errStr := awaitResult.errStr
+		serialization := storedSerialization
+		if childCancelled {
+			serialization = resolveEncoder(h.dbosContext).Name()
+			serializedErr := serializeWorkflowError(awaitErr, serialization)
+			errStr = &serializedErr
+		}
+		recordGetResultInput := recordOperationResultDBInput{
+			workflowID:      workflowState.workflowID,
+			childWorkflowID: h.workflowID,
+			stepID:          workflowState.nextStepID(),
+			output:          encodedStr,
+			errStr:          errStr,
+			startedAt:       startTime,
+			completedAt:     completedTime,
+			stepName:        "DBOS.getResult",
+			serialization:   serialization,
+		}
+		uncancellableCtx := context.WithoutCancel(h.dbosContext)
+		recordResultErr := retry(h.dbosContext, func() error {
+			return h.dbosContext.(*dbosContext).systemDB.recordOperationResult(uncancellableCtx, recordGetResultInput)
+		}, withRetrierLogger(h.dbosContext.(*dbosContext).logger))
+		if recordResultErr != nil {
+			h.dbosContext.(*dbosContext).logger.Error("failed to record get result", "error", recordResultErr)
+			return *new(R), newWorkflowExecutionError(workflowState.workflowID, fmt.Errorf("recording child workflow result: %w", recordResultErr))
+		}
+	}
+	return typedResult, err
 }
 
 // Wrapper handle -- useful for handling mocks in RunWorkflow

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -323,8 +323,8 @@ func (h *workflowHandle[R]) processOutcome(outcome workflowOutcome[R], startTime
 			return *new(R), newWorkflowCancelledError(workflowState.workflowID, outcome.err)
 		}
 		// A cancelled child is a terminal outcome for the awaiting parent: checkpoint
-		// it like any other child error so replay is deterministic, matching the
-		// other SDKs. Resuming the child later does not change what the parent saw.
+		// it like any other child error so replay is deterministic.
+		// Resuming the child later does not change what the parent saw.
 		if outcome.cancelled {
 			decodedResult = *new(R)
 			outcome.err = newAwaitedWorkflowCancelledError(h.workflowID)
@@ -1691,7 +1691,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 			}
 			// Remove from the active set before the outcome becomes durable: once it is
 			// visible, a resume→dequeue can re-dispatch this workflow to this executor,
-			// and a stale entry would make it skip the run, stranding the row PENDING.
+			// marking it PENDING. But a stale activeID entry would prevent the workflow from running.
 			removeActive()
 			recordErr := retry(c, func() error {
 				return c.systemDB.updateWorkflowOutcome(uncancellableCtx, updateWorkflowOutcomeDBInput{

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1577,24 +1577,24 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 		durableDeadline = insertStatusResult.workflowDeadline
 	}
 
-	var stopFunc func() bool
-	cancelFuncCompleted := make(chan struct{})
 	if !durableDeadline.IsZero() {
 		workflowCtx, _ = WithTimeout(workflowCtx, time.Until(durableDeadline))
-		// Register a cancel function that cancels the workflow in the DB as soon as the context is cancelled
-		workflowCancelFunction := func() {
-			c.logger.Info("Cancelling workflow", "workflow_id", workflowID)
-			err := retry(c, func() error {
-				_, err := c.systemDB.cancelWorkflows(uncancellableCtx, cancelWorkflowsDBInput{workflowIDs: []string{workflowID}})
-				return err
-			}, withRetrierLogger(c.logger))
-			if err != nil {
-				c.logger.Error("Failed to cancel workflow", "error", err)
-			}
-			close(cancelFuncCompleted)
-		}
-		stopFunc = context.AfterFunc(workflowCtx, workflowCancelFunction)
 	}
+	// Register a cancel function that durably cancels the workflow in the DB as soon as
+	// the context is cancelled (durable deadline, user cancel, or parent cancellation).
+	cancelFuncCompleted := make(chan struct{})
+	workflowCancelFunction := func() {
+		c.logger.Info("Cancelling workflow", "workflow_id", workflowID)
+		err := retry(c, func() error {
+			_, err := c.systemDB.cancelWorkflows(uncancellableCtx, cancelWorkflowsDBInput{workflowIDs: []string{workflowID}})
+			return err
+		}, withRetrierLogger(c.logger))
+		if err != nil {
+			c.logger.Error("Failed to cancel workflow", "error", err)
+		}
+		close(cancelFuncCompleted)
+	}
+	stopFunc := context.AfterFunc(workflowCtx, workflowCancelFunction)
 	wfState.workflowCtx = workflowCtx
 
 	// Run the function in a goroutine
@@ -1623,7 +1623,6 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 
 		var result any
 		var err error
-		cancelled := false
 
 		result, err = fn(workflowCtx, input)
 
@@ -1649,32 +1648,39 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 			close(outcomeChan)
 			return
 		} else {
-			status := WorkflowStatusSuccess
+			// A cancelled run skips updateWorkflowOutcome entirely so it can never
+			// clobber the row (e.g., ENQUEUED written by a concurrent resume).
+			if !stopFunc() {
+				// AfterFunc fired => context is cancelled. Wait for the DB cancel to finish.
+				c.logger.Info("Workflow was cancelled. Waiting for cancel function to complete", "workflow_id", workflowID)
+				<-cancelFuncCompleted
+				removeActive()
+				outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: true}
+				close(outcomeChan)
+				return
+			}
+			if workflowCtx.Err() != nil && isCancellationError(err) {
+				// We stopped the AfterFunc but the context was already cancelled
+				// so we need to run the durable cancel ourselves.
+				workflowCancelFunction()
+				removeActive()
+				outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: true}
+				close(outcomeChan)
+				return
+			}
+			if errors.Is(err, &DBOSError{Code: WorkflowCancelled}) {
+				// The workflow observed its own cancellation in the DB (external
+				// cancel): the row is already CANCELLED. Skip the outcome write.
+				removeActive()
+				outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: true}
+				close(outcomeChan)
+				return
+			}
 
-			// If an error occurred, set the status to error
+			status := WorkflowStatusSuccess
 			if err != nil {
 				status = WorkflowStatusError
 			}
-
-			// If the afterFunc has started, the workflow was cancelled and the status should be set to cancelled
-			// Also handle the race between the AfterFunc firing and the workflow returning with a context cancellation.
-			if stopFunc != nil {
-				if !stopFunc() {
-					// AfterFunc fired => context is cancelled. Wait for the DB cancel to finish.
-					c.logger.Info("Workflow was cancelled. Waiting for cancel function to complete", "workflow_id", workflowID)
-					<-cancelFuncCompleted
-					status = WorkflowStatusCancelled
-				} else if workflowCtx.Err() != nil {
-					// We stopped the AfterFunc, but lost the race: the context was already
-					// cancelled by the time the workflow returned.
-					status = WorkflowStatusCancelled
-				}
-			} else if workflowCtx.Err() != nil && isCancellationError(err) {
-				// No durable deadline (no AfterFunc): the workflow was interrupted by
-				// context cancellation. Mark it CANCELLED, not ERROR, so it can be resumed.
-				status = WorkflowStatusCancelled
-			}
-			cancelled = status == WorkflowStatusCancelled
 
 			// Serialize the output before recording
 			encodedOutput, serErr := resolveEncoder(workflowCtx).Encode(result)
@@ -1702,11 +1708,11 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 				})
 			}, withRetrierLogger(c.logger))
 			if recordErr != nil {
-				// The write was refused because the workflow is already durably CANCELLED
-				// (e.g. cancelled during its final step): it must end as cancelled, not
-				// complete. Deliver a cancellation outcome wrapping the workflow's own
-				// error so context.Canceled/DeadlineExceeded still match via errors.Is.
-				// The in-memory result still rides along for direct callers.
+				// The write was refused because the row is already terminal or has been
+				// superseded (cancelled during the final step, or re-enqueued by a
+				// concurrent resume): end as cancelled, not complete. Deliver a
+				// cancellation outcome wrapping the workflow's own error so
+				// context.Canceled/DeadlineExceeded still match via errors.Is.
 				if errors.Is(recordErr, &DBOSError{Code: WorkflowCancelled}) {
 					outcomeChan <- workflowOutcome[any]{result: result, err: newWorkflowCancelledError(workflowID, err), cancelled: true}
 					close(outcomeChan)
@@ -1718,7 +1724,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 				return
 			}
 		}
-		outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: cancelled}
+		outcomeChan <- workflowOutcome[any]{result: result, err: err}
 		close(outcomeChan)
 	}()
 

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1688,6 +1688,16 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 				})
 			}, withRetrierLogger(c.logger))
 			if recordErr != nil {
+				// The write was refused because the workflow is already durably CANCELLED
+				// (e.g. cancelled during its final step): it must end as cancelled, not
+				// complete. Deliver a cancellation outcome wrapping the workflow's own
+				// error so context.Canceled/DeadlineExceeded still match via errors.Is.
+				// The in-memory result still rides along for direct callers.
+				if errors.Is(recordErr, &DBOSError{Code: WorkflowCancelled}) {
+					outcomeChan <- workflowOutcome[any]{result: result, err: newWorkflowCancelledError(workflowID, err), cancelled: true}
+					close(outcomeChan)
+					return
+				}
 				c.logger.Error("Error recording workflow outcome", "workflow_id", workflowID, "error", recordErr)
 				outcomeChan <- workflowOutcome[any]{result: nil, err: recordErr}
 				close(outcomeChan)

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -277,13 +277,12 @@ func (h *workflowHandle[R]) GetResult(opts ...GetResultOption) (R, error) {
 
 	// If within a workflow, check if we already ran that step
 	result, found, err := checkGetResultExecution[R](h.dbosContext)
-	if err != nil {
+	if found {
+		return result, err
+	}
+	if err != nil { // not found and err means err is an infrastructure error
 		return *new(R), err
 	}
-	if found {
-		return result, nil
-	}
-
 	startTime := time.Now()
 
 	var timeoutChan <-chan time.Time
@@ -379,13 +378,12 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 
 	// If within a workflow, check if we already ran that step
 	result, found, err := checkGetResultExecution[R](h.dbosContext)
+	if found {
+		return result, err
+	}
 	if err != nil {
 		return *new(R), err
 	}
-	if found {
-		return result, nil
-	}
-
 	startTime := time.Now()
 
 	// Use timeout if specified, otherwise use DBOS context directly

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -358,6 +358,11 @@ func (h *workflowHandle[R]) processOutcome(outcome workflowOutcome[R], startTime
 			h.dbosContext.(*dbosContext).logger.Error("failed to record get result", "error", recordResultErr)
 			return *new(R), newWorkflowExecutionError(workflowState.workflowID, fmt.Errorf("recording child workflow result: %w", recordResultErr))
 		}
+	} else if outcome.cancelled && !isCancellationError(outcome.err) {
+		// The workflow swallowed its cancellation (returned normally or with an
+		// unrelated error) but we triggered durable cancel and no output was
+		// recorded: report cancellation, not success.
+		return *new(R), newWorkflowCancelledError(h.workflowID, outcome.err)
 	}
 	return decodedResult, outcome.err
 }

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1633,6 +1633,9 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 
 		// Handle DBOS ID conflict errors by waiting workflow result
 		if errors.Is(err, &DBOSError{Code: ConflictingIDError}) {
+			// This run lost the ID conflict: it does not own the workflow, so its
+			// context must no longer durably cancel it. Disarm the cancel function.
+			stopFunc()
 			c.logger.Warn("Workflow ID conflict detected. Waiting for existing workflow to complete", "workflow_id", workflowID)
 			awaitOut, awaitErr := retryWithResult(c, func() (*awaitWorkflowResultOutput, error) {
 				return c.systemDB.awaitWorkflowResult(uncancellableCtx, workflowID, _DB_RETRY_INTERVAL)

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -5772,10 +5772,14 @@ func TestWorkflowCancel(t *testing.T) {
 		// Signal the event so the workflow can move on to Recv()
 		blockingEventNoError.Set()
 
-		// Check the return values of the workflow
-		// Because this is a direct handle it'll not return an error
+		// The workflow swallowed the cancellation and returned success, but the
+		// outcome gate detected the CANCELLED row and propagates the cancellation
+		// to the caller instead of reporting success.
 		result, err := handle.GetResult()
-		require.NoError(t, err, "expected no error from direct handle")
+		require.Error(t, err, "expected cancellation error from direct handle")
+		var directErr *DBOSError
+		require.ErrorAs(t, err, &directErr, "expected error to be of type *DBOSError, got %T", err)
+		assert.Equal(t, WorkflowCancelled, directErr.Code, "expected WorkflowCancelled error code, got: %v", directErr.Code)
 		assert.Equal(t, "", result, "expected empty result from cancelled workflow")
 
 		// Now use a polling handle to get result -- observe the error

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1349,10 +1349,11 @@ func TestSteps(t *testing.T) {
 		require.Len(t, steps, 1, "expected the re-executed step to be recorded")
 	})
 
-	t.Run("CancelledParentRecordsSurvivingChildOutcome", func(t *testing.T) {
-		// Parent cancelled while awaiting a child that ignores cancellation: the
-		// child's delivered outcome is durably recorded by getResult, then the
-		// next step aborts on cancellation. Resume picks up after the await.
+	t.Run("CancelledParentCancelsChild", func(t *testing.T) {
+		// Cancelling the parent durably cancels the child too: a cancelled run
+		// never writes its outcome, even if its function ignores cancellation and
+		// returns successfully. The parent checkpoints the child's cancellation
+		// via getResult; resuming the parent replays it deterministically.
 		cancelCtx, cancelFunc := WithCancel(dbosCtx)
 		defer cancelFunc()
 		handle, err := RunWorkflow(cancelCtx, stubbornParentWorkflow, "")
@@ -1364,7 +1365,7 @@ func TestSteps(t *testing.T) {
 
 		_, err = handle.GetResult()
 		require.Error(t, err, "expected error from cancelled parent")
-		require.True(t, errors.Is(err, context.Canceled), "expected wrapped context.Canceled, got: %v", err)
+		require.True(t, errors.Is(err, &DBOSError{Code: AwaitedWorkflowCancelled}), "expected AwaitedWorkflowCancelled, got: %v", err)
 
 		require.Eventually(t, func() bool {
 			status, err := handle.GetStatus()
@@ -1374,24 +1375,30 @@ func TestSteps(t *testing.T) {
 
 		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
 		require.NoError(t, err, "failed to get workflow steps")
-		require.Len(t, steps, 2, "expected child spawn and getResult recorded; the interrupted step must not be")
+		require.Len(t, steps, 2, "expected child spawn and getResult recorded")
 		childID := steps[0].ChildWorkflowID
 		require.NotEmpty(t, childID, "expected the first step to be the child spawn")
 		require.Equal(t, "DBOS.getResult", steps[1].StepName)
-		require.Nil(t, steps[1].Error, "the delivered child outcome must be recorded without error")
+		require.NotNil(t, steps[1].Error, "the child's cancellation must be checkpointed")
 
 		childHandle, err := RetrieveWorkflow[string](dbosCtx, childID)
 		require.NoError(t, err, "failed to retrieve child workflow")
 		childStatus, err := childHandle.GetStatus()
 		require.NoError(t, err, "failed to get child workflow status")
-		require.Equal(t, WorkflowStatusSuccess, childStatus.Status, "child ignoring cancellation must complete")
+		require.Equal(t, WorkflowStatusCancelled, childStatus.Status, "child cannot outlive the parent's cancellation")
 
+		// The checkpointed child cancellation is a terminal outcome for the
+		// parent: resuming replays it.
 		resumedHandle, err := ResumeWorkflow[string](dbosCtx, handle.GetWorkflowID())
 		require.NoError(t, err, "failed to resume parent workflow")
-		result, err := resumedHandle.GetResult()
-		require.NoError(t, err, "resumed parent should complete")
-		require.Equal(t, "child-result-done", result)
+		_, err = resumedHandle.GetResult()
+		require.Error(t, err, "resumed parent must replay the checkpointed child cancellation")
+		require.True(t, errors.Is(err, &DBOSError{Code: AwaitedWorkflowCancelled}), "expected AwaitedWorkflowCancelled on replay, got: %v", err)
 		require.EqualValues(t, 1, stubbornChildExecutions.Load(), "child must not re-execute on parent resume")
+
+		status, err := resumedHandle.GetStatus()
+		require.NoError(t, err, "failed to get resumed workflow status")
+		require.Equal(t, WorkflowStatusError, status.Status, "replayed child cancellation is a terminal error outcome")
 	})
 
 	t.Run("PreemptedChildCancellationNotCheckpointed", func(t *testing.T) {
@@ -1409,8 +1416,10 @@ func TestSteps(t *testing.T) {
 
 		_, err = handle.GetResult()
 		require.Error(t, err, "expected error from cancelled parent")
+		// The durable cancel lands in the DB as soon as the context is cancelled,
+		// so the parent is interrupted either by the delivered child cancellation
+		// or by observing its own CANCELLED status at the step boundary.
 		require.True(t, errors.Is(err, &DBOSError{Code: WorkflowCancelled}), "expected WorkflowCancelled error, got: %v", err)
-		require.True(t, errors.Is(err, context.Canceled), "expected wrapped context.Canceled, got: %v", err)
 
 		require.Eventually(t, func() bool {
 			status, err := handle.GetStatus()
@@ -1620,8 +1629,12 @@ func TestSelect(t *testing.T) {
 
 	selectBlockStartEvent := NewEvent()
 	selectBlockEvent := NewEvent()
+	selectGoStepStarted := NewEvent()
 	selectCancelWorkflow := func(dbosCtx DBOSContext, input string) (string, error) {
 		ch1, err := Go(dbosCtx, func(ctx context.Context) (string, error) {
+			// Signal the step body has started (its checkpoint lookup passed), so
+			// the test can cancel without racing the durable cancel against it.
+			selectGoStepStarted.Set()
 			selectBlockEvent.Wait()
 			return "result", nil
 		})
@@ -1699,6 +1712,12 @@ func TestSelect(t *testing.T) {
 		// Wait for the workflow to reach the Select call (step has started and set the event)
 		selectBlockStartEvent.Wait()
 		selectBlockStartEvent.Clear()
+		// Wait for the Go step body to start: once it runs, its outcome is delivered
+		// and checkpointed even though the workflow is cancelled. Cancelling earlier
+		// would race the durable cancel against the step's checkpoint lookup, which
+		// can refuse to start the step at all (a valid outcome, but not this test's).
+		selectGoStepStarted.Wait()
+		selectGoStepStarted.Clear()
 
 		// Cancel the context manually
 		cancelFunc(nil)
@@ -1708,8 +1727,11 @@ func TestSelect(t *testing.T) {
 		require.Error(t, err, "expected error from cancelled workflow")
 		assert.Equal(t, "", result, "expected zero value string when cancelled")
 
-		// Verify the error is a cancellation error
-		assert.True(t, errors.Is(err, context.Canceled), "expected context.Canceled error, got: %v", err)
+		// Verify the error is a cancellation error. The durable cancel lands in the
+		// DB as soon as the context is cancelled, so Select is interrupted either
+		// mid-wait (wrapping context.Canceled) or at its step boundary by observing
+		// the CANCELLED status; both wrap WorkflowCancelled.
+		assert.True(t, errors.Is(err, &DBOSError{Code: WorkflowCancelled}), "expected WorkflowCancelled error, got: %v", err)
 
 		// Set the event to unblock the goroutine (cleanup)
 		selectBlockEvent.Set()
@@ -2691,6 +2713,17 @@ func TestWorkflowRecovery(t *testing.T) {
 
 	RegisterWorkflow(dbosCtx, recoveryWorkflow)
 
+	blockingStart := NewEvent()
+	blockingEvent := NewEvent()
+	blockingWorkflow := func(dbosCtx DBOSContext, input string) (string, error) {
+		return RunAsStep(dbosCtx, func(ctx context.Context) (string, error) {
+			blockingStart.Set()
+			blockingEvent.Wait()
+			return input, nil
+		})
+	}
+	RegisterWorkflow(dbosCtx, blockingWorkflow, WithWorkflowName("blocking-recovery-workflow"))
+
 	err := Launch(dbosCtx)
 	require.NoError(t, err, "failed to launch DBOS")
 
@@ -2767,6 +2800,39 @@ func TestWorkflowRecovery(t *testing.T) {
 			require.True(t, ok, "workflow %d not found in list result", i)
 			require.Equal(t, 2, wf.Attempts, "workflow %d should have 2 attempts after recovery", i)
 		}
+	})
+
+	// Recovering a workflow that is actively running on this executor must not
+	// fence out the live run: recovery skips launching (already active locally)
+	// and must leave owner_xid untouched so the run can record its outcome.
+	t.Run("RecoverWhileRunning", func(t *testing.T) {
+		handle, err := RunWorkflow(dbosCtx, blockingWorkflow, "hello", WithWorkflowID("recover-while-running"))
+		require.NoError(t, err, "failed to start blocking workflow")
+		blockingStart.Wait()
+
+		recoveredHandles, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
+		require.NoError(t, err, "failed to recover pending workflows")
+		var recoveredHandle WorkflowHandle[any]
+		for _, h := range recoveredHandles {
+			if h.GetWorkflowID() == handle.GetWorkflowID() {
+				recoveredHandle = h
+			}
+		}
+		require.NotNil(t, recoveredHandle, "expected a handle for the running workflow")
+
+		blockingEvent.Set()
+
+		result, err := handle.GetResult()
+		require.NoError(t, err, "live run should complete despite recovery dispatch")
+		require.Equal(t, "hello", result)
+
+		recoveredResult, err := recoveredHandle.GetResult()
+		require.NoError(t, err, "recovered handle should observe the run's outcome")
+		require.Equal(t, "hello", recoveredResult)
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get workflow status")
+		require.Equal(t, WorkflowStatusSuccess, status.Status)
 	})
 }
 
@@ -8756,8 +8822,8 @@ func TestWorkflowAttributes(t *testing.T) {
 			assert.Nil(t, s.Attributes)
 		}
 	})
-  
-  t.Run("Update", func(t *testing.T) {
+
+	t.Run("Update", func(t *testing.T) {
 		wfid := uuid.NewString()
 		handle, err := RunWorkflow(dbosCtx, attrNoopWorkflow, 1, WithWorkflowID(wfid), WithWorkflowAttributes(map[string]any{"customer": "acme-upd", "tier": 1}))
 		require.NoError(t, err)
@@ -8789,7 +8855,7 @@ func TestWorkflowAttributes(t *testing.T) {
 		var dbosErr *DBOSError
 		require.ErrorAs(t, err, &dbosErr)
 		assert.Equal(t, NonExistentWorkflowError, dbosErr.Code)
-  })
+	})
 }
 
 func TestFork(t *testing.T) {
@@ -9217,4 +9283,119 @@ func TestFork(t *testing.T) {
 			require.Equal(t, forksBefore, listForks())
 		})
 	})
+}
+
+// parkingPool wraps the system database pool and parks the first
+// updateWorkflowOutcome Exec for the target workflow until released,
+// signaling staleDone once that write has been attempted.
+type parkingPool struct {
+	Pool
+	target    string
+	parked    *Event
+	release   chan struct{}
+	staleDone chan struct{}
+	first     atomic.Bool
+}
+
+func (p *parkingPool) Exec(ctx context.Context, query string, args ...any) (Result, error) {
+	// Match on placeholder-free fragments: sqlite rewrites $N to ?N, so keying on
+	// "$2"/"$4" would never match there. The outcome-write UPDATE is the only query
+	// that sets both output and completed_at.
+	isOutcomeWrite := strings.Contains(query, "output =") && strings.Contains(query, "completed_at =")
+	if isOutcomeWrite && len(args) >= 5 && args[4] == any(p.target) && p.first.CompareAndSwap(false, true) {
+		p.parked.Set()
+		<-p.release
+		res, err := p.Pool.Exec(ctx, query, args...)
+		close(p.staleDone)
+		return res, err
+	}
+	return p.Pool.Exec(ctx, query, args...)
+}
+
+// A cancelled run's stale outcome write landing while the resumed row is still
+// ENQUEUED (resumed but not yet dequeued) must not flip it back to a terminal
+// state: the row would never be dequeued and the resume would be lost. The
+// resume targets a queue this process does not listen to yet, holding the row
+// in ENQUEUED until the stale write has been refused.
+func TestStaleOutcomeWriteOverEnqueued(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+
+	wfID := uuid.NewString()
+
+	var runs atomic.Int64
+	firstEntered := NewEvent()
+	firstRelease := make(chan struct{})
+	releaseFirst := sync.OnceFunc(func() { close(firstRelease) })
+	t.Cleanup(releaseFirst)
+
+	wf := func(ctx DBOSContext, _ string) (string, error) {
+		if runs.Add(1) == 1 {
+			firstEntered.Set()
+			<-firstRelease
+			return "", ctx.Err() // interrupted by the cancellation
+		}
+		return "completed", nil
+	}
+	RegisterWorkflow(dbosCtx, wf, WithWorkflowName("stale-over-enqueued-workflow"))
+
+	const parkedQueue = "stale-outcome-parked-queue"
+	_, err := RegisterQueue(dbosCtx, parkedQueue)
+	require.NoError(t, err, "failed to register queue")
+	// Don't listen to the parked queue yet: the resumed row must stay ENQUEUED
+	// until the stale write has landed.
+	ListenQueues(dbosCtx, WorkflowQueue{Name: "stale-outcome-unused-queue"})
+
+	sysdb := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+	park := &parkingPool{
+		Pool:      sysdb.pool,
+		target:    wfID,
+		parked:    NewEvent(),
+		release:   make(chan struct{}),
+		staleDone: make(chan struct{}),
+	}
+	sysdb.pool = park
+	releaseStale := sync.OnceFunc(func() { close(park.release) })
+	t.Cleanup(releaseStale)
+
+	require.NoError(t, Launch(dbosCtx), "failed to launch DBOS instance")
+
+	handle, err := RunWorkflow(dbosCtx, wf, "", WithWorkflowID(wfID))
+	require.NoError(t, err, "failed to start workflow")
+	firstEntered.Wait()
+
+	// Durably cancel while the first run is executing.
+	require.NoError(t, CancelWorkflow(dbosCtx, wfID), "failed to cancel workflow")
+
+	// Let the first run return: its outcome write parks before executing.
+	releaseFirst()
+	park.parked.Wait()
+
+	// The durable status is CANCELLED (written by CancelWorkflow, not parked).
+	status, err := handle.GetStatus()
+	require.NoError(t, err, "failed to get workflow status")
+	require.Equal(t, WorkflowStatusCancelled, status.Status, "expected CANCELLED before resume")
+
+	// Resume onto the unlistened queue: the row is ENQUEUED and stays there.
+	resumedHandle, err := ResumeWorkflow[string](dbosCtx, wfID, WithResumeQueue(parkedQueue))
+	require.NoError(t, err, "failed to resume workflow")
+
+	// Land the stale write on the ENQUEUED row: it must be refused.
+	releaseStale()
+	<-park.staleDone
+
+	status, err = resumedHandle.GetStatus()
+	require.NoError(t, err, "failed to get workflow status")
+	require.Equal(t, WorkflowStatusEnqueued, status.Status, "the stale outcome write must not flip the resumed row terminal")
+
+	// Start listening to the queue: the workflow is dequeued and completes.
+	ListenQueues(dbosCtx, WorkflowQueue{Name: parkedQueue})
+
+	result, err := resumedHandle.GetResult()
+	require.NoError(t, err, "failed to get resumed workflow result")
+	require.Equal(t, "completed", result)
+	require.EqualValues(t, 2, runs.Load(), "the resume must re-dispatch the workflow")
+
+	status, err = resumedHandle.GetStatus()
+	require.NoError(t, err, "failed to get workflow status")
+	require.Equal(t, WorkflowStatusSuccess, status.Status, "the resumed run's outcome must survive")
 }

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -2801,6 +2801,15 @@ func TestWorkflowRecovery(t *testing.T) {
 
 	var recoveryCounters []int64
 
+	// A child that fails while still returning a value: the parent's getResult
+	// checkpoint must carry both so replay matches the live execution.
+	var recoveryChildExecutions atomic.Int64
+	recoveryChildWorkflow := func(dbosCtx DBOSContext, index int) (int64, error) {
+		recoveryChildExecutions.Add(1)
+		return 42, errors.New("child failure")
+	}
+	RegisterWorkflow(dbosCtx, recoveryChildWorkflow, WithWorkflowName("recovery-child-workflow"))
+
 	recoveryWorkflow := func(dbosCtx DBOSContext, index int) (int64, error) {
 		// First step - increments the counter
 		_, err := RunAsStep(dbosCtx, func(ctx context.Context) (int64, error) {
@@ -2817,6 +2826,18 @@ func TestWorkflowRecovery(t *testing.T) {
 		}, WithStepName("step-two"))
 		if err != nil {
 			return 0, err
+		}
+
+		childHandle, err := RunWorkflow(dbosCtx, recoveryChildWorkflow, index)
+		if err != nil {
+			return 0, err
+		}
+		childRes, childErr := childHandle.GetResult()
+		if childErr == nil {
+			return 0, errors.New("expected the child failure to be returned")
+		}
+		if childRes != 42 {
+			return 0, fmt.Errorf("child value lost alongside its error: got %d", childRes)
 		}
 
 		return recoveryCounters[index], nil
@@ -2842,6 +2863,7 @@ func TestWorkflowRecovery(t *testing.T) {
 		const numWorkflows = 5
 
 		recoveryCounters = make([]int64, numWorkflows)
+		recoveryChildExecutions.Store(0)
 
 		// Start all workflows and let them run to completion
 		handles := make([]WorkflowHandle[int64], numWorkflows)
@@ -2854,6 +2876,7 @@ func TestWorkflowRecovery(t *testing.T) {
 			_, err := handles[i].GetResult()
 			require.NoError(t, err, "failed to get result from workflow %d", i)
 		}
+		require.EqualValues(t, numWorkflows, recoveryChildExecutions.Load(), "each workflow runs its child once")
 
 		// Flip all workflow statuses to PENDING, then recover
 		for i := range numWorkflows {
@@ -2868,7 +2891,9 @@ func TestWorkflowRecovery(t *testing.T) {
 			recoveredMap[h.GetWorkflowID()] = h
 		}
 
-		// 1) Result is as expected (counter value 1 from single execution, replayed idempotently)
+		// 1) Result is as expected (counter value 1 from single execution, replayed
+		// idempotently). The recovered run replays the child's checkpointed
+		// getResult, which must carry both the child's value and its error.
 		for i := range numWorkflows {
 			recoveredHandle := recoveredMap[handles[i].GetWorkflowID()]
 			require.NotNil(t, recoveredHandle, "workflow %d not found in recovered handles", i)
@@ -2876,12 +2901,13 @@ func TestWorkflowRecovery(t *testing.T) {
 			require.NoError(t, err, "failed to get result from recovered workflow %d", i)
 			require.Equal(t, float64(1), result.(float64), "workflow %d result should be 1", i)
 		}
+		require.EqualValues(t, numWorkflows, recoveryChildExecutions.Load(), "children must replay from their checkpoint, not re-execute")
 
-		// 2) Steps are as expected from a single execution (2 steps: step-one, step-two)
+		// 2) Steps are as expected from a single execution (4 steps: step-one, step-two, child spawn, getResult)
 		for i := range numWorkflows {
 			steps, err := GetWorkflowSteps(dbosCtx, handles[i].GetWorkflowID())
 			require.NoError(t, err, "failed to get steps for workflow %d", i)
-			require.Len(t, steps, 2, "expected 2 steps for workflow %d", i)
+			require.Len(t, steps, 4, "expected 4 steps for workflow %d", i)
 			assert.Equal(t, "step-one", steps[0].StepName, "workflow %d first step name", i)
 			assert.Equal(t, 0, steps[0].StepID, "workflow %d first step ID", i)
 			assert.NotNil(t, steps[0].Output, "workflow %d first step should have output", i)
@@ -2890,6 +2916,13 @@ func TestWorkflowRecovery(t *testing.T) {
 			assert.Equal(t, 1, steps[1].StepID, "workflow %d second step ID", i)
 			assert.NotNil(t, steps[1].Output, "workflow %d second step should have output", i)
 			assert.Nil(t, steps[1].Error, "workflow %d second step should not have error", i)
+			assert.Equal(t, "recovery-child-workflow", steps[2].StepName, "workflow %d third step name", i)
+			assert.Equal(t, 2, steps[2].StepID, "workflow %d third step ID", i)
+			assert.NotEmpty(t, steps[2].ChildWorkflowID, "workflow %d third step should record the child spawn", i)
+			assert.Equal(t, "DBOS.getResult", steps[3].StepName, "workflow %d fourth step name", i)
+			assert.Equal(t, 3, steps[3].StepID, "workflow %d fourth step ID", i)
+			assert.NotNil(t, steps[3].Output, "workflow %d getResult must checkpoint the child's value alongside its error", i)
+			assert.Error(t, steps[3].Error, "workflow %d getResult must checkpoint the child's error", i)
 		}
 
 		// 3) Workflow Attempts counter is 2 (initial run + recovery)

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -2984,6 +2984,18 @@ func TestCancelWorkflows(t *testing.T) {
 	}
 	RegisterWorkflow(dbosCtx, noDeadlineCancelWorkflow)
 
+	var finalStepCancelAttempts atomic.Int64
+	finalStepCancelStarted := NewEvent()
+	finalStepCancelRelease := make(chan struct{})
+	finalStepCancelWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		if finalStepCancelAttempts.Add(1) == 1 {
+			finalStepCancelStarted.Set()
+			<-finalStepCancelRelease
+		}
+		return "completed", nil
+	}
+	RegisterWorkflow(dbosCtx, finalStepCancelWorkflow)
+
 	err := Launch(dbosCtx)
 	require.NoError(t, err, "failed to launch DBOS instance")
 
@@ -3056,6 +3068,35 @@ func TestCancelWorkflows(t *testing.T) {
 	t.Run("CancelWorkflowsNilContext", func(t *testing.T) {
 		require.Error(t, CancelWorkflows(nil, []string{"id"}),
 			"CancelWorkflows should error on nil context")
+	})
+
+	t.Run("CancelledDuringFinalStepDoesNotComplete", func(t *testing.T) {
+		// A workflow API-cancelled while finishing its last work must end as
+		// CANCELLED, not complete: the refused outcome write is surfaced as a
+		// cancellation and the workflow stays resumable (same semantics as the
+		// Python/TS/Java SDKs).
+		handle, err := RunWorkflow(dbosCtx, finalStepCancelWorkflow, "")
+		require.NoError(t, err, "failed to start workflow")
+		finalStepCancelStarted.Wait()
+
+		require.NoError(t, CancelWorkflow(dbosCtx, handle.GetWorkflowID()), "failed to cancel workflow")
+		close(finalStepCancelRelease)
+
+		_, err = handle.GetResult()
+		require.Error(t, err, "a cancelled workflow must not complete")
+		require.True(t, errors.Is(err, &DBOSError{Code: WorkflowCancelled}), "expected WorkflowCancelled error, got: %v", err)
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get workflow status")
+		require.Equal(t, WorkflowStatusCancelled, status.Status, "the durable status must remain CANCELLED")
+		require.Nil(t, status.Output, "the refused outcome must not record an output")
+
+		resumedHandle, err := ResumeWorkflow[string](dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to resume workflow")
+		result, err := resumedHandle.GetResult()
+		require.NoError(t, err, "resumed workflow should complete successfully")
+		require.Equal(t, "completed", result)
+		require.EqualValues(t, 2, finalStepCancelAttempts.Load(), "expected the workflow to re-execute on resume")
 	})
 
 	t.Run("CancelWithoutDeadlineIsResumable", func(t *testing.T) {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -939,6 +939,73 @@ func TestSteps(t *testing.T) {
 
 	RegisterWorkflow(dbosCtx, sleepStepIDDriftWorkflow)
 
+	var interruptedStepAttempts atomic.Int64
+	interruptedStepStarted := NewEvent()
+	interruptibleStepWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		return RunAsStep(ctx, func(ctx context.Context) (string, error) {
+			if interruptedStepAttempts.Add(1) == 1 {
+				interruptedStepStarted.Set()
+				<-ctx.Done()
+				return "", ctx.Err()
+			}
+			return "completed", nil
+		})
+	}
+	RegisterWorkflow(dbosCtx, interruptibleStepWorkflow)
+
+	// Child that accepts preemption: the first attempt blocks until cancelled,
+	// later attempts complete.
+	var awaitedChildExecutions atomic.Int64
+	awaitedChildStarted := NewEvent()
+	awaitedChildWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		if awaitedChildExecutions.Add(1) == 1 {
+			awaitedChildStarted.Set()
+			<-ctx.Done()
+			return "", ctx.Err()
+		}
+		return "child-result", nil
+	}
+	RegisterWorkflow(dbosCtx, awaitedChildWorkflow)
+
+	awaitingParentWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		childHandle, err := RunWorkflow(ctx, awaitedChildWorkflow, "")
+		if err != nil {
+			return "", err
+		}
+		return childHandle.GetResult()
+	}
+	RegisterWorkflow(dbosCtx, awaitingParentWorkflow)
+
+	// Child that ignores cancellation and completes once released.
+	var stubbornChildExecutions atomic.Int64
+	stubbornChildStarted := NewEvent()
+	stubbornChildRelease := make(chan struct{})
+	stubbornChildWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		stubbornChildExecutions.Add(1)
+		stubbornChildStarted.Set()
+		<-stubbornChildRelease
+		return "child-result", nil
+	}
+	RegisterWorkflow(dbosCtx, stubbornChildWorkflow)
+
+	stubbornParentWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		childHandle, err := RunWorkflow(ctx, stubbornChildWorkflow, "")
+		if err != nil {
+			return "", err
+		}
+		res, err := childHandle.GetResult()
+		if err != nil {
+			return "", err
+		}
+		return RunAsStep(ctx, func(stepCtx context.Context) (string, error) {
+			if stepCtx.Err() != nil {
+				return "", stepCtx.Err()
+			}
+			return res + "-done", nil
+		})
+	}
+	RegisterWorkflow(dbosCtx, stubbornParentWorkflow)
+
 	err := Launch(dbosCtx)
 	require.NoError(t, err, "failed to launch DBOS")
 
@@ -1205,6 +1272,149 @@ func TestSteps(t *testing.T) {
 		require.Equal(t, 0, steps[0].StepID,
 			"step ID was reallocated by the DB-layer retry: nextStepID() must be called outside the retried closure")
 	})
+
+	t.Run("CancelledStepNotCheckpointed", func(t *testing.T) {
+		// A step interrupted by workflow cancellation must not checkpoint its
+		// cancellation error, so resume re-executes it instead of replaying the error.
+		cancelCtx, cancelFunc := WithTimeout(dbosCtx, 5*time.Hour)
+		defer cancelFunc()
+		handle, err := RunWorkflow(cancelCtx, interruptibleStepWorkflow, "")
+		require.NoError(t, err, "failed to start workflow")
+
+		interruptedStepStarted.Wait()
+		cancelFunc()
+
+		_, err = handle.GetResult()
+		require.Error(t, err, "expected error from cancelled workflow")
+		require.True(t, errors.Is(err, &DBOSError{Code: WorkflowCancelled}), "expected WorkflowCancelled error, got: %v", err)
+		require.True(t, errors.Is(err, context.Canceled), "expected wrapped context.Canceled, got: %v", err)
+
+		require.Eventually(t, func() bool {
+			status, err := handle.GetStatus()
+			require.NoError(t, err, "failed to get workflow status")
+			return status.Status == WorkflowStatusCancelled
+		}, 5*time.Second, 100*time.Millisecond, "workflow did not reach cancelled status in time")
+
+		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps")
+		require.Len(t, steps, 0, "step interrupted by cancellation must not be recorded")
+
+		resumedHandle, err := ResumeWorkflow[string](dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to resume workflow")
+		result, err := resumedHandle.GetResult()
+		require.NoError(t, err, "resumed workflow should complete successfully")
+		require.Equal(t, "completed", result)
+		require.EqualValues(t, 2, interruptedStepAttempts.Load(), "expected the step to re-execute on resume")
+
+		steps, err = GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps after resume")
+		require.Len(t, steps, 1, "expected the re-executed step to be recorded")
+	})
+
+	t.Run("CancelledParentRecordsSurvivingChildOutcome", func(t *testing.T) {
+		// Parent cancelled while awaiting a child that ignores cancellation: the
+		// child's delivered outcome is durably recorded by getResult, then the
+		// next step aborts on cancellation. Resume picks up after the await.
+		cancelCtx, cancelFunc := WithCancel(dbosCtx)
+		defer cancelFunc()
+		handle, err := RunWorkflow(cancelCtx, stubbornParentWorkflow, "")
+		require.NoError(t, err, "failed to start parent workflow")
+
+		stubbornChildStarted.Wait()
+		cancelFunc()
+		close(stubbornChildRelease)
+
+		_, err = handle.GetResult()
+		require.Error(t, err, "expected error from cancelled parent")
+		require.True(t, errors.Is(err, context.Canceled), "expected wrapped context.Canceled, got: %v", err)
+
+		require.Eventually(t, func() bool {
+			status, err := handle.GetStatus()
+			require.NoError(t, err, "failed to get workflow status")
+			return status.Status == WorkflowStatusCancelled
+		}, 5*time.Second, 100*time.Millisecond, "parent did not reach cancelled status in time")
+
+		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps")
+		require.Len(t, steps, 2, "expected child spawn and getResult recorded; the interrupted step must not be")
+		childID := steps[0].ChildWorkflowID
+		require.NotEmpty(t, childID, "expected the first step to be the child spawn")
+		require.Equal(t, "DBOS.getResult", steps[1].StepName)
+		require.Nil(t, steps[1].Error, "the delivered child outcome must be recorded without error")
+
+		childHandle, err := RetrieveWorkflow[string](dbosCtx, childID)
+		require.NoError(t, err, "failed to retrieve child workflow")
+		childStatus, err := childHandle.GetStatus()
+		require.NoError(t, err, "failed to get child workflow status")
+		require.Equal(t, WorkflowStatusSuccess, childStatus.Status, "child ignoring cancellation must complete")
+
+		resumedHandle, err := ResumeWorkflow[string](dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to resume parent workflow")
+		result, err := resumedHandle.GetResult()
+		require.NoError(t, err, "resumed parent should complete")
+		require.Equal(t, "child-result-done", result)
+		require.EqualValues(t, 1, stubbornChildExecutions.Load(), "child must not re-execute on parent resume")
+	})
+
+	t.Run("PreemptedChildCancellationNotCheckpointed", func(t *testing.T) {
+		// Parent cancelled while awaiting a child that accepts preemption: the
+		// child's cancellation error passes through getResult and must not be
+		// checkpointed, so the parent resumes at the await. After resuming the
+		// child, resuming the parent re-awaits and gets the child's real outcome.
+		cancelCtx, cancelFunc := WithCancel(dbosCtx)
+		defer cancelFunc()
+		handle, err := RunWorkflow(cancelCtx, awaitingParentWorkflow, "")
+		require.NoError(t, err, "failed to start parent workflow")
+
+		awaitedChildStarted.Wait()
+		cancelFunc()
+
+		_, err = handle.GetResult()
+		require.Error(t, err, "expected error from cancelled parent")
+		require.True(t, errors.Is(err, &DBOSError{Code: WorkflowCancelled}), "expected WorkflowCancelled error, got: %v", err)
+		require.True(t, errors.Is(err, context.Canceled), "expected wrapped context.Canceled, got: %v", err)
+
+		require.Eventually(t, func() bool {
+			status, err := handle.GetStatus()
+			require.NoError(t, err, "failed to get workflow status")
+			return status.Status == WorkflowStatusCancelled
+		}, 5*time.Second, 100*time.Millisecond, "parent did not reach cancelled status in time")
+
+		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps")
+		require.Len(t, steps, 1, "only the child spawn must be recorded, not the preempted await")
+		childID := steps[0].ChildWorkflowID
+		require.NotEmpty(t, childID, "expected the recorded step to be the child spawn")
+
+		childHandle, err := RetrieveWorkflow[string](dbosCtx, childID)
+		require.NoError(t, err, "failed to retrieve child workflow")
+		require.Eventually(t, func() bool {
+			status, err := childHandle.GetStatus()
+			require.NoError(t, err, "failed to get child workflow status")
+			return status.Status == WorkflowStatusCancelled
+		}, 5*time.Second, 100*time.Millisecond, "child did not reach cancelled status in time")
+
+		// Resume the child, then the parent: the re-executed await must return
+		// the child's real outcome.
+		resumedChild, err := ResumeWorkflow[string](dbosCtx, childID)
+		require.NoError(t, err, "failed to resume child workflow")
+		childResult, err := resumedChild.GetResult()
+		require.NoError(t, err, "resumed child should complete")
+		require.Equal(t, "child-result", childResult)
+
+		resumedHandle, err := ResumeWorkflow[string](dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to resume parent workflow")
+		result, err := resumedHandle.GetResult()
+		require.NoError(t, err, "resumed parent should complete with the child's outcome")
+		require.Equal(t, "child-result", result)
+		require.EqualValues(t, 2, awaitedChildExecutions.Load(), "child executes once per attempt, never replays past outcomes")
+
+		steps, err = GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps after resume")
+		require.Len(t, steps, 2, "expected spawn and the re-executed getResult after resume")
+		require.Equal(t, "DBOS.getResult", steps[1].StepName)
+		require.Nil(t, steps[1].Error)
+	})
 }
 
 func stepReturningStepID(ctx context.Context) (int, error) {
@@ -1433,23 +1643,20 @@ func TestSelect(t *testing.T) {
 		// Set the event to unblock the goroutine (cleanup)
 		selectBlockEvent.Set()
 
-		// Verify workflow status is error (Select returns an error when the context is cancelled)
+		// Verify workflow status is cancelled (the workflow was interrupted by context cancellation)
 		status, err := handle.GetStatus()
 		require.NoError(t, err, "failed to get workflow status")
-		assert.Equal(t, WorkflowStatusError, status.Status, "expected workflow status to be WorkflowStatusError")
+		assert.Equal(t, WorkflowStatusCancelled, status.Status, "expected workflow status to be WorkflowStatusCancelled")
 
-		// Verify DBOS.select step is present at index 1 (after Go step at index 0)
-		// There is a race condition here, so we need to wait for the steps to be recorded
+		// The cancelled Select step must not be checkpointed (it would replay its
+		// cancellation error on resume); only the Go step, unblocked above, records.
 		require.Eventually(t, func() bool {
 			steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
 			if err != nil {
 				return false
 			}
-			if len(steps) != 2 {
-				return false
-			}
-			return steps[1].StepName == "DBOS.select" && steps[1].StepID == 1
-		}, 5*time.Second, 100*time.Millisecond, "expected 2 steps (Go + Select) with DBOS.select at index 1")
+			return len(steps) == 1 && steps[0].StepID == 0
+		}, 5*time.Second, 100*time.Millisecond, "expected only the Go step to be recorded")
 	})
 
 	t.Run("Select idempotency", func(t *testing.T) {
@@ -2755,6 +2962,18 @@ func TestCancelWorkflows(t *testing.T) {
 	}
 	RegisterWorkflow(dbosCtx, blockingWorkflow)
 
+	var noDeadlineCancelAttempts atomic.Int64
+	noDeadlineCancelStarted := NewEvent()
+	noDeadlineCancelWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		if noDeadlineCancelAttempts.Add(1) == 1 {
+			noDeadlineCancelStarted.Set()
+			<-ctx.Done()
+			return "", ctx.Err()
+		}
+		return "completed", nil
+	}
+	RegisterWorkflow(dbosCtx, noDeadlineCancelWorkflow)
+
 	err := Launch(dbosCtx)
 	require.NoError(t, err, "failed to launch DBOS instance")
 
@@ -2827,6 +3046,34 @@ func TestCancelWorkflows(t *testing.T) {
 	t.Run("CancelWorkflowsNilContext", func(t *testing.T) {
 		require.Error(t, CancelWorkflows(nil, []string{"id"}),
 			"CancelWorkflows should error on nil context")
+	})
+
+	t.Run("CancelWithoutDeadlineIsResumable", func(t *testing.T) {
+		// A workflow interrupted by plain context cancellation (no deadline, so no
+		// AfterFunc cancels it in the DB) must be marked CANCELLED, not ERROR, so
+		// it can be resumed.
+		cancelCtx, cancelFunc := WithCancel(dbosCtx)
+		defer cancelFunc()
+		handle, err := RunWorkflow(cancelCtx, noDeadlineCancelWorkflow, "")
+		require.NoError(t, err, "failed to start workflow")
+
+		noDeadlineCancelStarted.Wait()
+		cancelFunc()
+
+		_, err = handle.GetResult()
+		require.Error(t, err, "expected error from cancelled workflow")
+		require.True(t, errors.Is(err, context.Canceled), "expected context.Canceled, got: %v", err)
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get workflow status")
+		require.Equal(t, WorkflowStatusCancelled, status.Status, "expected workflow status to be WorkflowStatusCancelled")
+
+		resumedHandle, err := ResumeWorkflow[string](dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to resume workflow")
+		result, err := resumedHandle.GetResult()
+		require.NoError(t, err, "resumed workflow should complete successfully")
+		require.Equal(t, "completed", result)
+		require.EqualValues(t, 2, noDeadlineCancelAttempts.Load(), "expected the workflow to re-execute on resume")
 	})
 }
 
@@ -5027,12 +5274,11 @@ func TestWorkflowTimeout(t *testing.T) {
 		require.NoError(t, err, "failed to get recovered workflow status")
 		assert.Equal(t, WorkflowStatusCancelled, recoveredStatus.Status, "expected recovered workflow status to be WorkflowStatusCancelled")
 
-		// Check the deadline on the status was is within an expected range (start time + timeout * .1)
-		// FIXME this might be flaky and frankly not super useful
-		expectedDeadline := start.Add(timeout * 10 / 100)
-		assert.True(t, status.Deadline.After(expectedDeadline) && status.Deadline.Before(start.Add(timeout)),
-			"expected workflow deadline to be within %v and %v, got %v", expectedDeadline, start.Add(timeout), status.Deadline)
+		// The durable deadline is insert time + timeout; allow tolerance for insert latency and ms truncation
+		assert.WithinDuration(t, start.Add(timeout), status.Deadline, 500*time.Millisecond,
+			"expected workflow deadline to be about %v, got %v", start.Add(timeout), status.Deadline)
 	})
+
 }
 
 func notificationWaiterWorkflow(ctx DBOSContext, pairID int) (string, error) {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1044,6 +1044,28 @@ func TestSteps(t *testing.T) {
 	}
 	RegisterWorkflow(dbosCtx, apiCancelParentWorkflow)
 
+	// Two live executions of the same workflow race to checkpoint this step:
+	// each blocks until released; the one released second loses the checkpoint
+	// race. Used by ConflictingRunDisarmsDurableCancel.
+	var conflictCancelExecs atomic.Int64
+	conflictCancelFirstStarted := NewEvent()
+	conflictCancelSecondStarted := NewEvent()
+	conflictCancelReleaseFirst := make(chan struct{})
+	conflictCancelReleaseSecond := make(chan struct{})
+	conflictCancelWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		return RunAsStep(ctx, func(context.Context) (string, error) {
+			if conflictCancelExecs.Add(1) == 1 {
+				conflictCancelFirstStarted.Set()
+				<-conflictCancelReleaseFirst
+			} else {
+				conflictCancelSecondStarted.Set()
+				<-conflictCancelReleaseSecond
+			}
+			return "ok", nil
+		})
+	}
+	RegisterWorkflow(dbosCtx, conflictCancelWorkflow, WithWorkflowName("conflict-cancel-workflow"))
+
 	// Installed before Launch so no goroutine reads sysDB.pool concurrently
 	// with the swap; armed on demand by StepIDNotReallocatedOnDBRetry.
 	sysdb := dbosCtx.(*dbosContext).systemDB.(*sysDB)
@@ -1494,6 +1516,95 @@ func TestSteps(t *testing.T) {
 		require.Equal(t, "DBOS.getResult", steps[1].StepName)
 		require.Error(t, steps[1].Error, "the child's cancellation must be durably recorded")
 		require.True(t, errors.Is(steps[1].Error, &DBOSError{Code: AwaitedWorkflowCancelled}), "expected recorded AwaitedWorkflowCancelled error, got: %v", steps[1].Error)
+	})
+
+	t.Run("ConflictingRunDisarmsDurableCancel", func(t *testing.T) {
+		// When two live executions of the same workflow ID race to checkpoint a
+		// step, the loser's function returns ConflictingIDError and its
+		// RunWorkflow goroutine awaits the winner's result. Losing the conflict
+		// disproves ownership, so the branch must disarm the durable-cancel
+		// AfterFunc right there: a later cancellation of the context the caller
+		// used for the losing dispatch (the routine `defer cancelFunc()`
+		// pattern) must not durably cancel the owning — or a future resumed —
+		// run. The disarm cannot wait for the branch to settle: the loss is
+		// observable through polling handles while the loser is still awaiting.
+		//
+		// The losing execution needs a real second executor: a single
+		// in-process guard cannot double-run a workflow (same construction as
+		// TestRecvStepConflict). No leak check: its lifetime overlaps dbosCtx's.
+		ctxB := setupDBOS(t, setupDBOSOptions{dropDB: false, checkLeaks: false})
+		RegisterWorkflow(ctxB, conflictCancelWorkflow, WithWorkflowName("conflict-cancel-workflow"))
+		// Register the parking queue on executor B but don't listen to it (and
+		// never register it on the main executor), so the later resume leaves
+		// the workflow durably ENQUEUED — making a spurious cancel observable.
+		const parkedQueue = "conflict-cancel-parked-queue"
+		_, err := RegisterQueue(ctxB, parkedQueue)
+		require.NoError(t, err, "failed to register parking queue")
+		ListenQueues(ctxB, WorkflowQueue{Name: "conflict-cancel-unused-queue"})
+		require.NoError(t, Launch(ctxB), "failed to launch executor B")
+
+		wfID := uuid.NewString()
+
+		// Execution 1 on the main executor: enters the step and blocks.
+		handleA, err := RunWorkflow(dbosCtx, conflictCancelWorkflow, "", WithWorkflowID(wfID))
+		require.NoError(t, err, "failed to start workflow")
+		conflictCancelFirstStarted.Wait()
+
+		// Execution 2 on executor B, dispatched under a user-cancellable
+		// context. Recovery dispatch is the sanctioned way to get a genuinely
+		// concurrent second execution (a direct RunWorkflow attaches to the
+		// owner's run instead).
+		cancelCtx, cancelFunc := WithCancel(ctxB)
+		defer cancelFunc()
+		recovered, err := recoverPendingWorkflows(cancelCtx.(*dbosContext), []string{"local"})
+		require.NoError(t, err, "failed to recover the workflow on executor B")
+		require.Len(t, recovered, 1, "expected exactly one pending workflow to recover")
+		require.Equal(t, wfID, recovered[0].GetWorkflowID())
+		conflictCancelSecondStarted.Wait()
+
+		// Cancel the workflow durably, then let execution 1 finish: its
+		// in-flight step checkpoints and the run ends cancelled.
+		require.NoError(t, CancelWorkflow(dbosCtx, wfID), "failed to cancel workflow")
+		close(conflictCancelReleaseFirst)
+		_, _ = handleA.GetResult()
+
+		// Let execution 2 finish: its step-0 checkpoint hits the unique
+		// violation and its goroutine takes the conflict-await branch.
+		close(conflictCancelReleaseSecond)
+		_, err = recovered[0].GetResult()
+		require.Error(t, err, "the losing execution must observe the cancelled outcome")
+		require.True(t, errors.Is(err, &DBOSError{Code: AwaitedWorkflowCancelled}) || errors.Is(err, &DBOSError{Code: WorkflowCancelled}),
+			"expected a cancellation error from the losing execution, got: %v", err)
+		require.EqualValues(t, 2, conflictCancelExecs.Load(), "both executions must have genuinely run the step body")
+
+		// Resume the workflow onto the unlistened queue: it is durably
+		// ENQUEUED, non-terminal again.
+		resumedHandle, err := ResumeWorkflow[string](ctxB, wfID, WithResumeQueue(parkedQueue))
+		require.NoError(t, err, "failed to resume workflow")
+		status, err := resumedHandle.GetStatus()
+		require.NoError(t, err, "failed to get resumed workflow status")
+		require.Equal(t, WorkflowStatusEnqueued, status.Status, "precondition: resumed workflow is ENQUEUED")
+
+		// Cancel the context used for the conflicting dispatch. That run lost
+		// the conflict and never owned this workflow: the resumed row must not
+		// be touched. A still-armed AfterFunc would durably cancel it within
+		// milliseconds.
+		cancelFunc()
+
+		require.Never(t, func() bool {
+			status, err := resumedHandle.GetStatus()
+			require.NoError(t, err, "failed to get workflow status")
+			return status.Status == WorkflowStatusCancelled
+		}, 3*time.Second, 100*time.Millisecond,
+			"cancelling the stale conflicting-dispatch context must not durably cancel the resumed workflow")
+
+		// Drain: start listening to the parking queue so the resumed workflow
+		// completes (replaying the checkpointed step), which also lets the
+		// loser's conflict-await goroutine finish before executor B shuts down.
+		ListenQueues(ctxB, WorkflowQueue{Name: parkedQueue})
+		result, err := resumedHandle.GetResult()
+		require.NoError(t, err, "resumed workflow should complete")
+		require.Equal(t, "ok", result)
 	})
 }
 

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -790,18 +790,28 @@ type faultTx struct {
 }
 
 func (t *faultTx) QueryRow(ctx context.Context, query string, args ...any) Row {
-	if strings.Contains(query, "operation_outputs") &&
-		len(args) > 0 && args[0] == t.p.target &&
+	target, _ := t.p.target.Load().(string)
+	if target != "" && strings.Contains(query, "operation_outputs") &&
+		len(args) > 0 && args[0] == any(target) &&
 		t.p.fired.CompareAndSwap(false, true) {
 		return errRow{errors.New("conn closed")} // retryable per postgresDialect.IsRetryable
 	}
 	return t.Tx.QueryRow(ctx, query, args...)
 }
 
+// faultPool is installed over sysDB.pool before Launch — while no goroutine
+// reads the field — and stays for the whole test, so arming it later doesn't
+// race pool readers such as the queue runner. Disarmed (empty target) it is a
+// transparent pass-through.
 type faultPool struct {
 	Pool
-	target string       // workflow ID whose operation_outputs read should fault
-	fired  *atomic.Bool // ensures the fault triggers at most once
+	target atomic.Value // string: workflow ID whose operation_outputs read should fault; "" disarms
+	fired  atomic.Bool  // ensures the fault triggers at most once per arm
+}
+
+func (p *faultPool) arm(workflowID string) {
+	p.fired.Store(false)
+	p.target.Store(workflowID)
 }
 
 func (p *faultPool) BeginTx(ctx context.Context, opts TxOptions) (Tx, error) {
@@ -1005,6 +1015,12 @@ func TestSteps(t *testing.T) {
 		})
 	}
 	RegisterWorkflow(dbosCtx, stubbornParentWorkflow)
+
+	// Installed before Launch so no goroutine reads sysDB.pool concurrently
+	// with the swap; armed on demand by StepIDNotReallocatedOnDBRetry.
+	sysdb := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+	stepsFaultPool := &faultPool{Pool: sysdb.pool}
+	sysdb.pool = stepsFaultPool
 
 	err := Launch(dbosCtx)
 	require.NoError(t, err, "failed to launch DBOS")
@@ -1249,21 +1265,15 @@ func TestSteps(t *testing.T) {
 	t.Run("StepIDNotReallocatedOnDBRetry", func(t *testing.T) {
 		wfID := "step-id-drift-test"
 
-		s := dbosCtx.(*dbosContext).systemDB.(*sysDB)
-		orig := s.pool
-		var fired atomic.Bool
-		s.pool = &faultPool{Pool: orig, target: wfID, fired: &fired}
-		// The listener captured the real pool at Launch and no longer reads the
-		// field; the workflow goroutine is joined via GetResult before we restore,
-		// so this swap is race-free.
-		defer func() { s.pool = orig }()
+		stepsFaultPool.arm(wfID)
+		defer stepsFaultPool.arm("")
 
 		handle, err := RunWorkflow(dbosCtx, sleepStepIDDriftWorkflow, "", WithWorkflowID(wfID))
 		require.NoError(t, err)
 		result, err := handle.GetResult()
 		require.NoError(t, err)
 		require.Equal(t, "ok", result)
-		require.True(t, fired.Load(), "fault injection never triggered; the test did not exercise a retry")
+		require.True(t, stepsFaultPool.fired.Load(), "fault injection never triggered; the test did not exercise a retry")
 
 		steps, err := GetWorkflowSteps(dbosCtx, wfID)
 		require.NoError(t, err)

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -833,6 +833,7 @@ func sleepStepIDDriftWorkflow(ctx DBOSContext, _ string) (string, error) {
 
 func TestSteps(t *testing.T) {
 	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+	stepsDatabaseURL := backendDatabaseURL(t)
 
 	// Create workflows with executor
 	RegisterWorkflow(dbosCtx, stepWithinAStepWorkflow)
@@ -1532,7 +1533,9 @@ func TestSteps(t *testing.T) {
 		// The losing execution needs a real second executor: a single
 		// in-process guard cannot double-run a workflow (same construction as
 		// TestRecvStepConflict). No leak check: its lifetime overlaps dbosCtx's.
-		ctxB := setupDBOS(t, setupDBOSOptions{dropDB: false, checkLeaks: false})
+		// Pin executor B to the parent's database: sqlite URLs are per-test, so a
+		// subtest's setupDBOS would otherwise get a fresh DB with nothing to recover.
+		ctxB := setupDBOS(t, setupDBOSOptions{dropDB: false, checkLeaks: false, databaseURL: stepsDatabaseURL})
 		RegisterWorkflow(ctxB, conflictCancelWorkflow, WithWorkflowName("conflict-cancel-workflow"))
 		// Register the parking queue on executor B but don't listen to it (and
 		// never register it on the main executor), so the later resume leaves

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1594,12 +1594,17 @@ func TestSteps(t *testing.T) {
 		// milliseconds.
 		cancelFunc()
 
-		require.Never(t, func() bool {
+		// Poll synchronously rather than with require.Never: testify runs each
+		// tick in a goroutine and returns at the timeout without awaiting an
+		// in-flight tick, so a straggler GetStatus can race the subtest's
+		// ctxB shutdown in t.Cleanup and fail with "context canceled".
+		for deadline := time.Now().Add(3 * time.Second); time.Now().Before(deadline); {
 			status, err := resumedHandle.GetStatus()
 			require.NoError(t, err, "failed to get workflow status")
-			return status.Status == WorkflowStatusCancelled
-		}, 3*time.Second, 100*time.Millisecond,
-			"cancelling the stale conflicting-dispatch context must not durably cancel the resumed workflow")
+			require.NotEqual(t, WorkflowStatusCancelled, status.Status,
+				"cancelling the stale conflicting-dispatch context must not durably cancel the resumed workflow")
+			time.Sleep(100 * time.Millisecond)
+		}
 
 		// Drain: start listening to the parking queue so the resumed workflow
 		// completes (replaying the checkpointed step), which also lets the

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1016,6 +1016,34 @@ func TestSteps(t *testing.T) {
 	}
 	RegisterWorkflow(dbosCtx, stubbornParentWorkflow)
 
+	// Child cancelled via the API while the parent stays healthy: blocks until
+	// released, then observes its cancellation at the next step boundary.
+	var apiCancelledChildID string
+	apiCancelChildStarted := NewEvent()
+	apiCancelChildRelease := make(chan struct{})
+	apiCancelChildWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		id, err := GetWorkflowID(ctx)
+		if err != nil {
+			return "", err
+		}
+		apiCancelledChildID = id
+		apiCancelChildStarted.Set()
+		<-apiCancelChildRelease
+		return RunAsStep(ctx, func(context.Context) (string, error) {
+			return "child-result", nil
+		})
+	}
+	RegisterWorkflow(dbosCtx, apiCancelChildWorkflow)
+
+	apiCancelParentWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		childHandle, err := RunWorkflow(ctx, apiCancelChildWorkflow, "")
+		if err != nil {
+			return "", err
+		}
+		return childHandle.GetResult()
+	}
+	RegisterWorkflow(dbosCtx, apiCancelParentWorkflow)
+
 	// Installed before Launch so no goroutine reads sysDB.pool concurrently
 	// with the swap; armed on demand by StepIDNotReallocatedOnDBRetry.
 	sysdb := dbosCtx.(*dbosContext).systemDB.(*sysDB)
@@ -1424,6 +1452,39 @@ func TestSteps(t *testing.T) {
 		require.Len(t, steps, 2, "expected spawn and the re-executed getResult after resume")
 		require.Equal(t, "DBOS.getResult", steps[1].StepName)
 		require.Nil(t, steps[1].Error)
+	})
+
+	t.Run("CancelledChildOutcomeCheckpointed", func(t *testing.T) {
+		// The child is cancelled via the API while the parent stays healthy: the
+		// child's cancellation is a terminal outcome for the parent, recorded
+		// durably by getResult so replay is deterministic (like the other SDKs).
+		handle, err := RunWorkflow(dbosCtx, apiCancelParentWorkflow, "")
+		require.NoError(t, err, "failed to start parent workflow")
+
+		apiCancelChildStarted.Wait()
+		require.NoError(t, CancelWorkflow(dbosCtx, apiCancelledChildID), "failed to cancel child workflow")
+		close(apiCancelChildRelease)
+
+		_, err = handle.GetResult()
+		require.Error(t, err, "expected error from parent awaiting a cancelled child")
+		require.True(t, errors.Is(err, &DBOSError{Code: AwaitedWorkflowCancelled}), "expected AwaitedWorkflowCancelled error, got: %v", err)
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get parent workflow status")
+		require.Equal(t, WorkflowStatusError, status.Status, "healthy parent observing a cancelled child ends in ERROR")
+
+		childHandle, err := RetrieveWorkflow[string](dbosCtx, apiCancelledChildID)
+		require.NoError(t, err, "failed to retrieve child workflow")
+		childStatus, err := childHandle.GetStatus()
+		require.NoError(t, err, "failed to get child workflow status")
+		require.Equal(t, WorkflowStatusCancelled, childStatus.Status, "expected child workflow to be cancelled")
+
+		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps")
+		require.Len(t, steps, 2, "expected the child spawn and the recorded getResult")
+		require.Equal(t, "DBOS.getResult", steps[1].StepName)
+		require.Error(t, steps[1].Error, "the child's cancellation must be durably recorded")
+		require.True(t, errors.Is(steps[1].Error, &DBOSError{Code: AwaitedWorkflowCancelled}), "expected recorded AwaitedWorkflowCancelled error, got: %v", steps[1].Error)
 	})
 }
 

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3123,6 +3123,19 @@ func TestCancelWorkflows(t *testing.T) {
 	}
 	RegisterWorkflow(dbosCtx, finalStepCancelWorkflow)
 
+	// Ignores its cancellation entirely and returns a successful result.
+	var swallowCancelAttempts atomic.Int64
+	swallowCancelStarted := NewEvent()
+	swallowCancelRelease := make(chan struct{})
+	swallowCancelWorkflow := func(ctx DBOSContext, _ string) (string, error) {
+		if swallowCancelAttempts.Add(1) == 1 {
+			swallowCancelStarted.Set()
+			<-swallowCancelRelease
+		}
+		return "swallowed", nil
+	}
+	RegisterWorkflow(dbosCtx, swallowCancelWorkflow)
+
 	err := Launch(dbosCtx)
 	require.NoError(t, err, "failed to launch DBOS instance")
 
@@ -3252,6 +3265,47 @@ func TestCancelWorkflows(t *testing.T) {
 		require.NoError(t, err, "resumed workflow should complete successfully")
 		require.Equal(t, "completed", result)
 		require.EqualValues(t, 2, noDeadlineCancelAttempts.Load(), "expected the workflow to re-execute on resume")
+	})
+
+	t.Run("SwallowedCancellationIsNotSuccess", func(t *testing.T) {
+		// A workflow that ignores its cancellation and returns (result, nil) must
+		// not report success on the in-process handle: the durable row is CANCELLED
+		// and no output was recorded, so GetResult surfaces WorkflowCancelled —
+		// consistent with what a polling handle for the same workflow returns.
+		cancelCtx, cancelFunc := WithCancel(dbosCtx)
+		defer cancelFunc()
+		handle, err := RunWorkflow(cancelCtx, swallowCancelWorkflow, "")
+		require.NoError(t, err, "failed to start workflow")
+
+		swallowCancelStarted.Wait()
+		cancelFunc()
+
+		// Wait for the durable cancel before releasing the workflow, so its
+		// normal return deterministically lands after the cancellation.
+		require.Eventually(t, func() bool {
+			status, err := handle.GetStatus()
+			require.NoError(t, err, "failed to get workflow status")
+			return status.Status == WorkflowStatusCancelled
+		}, 5*time.Second, 10*time.Millisecond, "workflow did not reach cancelled status in time")
+		close(swallowCancelRelease)
+
+		result, err := handle.GetResult()
+		require.Error(t, err, "a cancelled workflow must not report success")
+		require.True(t, errors.Is(err, &DBOSError{Code: WorkflowCancelled}), "expected WorkflowCancelled error, got: %v", err)
+		require.Equal(t, "", result, "no output may be reported for a cancelled workflow")
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get workflow status")
+		require.Equal(t, WorkflowStatusCancelled, status.Status)
+		require.Nil(t, status.Output, "the swallowed result must not be recorded")
+
+		// Plain cancel remains resumable; re-execution completes normally.
+		resumedHandle, err := ResumeWorkflow[string](dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to resume workflow")
+		result, err = resumedHandle.GetResult()
+		require.NoError(t, err, "resumed workflow should complete successfully")
+		require.Equal(t, "swallowed", result)
+		require.EqualValues(t, 2, swallowCancelAttempts.Load(), "expected the workflow to re-execute on resume")
 	})
 }
 


### PR DESCRIPTION
- Trigger a durable cancel when the context is manually cancelled, too. Also forbid updating workflow outcome when status is cancelled.
- Stop recording durably cancellation errors for steps and transactions
- Stop updating workflow outcomes when the status is already CANCELLED.
- Fix a race between clearing the activeWorkflowIDs map and the workflow outcome being writen (the latter happens before the former and can lead to stuck workflows)

Also add a new chaos suite for context cancellation, checking that the invariant "cancelled workflow can be resumed".