### PR TITLE
Manual context cancel trigger durable cancellation

### DIFF
--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -930,7 +930,6 @@ type insertWorkflowStatusDBInput struct {
 	tx                Tx
 	ownerXID          *string
 	incrementAttempts bool
-	claimOwnership    bool
 }
 
 func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowStatusDBInput) (*insertWorkflowResult, error) {
@@ -1047,10 +1046,6 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
             executor_id = CASE
                 WHEN EXCLUDED.status IN ($28, $29) THEN workflow_status.executor_id
                 ELSE EXCLUDED.executor_id
-            END,
-            owner_xid = CASE
-                WHEN $31 > 0 THEN EXCLUDED.owner_xid
-                ELSE workflow_status.owner_xid
             END
         RETURNING recovery_attempts, status, name, queue_name, queue_partition_key, workflow_timeout_ms, workflow_deadline_epoch_ms, owner_xid`, s.dialect.SchemaPrefix(s.schema))
 
@@ -1069,10 +1064,6 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
 	recoveryIncrement := 0
 	if input.incrementAttempts {
 		recoveryIncrement = 1
-	}
-	ownershipClaim := 0
-	if input.claimOwnership {
-		ownershipClaim = 1
 	}
 	err = input.tx.QueryRow(ctx, query,
 		input.status.ID,
@@ -1105,7 +1096,6 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
 		WorkflowStatusEnqueued,
 		WorkflowStatusDelayed,
 		recoveryIncrement,
-		ownershipClaim,
 	).Scan(
 		&result.attempts,
 		&result.status,
@@ -1532,20 +1522,17 @@ type updateWorkflowOutcomeDBInput struct {
 	status     WorkflowStatusType
 	output     *string
 	errStr     string
-	ownerXID   string
 	tx         Tx
 }
 
-// updateWorkflowOutcome records a workflow's terminal outcome, but never overwrites a
-// row that is already terminal, a row that has been re-enqueued, or a row
-// whose owner_xid no longer matches this run's claim (the workflow was resumed or
-// re-dispatched to another executor/goroutine). If the write is refused for any reason other
-// than the workflow having completed (SUCCESS/ERROR), returns a WorkflowCancelled
-// error so the caller ends the workflow as cancelled rather than completing it.
+// updateWorkflowOutcome records a workflow's terminal outcome. Only a PENDING row can
+// receive an outcome: any other status means the run was superseded (already terminal,
+// re-enqueued by a resume, ...). If the write is refused for any reason other than the workflow having
+// completed (SUCCESS/ERROR), returns a WorkflowCancelled error.
 func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowOutcomeDBInput) error {
 	query := s.renderSQL(`UPDATE %sworkflow_status
 			  SET status = $1, output = $2, error = $3, updated_at = $4, completed_at = $4, deduplication_id = NULL
-			  WHERE workflow_uuid = $5 AND status NOT IN ($6, $7, $8, $9) AND owner_xid = $10`, s.dialect.SchemaPrefix(s.schema))
+			  WHERE workflow_uuid = $5 AND status = $6`, s.dialect.SchemaPrefix(s.schema))
 
 	var runner Querier = s.pool
 	if input.tx != nil {
@@ -1553,7 +1540,7 @@ func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowO
 	}
 
 	// input.output is already a *string from the database layer
-	res, err := runner.Exec(ctx, query, input.status, input.output, input.errStr, time.Now().UnixMilli(), input.workflowID, WorkflowStatusCancelled, WorkflowStatusSuccess, WorkflowStatusError, WorkflowStatusEnqueued, input.ownerXID)
+	res, err := runner.Exec(ctx, query, input.status, input.output, input.errStr, time.Now().UnixMilli(), input.workflowID, WorkflowStatusPending)
 	if err != nil {
 		return fmt.Errorf("failed to update workflow status: %w", err)
 	}
@@ -1564,8 +1551,8 @@ func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowO
 	if rowsAffected == 0 {
 		// The guarded UPDATE matched no rows. Re-read the status (only on this rare
 		// no-op path): if the workflow completed (SUCCESS/ERROR) the refusal is a
-		// no-op; otherwise the run was cancelled or superseded and must end as
-		// cancelled so it does not report a completion that was never recorded.
+		// no-op; otherwise the run was cancelled or superseded and is reported as
+		// cancelled to the caller.
 		statusQuery := s.renderSQL(`SELECT status FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
 		var currentStatus WorkflowStatusType
 		if err := runner.QueryRow(ctx, statusQuery, input.workflowID).Scan(&currentStatus); err != nil {
@@ -1997,9 +1984,6 @@ func (s *sysDB) resumeWorkflows(ctx context.Context, input resumeWorkflowsDBInpu
 		encodedIDs,
 		WorkflowStatusSuccess,
 		WorkflowStatusError,
-		// Rotate owner_xid so the superseded run's outcome write no longer
-		// matches the row and cannot clobber the resume.
-		uuid.NewString(),
 	}
 
 	// Dialects without data-modifying CTEs (sqlite) split the pg
@@ -2009,8 +1993,7 @@ func (s *sysDB) resumeWorkflows(ctx context.Context, input resumeWorkflowsDBInpu
 		updateQuery := s.renderSQL(`UPDATE %sworkflow_status
 			SET status = $1, queue_name = $2, recovery_attempts = $3,
 			    workflow_deadline_epoch_ms = NULL, deduplication_id = NULL,
-			    started_at_epoch_ms = NULL, updated_at = $4, completed_at = NULL,
-			    owner_xid = $8
+			    started_at_epoch_ms = NULL, updated_at = $4, completed_at = NULL
 			WHERE %s AND status NOT IN ($6, $7)`, schemaPrefix, anyClause)
 		selectAnyClause := dialectAnyClause(s.dialect, "workflow_uuid", 1)
 		selectQuery := s.renderSQL(`SELECT workflow_uuid FROM %sworkflow_status WHERE %s`, schemaPrefix, selectAnyClause)
@@ -2068,8 +2051,7 @@ func (s *sysDB) resumeWorkflows(ctx context.Context, input resumeWorkflowsDBInpu
 			UPDATE %sworkflow_status
 			SET status = $1, queue_name = $2, recovery_attempts = $3,
 			    workflow_deadline_epoch_ms = NULL, deduplication_id = NULL,
-			    started_at_epoch_ms = NULL, updated_at = $4, completed_at = NULL,
-			    owner_xid = $8
+			    started_at_epoch_ms = NULL, updated_at = $4, completed_at = NULL
 			WHERE %s AND status NOT IN ($6, $7)
 			RETURNING workflow_uuid
 		)
@@ -2488,7 +2470,6 @@ func (s *sysDB) awaitWorkflowResult(ctx context.Context, workflowID string, poll
 type recordOperationResultDBInput struct {
 	workflowID      string
 	childWorkflowID string
-	ownerXID        string
 	stepID          int
 	stepName        string
 	output          *string
@@ -2515,32 +2496,14 @@ func (s *sysDB) recordOperationResult(ctx context.Context, input recordOperation
 		args = append(args, input.childWorkflowID)
 	}
 
-	// When the caller carries an ownership claim, only record the step if this run
-	// still owns the workflow. A concurrent recovery/dequeue rotates owner_xid; a run
-	// that has since been superseded must not checkpoint (and, in a transaction, must
-	// roll back its consumeMessage) so the current owner takes over. Fold the guard
-	// into the INSERT so a non-owner never records, even on the non-transactional path
-	// where there is nothing to roll back. owner_xid = $1 reuses the workflow_uuid arg.
-	var query string
-	if input.ownerXID != "" {
-		argCounter++
-		args = append(args, input.ownerXID)
-		query = s.renderSQL(`INSERT INTO %soperation_outputs (%s)
-			SELECT %s
-			WHERE EXISTS (SELECT 1 FROM %sworkflow_status WHERE workflow_uuid = $1 AND owner_xid = $%d)`,
-			s.dialect.SchemaPrefix(s.schema), strings.Join(columns, ", "), strings.Join(placeholders, ", "),
-			s.dialect.SchemaPrefix(s.schema), argCounter)
-	} else {
-		query = s.renderSQL(`INSERT INTO %soperation_outputs (%s) VALUES (%s)`,
-			s.dialect.SchemaPrefix(s.schema), strings.Join(columns, ", "), strings.Join(placeholders, ", "))
-	}
+	query := s.renderSQL(`INSERT INTO %soperation_outputs (%s) VALUES (%s)`,
+		s.dialect.SchemaPrefix(s.schema), strings.Join(columns, ", "), strings.Join(placeholders, ", "))
 
-	var res Result
 	var err error
 	if input.tx != nil {
-		res, err = input.tx.Exec(ctx, query, args...)
+		_, err = input.tx.Exec(ctx, query, args...)
 	} else {
-		res, err = s.pool.Exec(ctx, query, args...)
+		_, err = s.pool.Exec(ctx, query, args...)
 	}
 
 	if err != nil {
@@ -2548,18 +2511,6 @@ func (s *sysDB) recordOperationResult(ctx context.Context, input recordOperation
 			return newWorkflowConflictIDError(input.workflowID)
 		}
 		return err
-	}
-
-	// The ownership guard matched no rows: this run won the record race but has been
-	// superseded. Signal a conflict so the caller yields to the current owner.
-	if input.ownerXID != "" {
-		rowsAffected, raErr := res.RowsAffected()
-		if raErr != nil {
-			return fmt.Errorf("failed to check operation result insert: %w", raErr)
-		}
-		if rowsAffected == 0 {
-			return newWorkflowConflictIDError(input.workflowID)
-		}
 	}
 
 	return nil

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -930,6 +930,7 @@ type insertWorkflowStatusDBInput struct {
 	tx                Tx
 	ownerXID          *string
 	incrementAttempts bool
+	claimOwnership    bool
 }
 
 func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowStatusDBInput) (*insertWorkflowResult, error) {
@@ -1048,7 +1049,7 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
                 ELSE EXCLUDED.executor_id
             END,
             owner_xid = CASE
-                WHEN $30 > 0 THEN EXCLUDED.owner_xid
+                WHEN $31 > 0 THEN EXCLUDED.owner_xid
                 ELSE workflow_status.owner_xid
             END
         RETURNING recovery_attempts, status, name, queue_name, queue_partition_key, workflow_timeout_ms, workflow_deadline_epoch_ms, owner_xid`, s.dialect.SchemaPrefix(s.schema))
@@ -1065,12 +1066,13 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
 		return nil, fmt.Errorf("failed to marshal the authenticated roles: %w", err)
 	}
 
-	// recoveryIncrement also gates the owner_xid re-claim: dequeue/recovery
-	// dispatches take ownership of the row, fencing a superseded run's
-	// outcome write (see updateWorkflowOutcome).
 	recoveryIncrement := 0
 	if input.incrementAttempts {
 		recoveryIncrement = 1
+	}
+	ownershipClaim := 0
+	if input.claimOwnership {
+		ownershipClaim = 1
 	}
 	err = input.tx.QueryRow(ctx, query,
 		input.status.ID,
@@ -1103,6 +1105,7 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
 		WorkflowStatusEnqueued,
 		WorkflowStatusDelayed,
 		recoveryIncrement,
+		ownershipClaim,
 	).Scan(
 		&result.attempts,
 		&result.status,

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -1046,6 +1046,10 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
             executor_id = CASE
                 WHEN EXCLUDED.status IN ($28, $29) THEN workflow_status.executor_id
                 ELSE EXCLUDED.executor_id
+            END,
+            owner_xid = CASE
+                WHEN $30 > 0 THEN EXCLUDED.owner_xid
+                ELSE workflow_status.owner_xid
             END
         RETURNING recovery_attempts, status, name, queue_name, queue_partition_key, workflow_timeout_ms, workflow_deadline_epoch_ms, owner_xid`, s.dialect.SchemaPrefix(s.schema))
 
@@ -1061,6 +1065,9 @@ func (s *sysDB) insertWorkflowStatus(ctx context.Context, input insertWorkflowSt
 		return nil, fmt.Errorf("failed to marshal the authenticated roles: %w", err)
 	}
 
+	// recoveryIncrement also gates the owner_xid re-claim: dequeue/recovery
+	// dispatches take ownership of the row, fencing a superseded run's
+	// outcome write (see updateWorkflowOutcome).
 	recoveryIncrement := 0
 	if input.incrementAttempts {
 		recoveryIncrement = 1
@@ -1522,18 +1529,20 @@ type updateWorkflowOutcomeDBInput struct {
 	status     WorkflowStatusType
 	output     *string
 	errStr     string
+	ownerXID   string
 	tx         Tx
 }
 
 // updateWorkflowOutcome records a workflow's terminal outcome, but never overwrites a
-// row that is already terminal. If the write is refused because the workflow is
-// CANCELLED (e.g. it was cancelled during its final step), returns a WorkflowCancelled
+// row that is already terminal, a row that has been re-enqueued, or a row
+// whose owner_xid no longer matches this run's claim (the workflow was resumed or
+// re-dispatched to another executor/goroutine). If the write is refused for any reason other
+// than the workflow having completed (SUCCESS/ERROR), returns a WorkflowCancelled
 // error so the caller ends the workflow as cancelled rather than completing it.
-// This mirrors update_workflow_outcome / #recordWorkflowOutcome in the other SDKs.
 func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowOutcomeDBInput) error {
 	query := s.renderSQL(`UPDATE %sworkflow_status
 			  SET status = $1, output = $2, error = $3, updated_at = $4, completed_at = $4, deduplication_id = NULL
-			  WHERE workflow_uuid = $5 AND status NOT IN ($6, $7, $8)`, s.dialect.SchemaPrefix(s.schema))
+			  WHERE workflow_uuid = $5 AND status NOT IN ($6, $7, $8, $9) AND owner_xid = $10`, s.dialect.SchemaPrefix(s.schema))
 
 	var runner Querier = s.pool
 	if input.tx != nil {
@@ -1541,7 +1550,7 @@ func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowO
 	}
 
 	// input.output is already a *string from the database layer
-	res, err := runner.Exec(ctx, query, input.status, input.output, input.errStr, time.Now().UnixMilli(), input.workflowID, WorkflowStatusCancelled, WorkflowStatusSuccess, WorkflowStatusError)
+	res, err := runner.Exec(ctx, query, input.status, input.output, input.errStr, time.Now().UnixMilli(), input.workflowID, WorkflowStatusCancelled, WorkflowStatusSuccess, WorkflowStatusError, WorkflowStatusEnqueued, input.ownerXID)
 	if err != nil {
 		return fmt.Errorf("failed to update workflow status: %w", err)
 	}
@@ -1550,8 +1559,10 @@ func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowO
 		return fmt.Errorf("failed to check workflow status update: %w", err)
 	}
 	if rowsAffected == 0 {
-		// The guarded UPDATE matched no rows: the workflow is already terminal. Re-read
-		// the status (only on this rare no-op path) and, if it is CANCELLED, report it.
+		// The guarded UPDATE matched no rows. Re-read the status (only on this rare
+		// no-op path): if the workflow completed (SUCCESS/ERROR) the refusal is a
+		// no-op; otherwise the run was cancelled or superseded and must end as
+		// cancelled so it does not report a completion that was never recorded.
 		statusQuery := s.renderSQL(`SELECT status FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
 		var currentStatus WorkflowStatusType
 		if err := runner.QueryRow(ctx, statusQuery, input.workflowID).Scan(&currentStatus); err != nil {
@@ -1560,7 +1571,7 @@ func (s *sysDB) updateWorkflowOutcome(ctx context.Context, input updateWorkflowO
 			}
 			return fmt.Errorf("failed to read workflow status after refused outcome update: %w", err)
 		}
-		if currentStatus == WorkflowStatusCancelled {
+		if currentStatus != WorkflowStatusSuccess && currentStatus != WorkflowStatusError {
 			return newWorkflowCancelledError(input.workflowID, nil)
 		}
 	}
@@ -1983,6 +1994,9 @@ func (s *sysDB) resumeWorkflows(ctx context.Context, input resumeWorkflowsDBInpu
 		encodedIDs,
 		WorkflowStatusSuccess,
 		WorkflowStatusError,
+		// Rotate owner_xid so the superseded run's outcome write no longer
+		// matches the row and cannot clobber the resume.
+		uuid.NewString(),
 	}
 
 	// Dialects without data-modifying CTEs (sqlite) split the pg
@@ -1992,7 +2006,8 @@ func (s *sysDB) resumeWorkflows(ctx context.Context, input resumeWorkflowsDBInpu
 		updateQuery := s.renderSQL(`UPDATE %sworkflow_status
 			SET status = $1, queue_name = $2, recovery_attempts = $3,
 			    workflow_deadline_epoch_ms = NULL, deduplication_id = NULL,
-			    started_at_epoch_ms = NULL, updated_at = $4, completed_at = NULL
+			    started_at_epoch_ms = NULL, updated_at = $4, completed_at = NULL,
+			    owner_xid = $8
 			WHERE %s AND status NOT IN ($6, $7)`, schemaPrefix, anyClause)
 		selectAnyClause := dialectAnyClause(s.dialect, "workflow_uuid", 1)
 		selectQuery := s.renderSQL(`SELECT workflow_uuid FROM %sworkflow_status WHERE %s`, schemaPrefix, selectAnyClause)
@@ -2050,7 +2065,8 @@ func (s *sysDB) resumeWorkflows(ctx context.Context, input resumeWorkflowsDBInpu
 			UPDATE %sworkflow_status
 			SET status = $1, queue_name = $2, recovery_attempts = $3,
 			    workflow_deadline_epoch_ms = NULL, deduplication_id = NULL,
-			    started_at_epoch_ms = NULL, updated_at = $4, completed_at = NULL
+			    started_at_epoch_ms = NULL, updated_at = $4, completed_at = NULL,
+			    owner_xid = $8
 			WHERE %s AND status NOT IN ($6, $7)
 			RETURNING workflow_uuid
 		)

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -2488,6 +2488,7 @@ func (s *sysDB) awaitWorkflowResult(ctx context.Context, workflowID string, poll
 type recordOperationResultDBInput struct {
 	workflowID      string
 	childWorkflowID string
+	ownerXID        string
 	stepID          int
 	stepName        string
 	output          *string
@@ -2514,14 +2515,32 @@ func (s *sysDB) recordOperationResult(ctx context.Context, input recordOperation
 		args = append(args, input.childWorkflowID)
 	}
 
-	query := s.renderSQL(`INSERT INTO %soperation_outputs (%s) VALUES (%s)`,
-		s.dialect.SchemaPrefix(s.schema), strings.Join(columns, ", "), strings.Join(placeholders, ", "))
+	// When the caller carries an ownership claim, only record the step if this run
+	// still owns the workflow. A concurrent recovery/dequeue rotates owner_xid; a run
+	// that has since been superseded must not checkpoint (and, in a transaction, must
+	// roll back its consumeMessage) so the current owner takes over. Fold the guard
+	// into the INSERT so a non-owner never records, even on the non-transactional path
+	// where there is nothing to roll back. owner_xid = $1 reuses the workflow_uuid arg.
+	var query string
+	if input.ownerXID != "" {
+		argCounter++
+		args = append(args, input.ownerXID)
+		query = s.renderSQL(`INSERT INTO %soperation_outputs (%s)
+			SELECT %s
+			WHERE EXISTS (SELECT 1 FROM %sworkflow_status WHERE workflow_uuid = $1 AND owner_xid = $%d)`,
+			s.dialect.SchemaPrefix(s.schema), strings.Join(columns, ", "), strings.Join(placeholders, ", "),
+			s.dialect.SchemaPrefix(s.schema), argCounter)
+	} else {
+		query = s.renderSQL(`INSERT INTO %soperation_outputs (%s) VALUES (%s)`,
+			s.dialect.SchemaPrefix(s.schema), strings.Join(columns, ", "), strings.Join(placeholders, ", "))
+	}
 
+	var res Result
 	var err error
 	if input.tx != nil {
-		_, err = input.tx.Exec(ctx, query, args...)
+		res, err = input.tx.Exec(ctx, query, args...)
 	} else {
-		_, err = s.pool.Exec(ctx, query, args...)
+		res, err = s.pool.Exec(ctx, query, args...)
 	}
 
 	if err != nil {
@@ -2529,6 +2548,18 @@ func (s *sysDB) recordOperationResult(ctx context.Context, input recordOperation
 			return newWorkflowConflictIDError(input.workflowID)
 		}
 		return err
+	}
+
+	// The ownership guard matched no rows: this run won the record race but has been
+	// superseded. Signal a conflict so the caller yields to the current owner.
+	if input.ownerXID != "" {
+		rowsAffected, raErr := res.RowsAffected()
+		if raErr != nil {
+			return fmt.Errorf("failed to check operation result insert: %w", raErr)
+		}
+		if rowsAffected == 0 {
+			return newWorkflowConflictIDError(input.workflowID)
+		}
 	}
 
 	return nil

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -73,6 +73,7 @@ type WorkflowStatus struct {
 // workflowState holds the runtime state for a workflow execution
 type workflowState struct {
 	workflowID          string
+	ownerXID            string
 	stepID              int
 	isWithinStep        bool
 	isWithinTransaction bool
@@ -1561,6 +1562,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 	// Create workflow state to track step execution
 	wfState := &workflowState{
 		workflowID:         workflowID,
+		ownerXID:           insertStatusResult.ownerXID,
 		stepID:             -1, // Steps are O-indexed
 		isPortableWorkflow: params.isPortableWorkflow,
 		authenticatedUser:  params.AuthenticatedUser,
@@ -1942,6 +1944,7 @@ func prepareStepExecution(c *dbosContext, opts []StepOption) (*preparedStep, err
 	}
 	stepState := workflowState{
 		workflowID:   wfState.workflowID,
+		ownerXID:     wfState.ownerXID,
 		stepID:       stepID,
 		isWithinStep: true,
 		workflowCtx:  wfState.workflowCtx,
@@ -2157,6 +2160,7 @@ func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, opts ...StepOption) 
 	}
 	dbInput := recordOperationResultDBInput{
 		workflowID:    stepState.workflowID,
+		ownerXID:      stepState.ownerXID,
 		stepName:      stepOpts.stepName,
 		stepID:        stepState.stepID,
 		errStr:        serializedStepErr,
@@ -2331,6 +2335,7 @@ func (c *dbosContext) runAsTxn(_ DBOSContext, fn TxnFunc, opts ...StepOption) (a
 		}
 		dbInput := recordOperationResultDBInput{
 			workflowID:    stepState.workflowID,
+			ownerXID:      stepState.ownerXID,
 			stepName:      stepOpts.stepName,
 			stepID:        stepState.stepID,
 			errStr:        serializedTxnErr,

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -73,7 +73,6 @@ type WorkflowStatus struct {
 // workflowState holds the runtime state for a workflow execution
 type workflowState struct {
 	workflowID          string
-	ownerXID            string
 	stepID              int
 	isWithinStep        bool
 	isWithinTransaction bool
@@ -1463,8 +1462,6 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 			tx:                tx,
 			ownerXID:          &ownerXID,
 			incrementAttempts: params.isDequeue || params.isRecovery,
-			// Only claim ownership if this dispatch will launch the workflow:
-			claimOwnership: (params.isDequeue || params.isRecovery) && !loaded,
 		}
 		insertStatusResult, err = c.systemDB.insertWorkflowStatus(uncancellableCtx, insertInput)
 		if err != nil {
@@ -1562,7 +1559,6 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 	// Create workflow state to track step execution
 	wfState := &workflowState{
 		workflowID:         workflowID,
-		ownerXID:           insertStatusResult.ownerXID,
 		stepID:             -1, // Steps are O-indexed
 		isPortableWorkflow: params.isPortableWorkflow,
 		authenticatedUser:  params.AuthenticatedUser,
@@ -1580,24 +1576,24 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 		durableDeadline = insertStatusResult.workflowDeadline
 	}
 
-	var stopFunc func() bool
-	cancelFuncCompleted := make(chan struct{})
 	if !durableDeadline.IsZero() {
 		workflowCtx, _ = WithTimeout(workflowCtx, time.Until(durableDeadline))
-		// Register a cancel function that cancels the workflow in the DB as soon as the context is cancelled
-		workflowCancelFunction := func() {
-			c.logger.Info("Cancelling workflow", "workflow_id", workflowID)
-			err := retry(c, func() error {
-				_, err := c.systemDB.cancelWorkflows(uncancellableCtx, cancelWorkflowsDBInput{workflowIDs: []string{workflowID}})
-				return err
-			}, withRetrierLogger(c.logger))
-			if err != nil {
-				c.logger.Error("Failed to cancel workflow", "error", err)
-			}
-			close(cancelFuncCompleted)
-		}
-		stopFunc = context.AfterFunc(workflowCtx, workflowCancelFunction)
 	}
+	// Register a cancel function that durably cancels the workflow in the DB as soon as
+	// the context is cancelled (durable deadline, user cancel, or parent cancellation).
+	cancelFuncCompleted := make(chan struct{})
+	workflowCancelFunction := func() {
+		c.logger.Info("Cancelling workflow", "workflow_id", workflowID)
+		err := retry(c, func() error {
+			_, err := c.systemDB.cancelWorkflows(uncancellableCtx, cancelWorkflowsDBInput{workflowIDs: []string{workflowID}})
+			return err
+		}, withRetrierLogger(c.logger))
+		if err != nil {
+			c.logger.Error("Failed to cancel workflow", "error", err)
+		}
+		close(cancelFuncCompleted)
+	}
+	stopFunc := context.AfterFunc(workflowCtx, workflowCancelFunction)
 	wfState.workflowCtx = workflowCtx
 
 	// Run the function in a goroutine
@@ -1626,7 +1622,6 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 
 		var result any
 		var err error
-		cancelled := false
 
 		result, err = fn(workflowCtx, input)
 
@@ -1652,32 +1647,40 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 			close(outcomeChan)
 			return
 		} else {
-			status := WorkflowStatusSuccess
+			// The cancel path (cancelWorkflows) is the sole writer of CANCELLED: a
+			// cancelled run skips updateWorkflowOutcome entirely so it can never
+			// clobber the row (e.g., ENQUEUED written by a concurrent resume).
+			if !stopFunc() {
+				// AfterFunc fired => context is cancelled. Wait for the DB cancel to finish.
+				c.logger.Info("Workflow was cancelled. Waiting for cancel function to complete", "workflow_id", workflowID)
+				<-cancelFuncCompleted
+				removeActive()
+				outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: true}
+				close(outcomeChan)
+				return
+			}
+			if workflowCtx.Err() != nil && isCancellationError(err) {
+				// We stopped the AfterFunc but lost the race: the context was already
+				// cancelled when the workflow returned. Run the durable cancel ourselves.
+				workflowCancelFunction()
+				removeActive()
+				outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: true}
+				close(outcomeChan)
+				return
+			}
+			if errors.Is(err, &DBOSError{Code: WorkflowCancelled}) {
+				// The workflow observed its own cancellation in the DB (external
+				// cancel): the row is already CANCELLED. Skip the outcome write.
+				removeActive()
+				outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: true}
+				close(outcomeChan)
+				return
+			}
 
-			// If an error occurred, set the status to error
+			status := WorkflowStatusSuccess
 			if err != nil {
 				status = WorkflowStatusError
 			}
-
-			// If the afterFunc has started, the workflow was cancelled and the status should be set to cancelled
-			// Also handle the race between the AfterFunc firing and the workflow returning with a context cancellation.
-			if stopFunc != nil {
-				if !stopFunc() {
-					// AfterFunc fired => context is cancelled. Wait for the DB cancel to finish.
-					c.logger.Info("Workflow was cancelled. Waiting for cancel function to complete", "workflow_id", workflowID)
-					<-cancelFuncCompleted
-					status = WorkflowStatusCancelled
-				} else if workflowCtx.Err() != nil {
-					// We stopped the AfterFunc, but lost the race: the context was already
-					// cancelled by the time the workflow returned.
-					status = WorkflowStatusCancelled
-				}
-			} else if workflowCtx.Err() != nil && isCancellationError(err) {
-				// No durable deadline (no AfterFunc): the workflow was interrupted by
-				// context cancellation. Mark it CANCELLED, not ERROR, so it can be resumed.
-				status = WorkflowStatusCancelled
-			}
-			cancelled = status == WorkflowStatusCancelled
 
 			// Serialize the output before recording
 			encodedOutput, serErr := resolveEncoder(workflowCtx).Encode(result)
@@ -1702,15 +1705,14 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 					status:     status,
 					errStr:     serializedErr,
 					output:     encodedOutput,
-					ownerXID:   insertStatusResult.ownerXID,
 				})
 			}, withRetrierLogger(c.logger))
 			if recordErr != nil {
-				// The write was refused because the workflow is already durably CANCELLED
-				// (e.g. cancelled during its final step): it must end as cancelled, not
-				// complete. Deliver a cancellation outcome wrapping the workflow's own
-				// error so context.Canceled/DeadlineExceeded still match via errors.Is.
-				// The in-memory result still rides along for direct callers.
+				// The write was refused because the row is already terminal or has been
+				// superseded (cancelled during the final step, or re-enqueued by a
+				// concurrent resume): end as cancelled, not complete. Deliver a
+				// cancellation outcome wrapping the workflow's own error so
+				// context.Canceled/DeadlineExceeded still match via errors.Is.
 				if errors.Is(recordErr, &DBOSError{Code: WorkflowCancelled}) {
 					outcomeChan <- workflowOutcome[any]{result: result, err: newWorkflowCancelledError(workflowID, err), cancelled: true}
 					close(outcomeChan)
@@ -1722,7 +1724,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 				return
 			}
 		}
-		outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: cancelled}
+		outcomeChan <- workflowOutcome[any]{result: result, err: err}
 		close(outcomeChan)
 	}()
 
@@ -1944,7 +1946,6 @@ func prepareStepExecution(c *dbosContext, opts []StepOption) (*preparedStep, err
 	}
 	stepState := workflowState{
 		workflowID:   wfState.workflowID,
-		ownerXID:     wfState.ownerXID,
 		stepID:       stepID,
 		isWithinStep: true,
 		workflowCtx:  wfState.workflowCtx,
@@ -2160,7 +2161,6 @@ func (c *dbosContext) RunAsStep(_ DBOSContext, fn StepFunc, opts ...StepOption) 
 	}
 	dbInput := recordOperationResultDBInput{
 		workflowID:    stepState.workflowID,
-		ownerXID:      stepState.ownerXID,
 		stepName:      stepOpts.stepName,
 		stepID:        stepState.stepID,
 		errStr:        serializedStepErr,
@@ -2335,7 +2335,6 @@ func (c *dbosContext) runAsTxn(_ DBOSContext, fn TxnFunc, opts ...StepOption) (a
 		}
 		dbInput := recordOperationResultDBInput{
 			workflowID:    stepState.workflowID,
-			ownerXID:      stepState.ownerXID,
 			stepName:      stepOpts.stepName,
 			stepID:        stepState.stepID,
 			errStr:        serializedTxnErr,

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1451,10 +1451,6 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 		defer tx.Rollback(uncancellableCtx) // Rollback if not committed
 
 		// Insert workflow status with transaction
-		var loaded bool
-		if c.activeWorkflowIDs != nil {
-			_, loaded = c.activeWorkflowIDs.Load(workflowID)
-		}
 		ownerXID := uuid.New().String()
 		insertInput := insertWorkflowStatusDBInput{
 			status:            workflowStatus,
@@ -1490,6 +1486,11 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 				c.logger.Error("failed to record child workflow", "error", err, "parent_workflow_id", parentWorkflowState.workflowID, "child_workflow_id", workflowID)
 				return newWorkflowExecutionError(parentWorkflowState.workflowID, fmt.Errorf("recording child workflow: %w", err))
 			}
+		}
+
+		var loaded bool
+		if c.activeWorkflowIDs != nil {
+			_, loaded = c.activeWorkflowIDs.Load(workflowID)
 		}
 
 		shouldSkip :=
@@ -1647,8 +1648,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 			close(outcomeChan)
 			return
 		} else {
-			// The cancel path (cancelWorkflows) is the sole writer of CANCELLED: a
-			// cancelled run skips updateWorkflowOutcome entirely so it can never
+			// A cancelled run skips updateWorkflowOutcome entirely so it can never
 			// clobber the row (e.g., ENQUEUED written by a concurrent resume).
 			if !stopFunc() {
 				// AfterFunc fired => context is cancelled. Wait for the DB cancel to finish.
@@ -1660,8 +1660,8 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 				return
 			}
 			if workflowCtx.Err() != nil && isCancellationError(err) {
-				// We stopped the AfterFunc but lost the race: the context was already
-				// cancelled when the workflow returned. Run the durable cancel ourselves.
+				// We stopped the AfterFunc but the context was already cancelled
+				// so we need to run the durable cancel ourselves.
 				workflowCancelFunction()
 				removeActive()
 				outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: true}

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1451,6 +1451,10 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 		defer tx.Rollback(uncancellableCtx) // Rollback if not committed
 
 		// Insert workflow status with transaction
+		var loaded bool
+		if c.activeWorkflowIDs != nil {
+			_, loaded = c.activeWorkflowIDs.Load(workflowID)
+		}
 		ownerXID := uuid.New().String()
 		insertInput := insertWorkflowStatusDBInput{
 			status:            workflowStatus,
@@ -1458,6 +1462,8 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 			tx:                tx,
 			ownerXID:          &ownerXID,
 			incrementAttempts: params.isDequeue || params.isRecovery,
+			// Only claim ownership if this dispatch will launch the workflow:
+			claimOwnership: (params.isDequeue || params.isRecovery) && !loaded,
 		}
 		insertStatusResult, err = c.systemDB.insertWorkflowStatus(uncancellableCtx, insertInput)
 		if err != nil {
@@ -1486,11 +1492,6 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 				c.logger.Error("failed to record child workflow", "error", err, "parent_workflow_id", parentWorkflowState.workflowID, "child_workflow_id", workflowID)
 				return newWorkflowExecutionError(parentWorkflowState.workflowID, fmt.Errorf("recording child workflow: %w", err))
 			}
-		}
-
-		var loaded bool
-		if c.activeWorkflowIDs != nil {
-			_, loaded = c.activeWorkflowIDs.Load(workflowID)
 		}
 
 		shouldSkip :=

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1699,6 +1699,7 @@ func (c *dbosContext) RunWorkflow(_ DBOSContext, fn WorkflowFunc, input any, opt
 					status:     status,
 					errStr:     serializedErr,
 					output:     encodedOutput,
+					ownerXID:   insertStatusResult.ownerXID,
 				})
 			}, withRetrierLogger(c.logger))
 			if recordErr != nil {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -2691,6 +2691,17 @@ func TestWorkflowRecovery(t *testing.T) {
 
 	RegisterWorkflow(dbosCtx, recoveryWorkflow)
 
+	blockingStart := NewEvent()
+	blockingEvent := NewEvent()
+	blockingWorkflow := func(dbosCtx DBOSContext, input string) (string, error) {
+		return RunAsStep(dbosCtx, func(ctx context.Context) (string, error) {
+			blockingStart.Set()
+			blockingEvent.Wait()
+			return input, nil
+		})
+	}
+	RegisterWorkflow(dbosCtx, blockingWorkflow, WithWorkflowName("blocking-recovery-workflow"))
+
 	err := Launch(dbosCtx)
 	require.NoError(t, err, "failed to launch DBOS")
 
@@ -2767,6 +2778,39 @@ func TestWorkflowRecovery(t *testing.T) {
 			require.True(t, ok, "workflow %d not found in list result", i)
 			require.Equal(t, 2, wf.Attempts, "workflow %d should have 2 attempts after recovery", i)
 		}
+	})
+
+	// Recovering a workflow that is actively running on this executor must not
+	// fence out the live run: recovery skips launching (already active locally)
+	// and must leave owner_xid untouched so the run can record its outcome.
+	t.Run("RecoverWhileRunning", func(t *testing.T) {
+		handle, err := RunWorkflow(dbosCtx, blockingWorkflow, "hello", WithWorkflowID("recover-while-running"))
+		require.NoError(t, err, "failed to start blocking workflow")
+		blockingStart.Wait()
+
+		recoveredHandles, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
+		require.NoError(t, err, "failed to recover pending workflows")
+		var recoveredHandle WorkflowHandle[any]
+		for _, h := range recoveredHandles {
+			if h.GetWorkflowID() == handle.GetWorkflowID() {
+				recoveredHandle = h
+			}
+		}
+		require.NotNil(t, recoveredHandle, "expected a handle for the running workflow")
+
+		blockingEvent.Set()
+
+		result, err := handle.GetResult()
+		require.NoError(t, err, "live run should complete despite recovery dispatch")
+		require.Equal(t, "hello", result)
+
+		recoveredResult, err := recoveredHandle.GetResult()
+		require.NoError(t, err, "recovered handle should observe the run's outcome")
+		require.Equal(t, "hello", recoveredResult)
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get workflow status")
+		require.Equal(t, WorkflowStatusSuccess, status.Status)
 	})
 }
 

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1629,8 +1629,12 @@ func TestSelect(t *testing.T) {
 
 	selectBlockStartEvent := NewEvent()
 	selectBlockEvent := NewEvent()
+	selectGoStepStarted := NewEvent()
 	selectCancelWorkflow := func(dbosCtx DBOSContext, input string) (string, error) {
 		ch1, err := Go(dbosCtx, func(ctx context.Context) (string, error) {
+			// Signal the step body has started (its checkpoint lookup passed), so
+			// the test can cancel without racing the durable cancel against it.
+			selectGoStepStarted.Set()
 			selectBlockEvent.Wait()
 			return "result", nil
 		})
@@ -1708,6 +1712,12 @@ func TestSelect(t *testing.T) {
 		// Wait for the workflow to reach the Select call (step has started and set the event)
 		selectBlockStartEvent.Wait()
 		selectBlockStartEvent.Clear()
+		// Wait for the Go step body to start: once it runs, its outcome is delivered
+		// and checkpointed even though the workflow is cancelled. Cancelling earlier
+		// would race the durable cancel against the step's checkpoint lookup, which
+		// can refuse to start the step at all (a valid outcome, but not this test's).
+		selectGoStepStarted.Wait()
+		selectGoStepStarted.Clear()
 
 		// Cancel the context manually
 		cancelFunc(nil)
@@ -1717,8 +1727,11 @@ func TestSelect(t *testing.T) {
 		require.Error(t, err, "expected error from cancelled workflow")
 		assert.Equal(t, "", result, "expected zero value string when cancelled")
 
-		// Verify the error is a cancellation error
-		assert.True(t, errors.Is(err, context.Canceled), "expected context.Canceled error, got: %v", err)
+		// Verify the error is a cancellation error. The durable cancel lands in the
+		// DB as soon as the context is cancelled, so Select is interrupted either
+		// mid-wait (wrapping context.Canceled) or at its step boundary by observing
+		// the CANCELLED status; both wrap WorkflowCancelled.
+		assert.True(t, errors.Is(err, &DBOSError{Code: WorkflowCancelled}), "expected WorkflowCancelled error, got: %v", err)
 
 		// Set the event to unblock the goroutine (cleanup)
 		selectBlockEvent.Set()

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -8756,8 +8756,8 @@ func TestWorkflowAttributes(t *testing.T) {
 			assert.Nil(t, s.Attributes)
 		}
 	})
-  
-  t.Run("Update", func(t *testing.T) {
+
+	t.Run("Update", func(t *testing.T) {
 		wfid := uuid.NewString()
 		handle, err := RunWorkflow(dbosCtx, attrNoopWorkflow, 1, WithWorkflowID(wfid), WithWorkflowAttributes(map[string]any{"customer": "acme-upd", "tier": 1}))
 		require.NoError(t, err)
@@ -8789,7 +8789,7 @@ func TestWorkflowAttributes(t *testing.T) {
 		var dbosErr *DBOSError
 		require.ErrorAs(t, err, &dbosErr)
 		assert.Equal(t, NonExistentWorkflowError, dbosErr.Code)
-  })
+	})
 }
 
 func TestFork(t *testing.T) {
@@ -9217,4 +9217,210 @@ func TestFork(t *testing.T) {
 			require.Equal(t, forksBefore, listForks())
 		})
 	})
+}
+
+// parkingPool wraps the system database pool and parks the first
+// updateWorkflowOutcome Exec for the target workflow until released,
+// signaling staleDone once that write has been attempted.
+type parkingPool struct {
+	Pool
+	target    string
+	parked    *Event
+	release   chan struct{}
+	staleDone chan struct{}
+	first     atomic.Bool
+}
+
+func (p *parkingPool) Exec(ctx context.Context, query string, args ...any) (Result, error) {
+	isOutcomeWrite := strings.Contains(query, "output = $2") && strings.Contains(query, "completed_at = $4")
+	if isOutcomeWrite && len(args) >= 5 && args[4] == any(p.target) && p.first.CompareAndSwap(false, true) {
+		p.parked.Set()
+		<-p.release
+		res, err := p.Pool.Exec(ctx, query, args...)
+		close(p.staleDone)
+		return res, err
+	}
+	return p.Pool.Exec(ctx, query, args...)
+}
+
+// A cancelled run's outcome write landing after the workflow has been resumed
+// and re-dispatched to another executor must not clobber the new run's PENDING
+// row. Two DBOS contexts share the database: executor A runs and cancels the
+// workflow, parking its outcome write; the workflow is resumed onto a queue
+// only executor B listens to, so the second run is dequeued cross-executor
+// while A's stale write is still in flight.
+func TestStaleOutcomeWriteAfterResume(t *testing.T) {
+	ctxA := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+	ctxB := setupDBOS(t, setupDBOSOptions{dropDB: false})
+
+	wfID := uuid.NewString()
+
+	var runs atomic.Int64
+	firstEntered := NewEvent()
+	firstRelease := make(chan struct{})
+	secondEntered := NewEvent()
+	secondRelease := make(chan struct{})
+	releaseFirst := sync.OnceFunc(func() { close(firstRelease) })
+	releaseSecond := sync.OnceFunc(func() { close(secondRelease) })
+	t.Cleanup(releaseFirst)
+	t.Cleanup(releaseSecond)
+
+	wf := func(ctx DBOSContext, _ string) (string, error) {
+		if runs.Add(1) == 1 {
+			firstEntered.Set()
+			<-firstRelease
+			return "", ctx.Err() // interrupted by the cancellation
+		}
+		secondEntered.Set()
+		<-secondRelease
+		return "completed", nil
+	}
+	RegisterWorkflow(ctxA, wf, WithWorkflowName("stale-outcome-write-workflow"))
+	RegisterWorkflow(ctxB, wf, WithWorkflowName("stale-outcome-write-workflow"))
+
+	const resumeQueue = "stale-outcome-resume-queue"
+	_, err := RegisterQueue(ctxB, resumeQueue)
+	require.NoError(t, err, "failed to register resume queue")
+	// Restrict A to the internal queue so only B can dequeue the resumed run.
+	ListenQueues(ctxA, WorkflowQueue{Name: "stale-outcome-unused-queue"})
+
+	sysdb := ctxA.(*dbosContext).systemDB.(*sysDB)
+	park := &parkingPool{
+		Pool:      sysdb.pool,
+		target:    wfID,
+		parked:    NewEvent(),
+		release:   make(chan struct{}),
+		staleDone: make(chan struct{}),
+	}
+	sysdb.pool = park
+	releaseStale := sync.OnceFunc(func() { close(park.release) })
+	t.Cleanup(releaseStale)
+
+	require.NoError(t, Launch(ctxA), "failed to launch executor A")
+	require.NoError(t, Launch(ctxB), "failed to launch executor B")
+
+	handle, err := RunWorkflow(ctxA, wf, "", WithWorkflowID(wfID))
+	require.NoError(t, err, "failed to start workflow")
+	firstEntered.Wait()
+
+	// Durably cancel while the first run is executing.
+	require.NoError(t, CancelWorkflow(ctxA, wfID), "failed to cancel workflow")
+
+	// Let the first run return: its outcome write parks before executing.
+	releaseFirst()
+	park.parked.Wait()
+
+	// The durable status is CANCELLED (written by CancelWorkflow, not parked).
+	status, err := handle.GetStatus()
+	require.NoError(t, err, "failed to get workflow status")
+	require.Equal(t, WorkflowStatusCancelled, status.Status, "expected CANCELLED before resume")
+
+	// Resume onto B's queue: B dequeues and starts the second run while A's
+	// stale outcome write is still in flight.
+	resumedHandle, err := ResumeWorkflow[string](ctxB, wfID, WithResumeQueue(resumeQueue))
+	require.NoError(t, err, "failed to resume workflow")
+	secondEntered.Wait()
+
+	// Land the stale write while the second run is executing (row is PENDING),
+	// then let the second run finish.
+	releaseStale()
+	<-park.staleDone
+	releaseSecond()
+
+	result, err := resumedHandle.GetResult()
+	require.NoError(t, err, "the stale outcome write must not clobber the resumed run")
+	require.Equal(t, "completed", result)
+	require.EqualValues(t, 2, runs.Load(), "the resume must re-dispatch the workflow")
+
+	status, err = resumedHandle.GetStatus()
+	require.NoError(t, err, "failed to get workflow status")
+	require.Equal(t, WorkflowStatusSuccess, status.Status, "the resumed run's outcome must survive")
+}
+
+// A cancelled run's stale outcome write landing while the resumed row is still
+// ENQUEUED (resumed but not yet dequeued) must not flip it back to a terminal
+// state: the row would never be dequeued and the resume would be lost. The
+// resume targets a queue this process does not listen to yet, holding the row
+// in ENQUEUED until the stale write has been refused.
+func TestStaleOutcomeWriteOverEnqueued(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+
+	wfID := uuid.NewString()
+
+	var runs atomic.Int64
+	firstEntered := NewEvent()
+	firstRelease := make(chan struct{})
+	releaseFirst := sync.OnceFunc(func() { close(firstRelease) })
+	t.Cleanup(releaseFirst)
+
+	wf := func(ctx DBOSContext, _ string) (string, error) {
+		if runs.Add(1) == 1 {
+			firstEntered.Set()
+			<-firstRelease
+			return "", ctx.Err() // interrupted by the cancellation
+		}
+		return "completed", nil
+	}
+	RegisterWorkflow(dbosCtx, wf, WithWorkflowName("stale-over-enqueued-workflow"))
+
+	const parkedQueue = "stale-outcome-parked-queue"
+	_, err := RegisterQueue(dbosCtx, parkedQueue)
+	require.NoError(t, err, "failed to register queue")
+	// Don't listen to the parked queue yet: the resumed row must stay ENQUEUED
+	// until the stale write has landed.
+	ListenQueues(dbosCtx, WorkflowQueue{Name: "stale-outcome-unused-queue"})
+
+	sysdb := dbosCtx.(*dbosContext).systemDB.(*sysDB)
+	park := &parkingPool{
+		Pool:      sysdb.pool,
+		target:    wfID,
+		parked:    NewEvent(),
+		release:   make(chan struct{}),
+		staleDone: make(chan struct{}),
+	}
+	sysdb.pool = park
+	releaseStale := sync.OnceFunc(func() { close(park.release) })
+	t.Cleanup(releaseStale)
+
+	require.NoError(t, Launch(dbosCtx), "failed to launch DBOS instance")
+
+	handle, err := RunWorkflow(dbosCtx, wf, "", WithWorkflowID(wfID))
+	require.NoError(t, err, "failed to start workflow")
+	firstEntered.Wait()
+
+	// Durably cancel while the first run is executing.
+	require.NoError(t, CancelWorkflow(dbosCtx, wfID), "failed to cancel workflow")
+
+	// Let the first run return: its outcome write parks before executing.
+	releaseFirst()
+	park.parked.Wait()
+
+	// The durable status is CANCELLED (written by CancelWorkflow, not parked).
+	status, err := handle.GetStatus()
+	require.NoError(t, err, "failed to get workflow status")
+	require.Equal(t, WorkflowStatusCancelled, status.Status, "expected CANCELLED before resume")
+
+	// Resume onto the unlistened queue: the row is ENQUEUED and stays there.
+	resumedHandle, err := ResumeWorkflow[string](dbosCtx, wfID, WithResumeQueue(parkedQueue))
+	require.NoError(t, err, "failed to resume workflow")
+
+	// Land the stale write on the ENQUEUED row: it must be refused.
+	releaseStale()
+	<-park.staleDone
+
+	status, err = resumedHandle.GetStatus()
+	require.NoError(t, err, "failed to get workflow status")
+	require.Equal(t, WorkflowStatusEnqueued, status.Status, "the stale outcome write must not flip the resumed row terminal")
+
+	// Start listening to the queue: the workflow is dequeued and completes.
+	ListenQueues(dbosCtx, WorkflowQueue{Name: parkedQueue})
+
+	result, err := resumedHandle.GetResult()
+	require.NoError(t, err, "failed to get resumed workflow result")
+	require.Equal(t, "completed", result)
+	require.EqualValues(t, 2, runs.Load(), "the resume must re-dispatch the workflow")
+
+	status, err = resumedHandle.GetStatus()
+	require.NoError(t, err, "failed to get workflow status")
+	require.Equal(t, WorkflowStatusSuccess, status.Status, "the resumed run's outcome must survive")
 }

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -9276,7 +9276,10 @@ type parkingPool struct {
 }
 
 func (p *parkingPool) Exec(ctx context.Context, query string, args ...any) (Result, error) {
-	isOutcomeWrite := strings.Contains(query, "output = $2") && strings.Contains(query, "completed_at = $4")
+	// Match on placeholder-free fragments: sqlite rewrites $N to ?N, so keying on
+	// "$2"/"$4" would never match there. The outcome-write UPDATE is the only query
+	// that sets both output and completed_at.
+	isOutcomeWrite := strings.Contains(query, "output =") && strings.Contains(query, "completed_at =")
 	if isOutcomeWrite && len(args) >= 5 && args[4] == any(p.target) && p.first.CompareAndSwap(false, true) {
 		p.parked.Set()
 		<-p.release

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1349,10 +1349,11 @@ func TestSteps(t *testing.T) {
 		require.Len(t, steps, 1, "expected the re-executed step to be recorded")
 	})
 
-	t.Run("CancelledParentRecordsSurvivingChildOutcome", func(t *testing.T) {
-		// Parent cancelled while awaiting a child that ignores cancellation: the
-		// child's delivered outcome is durably recorded by getResult, then the
-		// next step aborts on cancellation. Resume picks up after the await.
+	t.Run("CancelledParentCancelsChild", func(t *testing.T) {
+		// Cancelling the parent durably cancels the child too: a cancelled run
+		// never writes its outcome, even if its function ignores cancellation and
+		// returns successfully. The parent checkpoints the child's cancellation
+		// via getResult; resuming the parent replays it deterministically.
 		cancelCtx, cancelFunc := WithCancel(dbosCtx)
 		defer cancelFunc()
 		handle, err := RunWorkflow(cancelCtx, stubbornParentWorkflow, "")
@@ -1364,7 +1365,7 @@ func TestSteps(t *testing.T) {
 
 		_, err = handle.GetResult()
 		require.Error(t, err, "expected error from cancelled parent")
-		require.True(t, errors.Is(err, context.Canceled), "expected wrapped context.Canceled, got: %v", err)
+		require.True(t, errors.Is(err, &DBOSError{Code: AwaitedWorkflowCancelled}), "expected AwaitedWorkflowCancelled, got: %v", err)
 
 		require.Eventually(t, func() bool {
 			status, err := handle.GetStatus()
@@ -1374,24 +1375,30 @@ func TestSteps(t *testing.T) {
 
 		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
 		require.NoError(t, err, "failed to get workflow steps")
-		require.Len(t, steps, 2, "expected child spawn and getResult recorded; the interrupted step must not be")
+		require.Len(t, steps, 2, "expected child spawn and getResult recorded")
 		childID := steps[0].ChildWorkflowID
 		require.NotEmpty(t, childID, "expected the first step to be the child spawn")
 		require.Equal(t, "DBOS.getResult", steps[1].StepName)
-		require.Nil(t, steps[1].Error, "the delivered child outcome must be recorded without error")
+		require.NotNil(t, steps[1].Error, "the child's cancellation must be checkpointed")
 
 		childHandle, err := RetrieveWorkflow[string](dbosCtx, childID)
 		require.NoError(t, err, "failed to retrieve child workflow")
 		childStatus, err := childHandle.GetStatus()
 		require.NoError(t, err, "failed to get child workflow status")
-		require.Equal(t, WorkflowStatusSuccess, childStatus.Status, "child ignoring cancellation must complete")
+		require.Equal(t, WorkflowStatusCancelled, childStatus.Status, "child cannot outlive the parent's cancellation")
 
+		// The checkpointed child cancellation is a terminal outcome for the
+		// parent: resuming replays it.
 		resumedHandle, err := ResumeWorkflow[string](dbosCtx, handle.GetWorkflowID())
 		require.NoError(t, err, "failed to resume parent workflow")
-		result, err := resumedHandle.GetResult()
-		require.NoError(t, err, "resumed parent should complete")
-		require.Equal(t, "child-result-done", result)
+		_, err = resumedHandle.GetResult()
+		require.Error(t, err, "resumed parent must replay the checkpointed child cancellation")
+		require.True(t, errors.Is(err, &DBOSError{Code: AwaitedWorkflowCancelled}), "expected AwaitedWorkflowCancelled on replay, got: %v", err)
 		require.EqualValues(t, 1, stubbornChildExecutions.Load(), "child must not re-execute on parent resume")
+
+		status, err := resumedHandle.GetStatus()
+		require.NoError(t, err, "failed to get resumed workflow status")
+		require.Equal(t, WorkflowStatusError, status.Status, "replayed child cancellation is a terminal error outcome")
 	})
 
 	t.Run("PreemptedChildCancellationNotCheckpointed", func(t *testing.T) {
@@ -1409,8 +1416,10 @@ func TestSteps(t *testing.T) {
 
 		_, err = handle.GetResult()
 		require.Error(t, err, "expected error from cancelled parent")
+		// The durable cancel lands in the DB as soon as the context is cancelled,
+		// so the parent is interrupted either by the delivered child cancellation
+		// or by observing its own CANCELLED status at the step boundary.
 		require.True(t, errors.Is(err, &DBOSError{Code: WorkflowCancelled}), "expected WorkflowCancelled error, got: %v", err)
-		require.True(t, errors.Is(err, context.Canceled), "expected wrapped context.Canceled, got: %v", err)
 
 		require.Eventually(t, func() bool {
 			status, err := handle.GetStatus()
@@ -9288,100 +9297,6 @@ func (p *parkingPool) Exec(ctx context.Context, query string, args ...any) (Resu
 		return res, err
 	}
 	return p.Pool.Exec(ctx, query, args...)
-}
-
-// A cancelled run's outcome write landing after the workflow has been resumed
-// and re-dispatched to another executor must not clobber the new run's PENDING
-// row. Two DBOS contexts share the database: executor A runs and cancels the
-// workflow, parking its outcome write; the workflow is resumed onto a queue
-// only executor B listens to, so the second run is dequeued cross-executor
-// while A's stale write is still in flight.
-func TestStaleOutcomeWriteAfterResume(t *testing.T) {
-	ctxA := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
-	ctxB := setupDBOS(t, setupDBOSOptions{dropDB: false})
-
-	wfID := uuid.NewString()
-
-	var runs atomic.Int64
-	firstEntered := NewEvent()
-	firstRelease := make(chan struct{})
-	secondEntered := NewEvent()
-	secondRelease := make(chan struct{})
-	releaseFirst := sync.OnceFunc(func() { close(firstRelease) })
-	releaseSecond := sync.OnceFunc(func() { close(secondRelease) })
-	t.Cleanup(releaseFirst)
-	t.Cleanup(releaseSecond)
-
-	wf := func(ctx DBOSContext, _ string) (string, error) {
-		if runs.Add(1) == 1 {
-			firstEntered.Set()
-			<-firstRelease
-			return "", ctx.Err() // interrupted by the cancellation
-		}
-		secondEntered.Set()
-		<-secondRelease
-		return "completed", nil
-	}
-	RegisterWorkflow(ctxA, wf, WithWorkflowName("stale-outcome-write-workflow"))
-	RegisterWorkflow(ctxB, wf, WithWorkflowName("stale-outcome-write-workflow"))
-
-	const resumeQueue = "stale-outcome-resume-queue"
-	_, err := RegisterQueue(ctxB, resumeQueue)
-	require.NoError(t, err, "failed to register resume queue")
-	// Restrict A to the internal queue so only B can dequeue the resumed run.
-	ListenQueues(ctxA, WorkflowQueue{Name: "stale-outcome-unused-queue"})
-
-	sysdb := ctxA.(*dbosContext).systemDB.(*sysDB)
-	park := &parkingPool{
-		Pool:      sysdb.pool,
-		target:    wfID,
-		parked:    NewEvent(),
-		release:   make(chan struct{}),
-		staleDone: make(chan struct{}),
-	}
-	sysdb.pool = park
-	releaseStale := sync.OnceFunc(func() { close(park.release) })
-	t.Cleanup(releaseStale)
-
-	require.NoError(t, Launch(ctxA), "failed to launch executor A")
-	require.NoError(t, Launch(ctxB), "failed to launch executor B")
-
-	handle, err := RunWorkflow(ctxA, wf, "", WithWorkflowID(wfID))
-	require.NoError(t, err, "failed to start workflow")
-	firstEntered.Wait()
-
-	// Durably cancel while the first run is executing.
-	require.NoError(t, CancelWorkflow(ctxA, wfID), "failed to cancel workflow")
-
-	// Let the first run return: its outcome write parks before executing.
-	releaseFirst()
-	park.parked.Wait()
-
-	// The durable status is CANCELLED (written by CancelWorkflow, not parked).
-	status, err := handle.GetStatus()
-	require.NoError(t, err, "failed to get workflow status")
-	require.Equal(t, WorkflowStatusCancelled, status.Status, "expected CANCELLED before resume")
-
-	// Resume onto B's queue: B dequeues and starts the second run while A's
-	// stale outcome write is still in flight.
-	resumedHandle, err := ResumeWorkflow[string](ctxB, wfID, WithResumeQueue(resumeQueue))
-	require.NoError(t, err, "failed to resume workflow")
-	secondEntered.Wait()
-
-	// Land the stale write while the second run is executing (row is PENDING),
-	// then let the second run finish.
-	releaseStale()
-	<-park.staleDone
-	releaseSecond()
-
-	result, err := resumedHandle.GetResult()
-	require.NoError(t, err, "the stale outcome write must not clobber the resumed run")
-	require.Equal(t, "completed", result)
-	require.EqualValues(t, 2, runs.Load(), "the resume must re-dispatch the workflow")
-
-	status, err = resumedHandle.GetStatus()
-	require.NoError(t, err, "failed to get workflow status")
-	require.Equal(t, WorkflowStatusSuccess, status.Status, "the resumed run's outcome must survive")
 }
 
 // A cancelled run's stale outcome write landing while the resumed row is still


### PR DESCRIPTION
Have manual context cancel trigger durable cancellation. Prevents a few race conditions.

Also forbid `updateWorkflowOutcome` when the status is not `PENDING`