### PR TITLE
Fix deadlock and sqlite err propagation

### DIFF
--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -3,6 +3,7 @@ package dbos
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -1044,6 +1045,37 @@ func TestSQLiteFoundation(t *testing.T) {
 		err := SQLDB(s2.pool).QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table).Scan(&name)
 		assert.NoErrorf(t, err, "table %q missing after migrations", table)
 	}
+
+	// A BeginTx interrupted by context cancellation must surface an error
+	// detectable as context.Canceled. modernc/sqlite substitutes ctx.Err()
+	// for interrupted statements (stmt.exec) but NOT for the transaction
+	// control path (tx.exec: begin/commit/rollback), which returns the raw
+	// SQLite code (`interrupted (9)` or `database is locked (5)`). The dbos
+	// layer must map it back so callers (e.g. handle.GetResult after
+	// Shutdown) can errors.Is it. Reproduces the
+	// "failed to begin transaction: interrupted (9)" CI failure in
+	// TestWorkflowHandleContextCancel on the sqlite backend.
+	blocker, err := s.pool.BeginTx(context.Background(), TxOptions{})
+	require.NoError(t, err)
+	_, err = blocker.Exec(context.Background(), `CREATE TABLE begin_cancel_probe (x INT)`)
+	require.NoError(t, err)
+
+	cctx, cancelBegin := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancelBegin()
+	}()
+	// Blocks on the write lock held by blocker (busy_timeout=5000), so the
+	// cancel deterministically lands while BEGIN is in flight.
+	tx2, err := s.pool.BeginTx(cctx, TxOptions{IsoLevel: s.dialect.SnapshotIsolation()})
+	if err == nil {
+		_ = tx2.Rollback(context.Background())
+	}
+	_ = blocker.Rollback(context.Background())
+	cancelBegin()
+	require.Error(t, err, "BeginTx should fail when its context is cancelled mid-flight")
+	assert.True(t, errors.Is(err, context.Canceled),
+		"expected error to be detectable as context.Canceled, got: %v", err)
 }
 
 // TestSQLiteURLParsing checks the DSN extraction for common URL forms.

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -1053,24 +1053,32 @@ func TestSQLiteFoundation(t *testing.T) {
 	// SQLite code (`interrupted (9)` or `database is locked (5)`). The dbos
 	// layer must map it back so callers (e.g. handle.GetResult after
 	// Shutdown) can errors.Is it.
+	// Every dbos sqlite connection is opened with _txlock=immediate, so BEGIN
+	// itself acquires the write lock: blocker holds it from BeginTx on, and
+	// tx2's BEGIN IMMEDIATE blocks in the busy handler for the full
+	// busy_timeout (5s) — the interrupt does not shorten the wait, only
+	// poisons the result. The 100ms cancel therefore lands mid-BEGIN unless
+	// the timer goroutine is starved for >5s; retry the scenario in that
+	// pathological case rather than mis-assert.
 	blocker, err := s.pool.BeginTx(context.Background(), TxOptions{})
 	require.NoError(t, err)
-	_, err = blocker.Exec(context.Background(), `CREATE TABLE begin_cancel_probe (x INT)`)
-	require.NoError(t, err)
-
-	cctx, cancelBegin := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(100 * time.Millisecond)
+	cancelLanded := false
+	for attempt := 0; attempt < 3 && !cancelLanded; attempt++ {
+		cctx, cancelBegin := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			cancelBegin()
+		}()
+		var tx2 Tx
+		tx2, err = s.pool.BeginTx(cctx, TxOptions{})
+		cancelLanded = cctx.Err() != nil
+		if tx2 != nil {
+			_ = tx2.Rollback(context.Background())
+		}
 		cancelBegin()
-	}()
-	// Blocks on the write lock held by blocker (busy_timeout=5000), so the
-	// cancel deterministically lands while BEGIN is in flight.
-	tx2, err := s.pool.BeginTx(cctx, TxOptions{IsoLevel: s.dialect.SnapshotIsolation()})
-	if err == nil {
-		_ = tx2.Rollback(context.Background())
 	}
 	_ = blocker.Rollback(context.Background())
-	cancelBegin()
+	require.True(t, cancelLanded, "cancel never landed while BEGIN was in flight")
 	require.Error(t, err, "BeginTx should fail when its context is cancelled mid-flight")
 	assert.True(t, errors.Is(err, context.Canceled),
 		"expected error to be detectable as context.Canceled, got: %v", err)

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -1052,9 +1052,7 @@ func TestSQLiteFoundation(t *testing.T) {
 	// control path (tx.exec: begin/commit/rollback), which returns the raw
 	// SQLite code (`interrupted (9)` or `database is locked (5)`). The dbos
 	// layer must map it back so callers (e.g. handle.GetResult after
-	// Shutdown) can errors.Is it. Reproduces the
-	// "failed to begin transaction: interrupted (9)" CI failure in
-	// TestWorkflowHandleContextCancel on the sqlite backend.
+	// Shutdown) can errors.Is it.
 	blocker, err := s.pool.BeginTx(context.Background(), TxOptions{})
 	require.NoError(t, err)
 	_, err = blocker.Exec(context.Background(), `CREATE TABLE begin_cancel_probe (x INT)`)

--- a/dbos/dbq.go
+++ b/dbos/dbq.go
@@ -209,6 +209,17 @@ func pgxTxOpts(o TxOptions) pgx.TxOptions {
 // newSQLPool wraps a *sql.DB so it satisfies Pool.
 func newSQLPool(db *sql.DB) Pool { return &sqlPoolAdapter{db: db} }
 
+// ctxErr attaches the context error to a driver error so callers can
+// errors.Is(err, context.Canceled/DeadlineExceeded). modernc/sqlite does this
+// substitution for statements (stmt.exec) but not for begin/commit/rollback
+// (tx.exec).
+func ctxErr(ctx context.Context, err error) error {
+	if err == nil || ctx.Err() == nil || errors.Is(err, ctx.Err()) {
+		return err
+	}
+	return errors.Join(err, ctx.Err())
+}
+
 type sqlPoolAdapter struct{ db *sql.DB }
 
 func (a *sqlPoolAdapter) Exec(ctx context.Context, q string, args ...any) (Result, error) {
@@ -234,7 +245,7 @@ func (a *sqlPoolAdapter) QueryRow(ctx context.Context, q string, args ...any) Ro
 func (a *sqlPoolAdapter) BeginTx(ctx context.Context, opts TxOptions) (Tx, error) {
 	tx, err := a.db.BeginTx(ctx, sqlTxOpts(opts))
 	if err != nil {
-		return nil, err
+		return nil, ctxErr(ctx, err)
 	}
 	return &sqlTxAdapter{tx: tx}, nil
 }
@@ -284,8 +295,8 @@ func (t *sqlTxAdapter) QueryRow(ctx context.Context, q string, args ...any) Row 
 	return &sqlRow{r: t.tx.QueryRowContext(ctx, q, args...)}
 }
 
-func (t *sqlTxAdapter) Commit(_ context.Context) error   { return t.tx.Commit() }
-func (t *sqlTxAdapter) Rollback(_ context.Context) error { return t.tx.Rollback() }
+func (t *sqlTxAdapter) Commit(ctx context.Context) error   { return ctxErr(ctx, t.tx.Commit()) }
+func (t *sqlTxAdapter) Rollback(ctx context.Context) error { return ctxErr(ctx, t.tx.Rollback()) }
 
 type sqlRows struct{ r *sql.Rows }
 

--- a/dbos/migration_test.go
+++ b/dbos/migration_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
@@ -194,4 +195,51 @@ func TestRunnerResumesAfterInvalidIndex(t *testing.T) {
 	var version int64
 	require.NoError(t, pool.QueryRow(bg, "SELECT version FROM dbos.dbos_migrations").Scan(&version))
 	assert.Equal(t, latest, version)
+}
+
+// TestNewSystemDatabaseErrorPathNoDeadlock forces shouldMigrate to fail inside
+// newSystemDatabase and verifies the error is returned instead of deadlocking.
+// The error paths after the CockroachDB-detection Acquire call pool.Close()
+// while that connection is still checked out; puddle's Close blocks until all
+// resources are destroyed, and the deferred Release can only run after
+// newSystemDatabase returns — a single-goroutine deadlock.
+func TestNewSystemDatabaseErrorPathNoDeadlock(t *testing.T) {
+	skipIfSqlite(t, "pg pool lifecycle; sqlite has no pgx pool to close")
+	databaseURL := getDatabaseURL()
+	bg := context.Background()
+
+	pool, err := pgxpool.New(bg, databaseURL)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	// A migration table without a version column makes shouldMigrate fail
+	// with a non-retryable error (undefined column).
+	const schema = "deadlock_test_schema"
+	_, err = pool.Exec(bg, fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schema))
+	require.NoError(t, err)
+	_, err = pool.Exec(bg, fmt.Sprintf("CREATE SCHEMA %s", schema))
+	require.NoError(t, err)
+	_, err = pool.Exec(bg, fmt.Sprintf("CREATE TABLE %s.%s (bogus INT)", schema, _DBOS_MIGRATION_TABLE))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(bg, fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schema))
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, sdErr := newSystemDatabase(bg, newSystemDatabaseInput{
+			databaseURL:    databaseURL,
+			databaseSchema: schema,
+			logger:         slog.Default(),
+		})
+		done <- sdErr
+	}()
+
+	select {
+	case sdErr := <-done:
+		require.Error(t, sdErr)
+		assert.Contains(t, sdErr.Error(), "failed to determine migration status")
+	case <-time.After(30 * time.Second):
+		t.Fatal("newSystemDatabase deadlocked on its error path: pool.Close() waits on the still-acquired CockroachDB-detection connection")
+	}
 }

--- a/dbos/system_database.go
+++ b/dbos/system_database.go
@@ -809,8 +809,10 @@ func newSystemDatabase(ctx context.Context, inputs newSystemDatabaseInput) (syst
 		}
 		return nil, fmt.Errorf("failed to acquire connection to detect database type: %v", err)
 	}
-	defer conn.Release()
 	isCockroach := isCockroachDB(conn.Conn())
+	// Release before any error path calls pool.Close(): Close blocks until all
+	// acquired connections are returned, so a deferred Release would deadlock.
+	conn.Release()
 	if isCockroach {
 		logger.Info("Detected CockroachDB")
 	}


### PR DESCRIPTION
- Fix a deadlock when calling `newSystemDatabase` fails
- Funnel context errors to the caller for sqlite Commit/Rollback