### PR TITLE
Add print only flags to dbos migrate

### DIFF
--- a/cmd/dbos/cli_integration_test.go
+++ b/cmd/dbos/cli_integration_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"database/sql"
 	_ "embed"
@@ -1060,4 +1061,52 @@ func buildCLI(t *testing.T) string {
 	absPath, err := filepath.Abs(cliPath)
 	require.NoError(t, err, "Failed to get absolute path")
 	return absPath
+}
+
+// TestMigratePrintOnly verifies `dbos migrate --print-only` prints clean SQL
+// to stdout without connecting to a database. The DB URL points at an
+// unreachable host so any connection attempt would fail the test.
+func TestMigratePrintOnly(t *testing.T) {
+	cliPath := buildCLI(t)
+	dir := t.TempDir()
+	env := append(os.Environ(), "DBOS_SYSTEM_DATABASE_URL=postgres://nouser:nopass@unreachable-host.invalid:5432/nodb")
+
+	t.Run("PrintsSQLWithoutConnecting", func(t *testing.T) {
+		cmd := exec.Command(cliPath, "migrate", "--print-only", "--app-role", "print_role", "--schema", "myschema")
+		cmd.Dir = dir
+		cmd.Env = env
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		require.NoError(t, cmd.Run(), "stderr: %s", stderr.String())
+
+		out := stdout.String()
+		assert.Contains(t, out, `CREATE SCHEMA IF NOT EXISTS "myschema";`)
+		assert.Contains(t, out, `CREATE TABLE IF NOT EXISTS "myschema".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY);`)
+		assert.Contains(t, out, `CREATE TABLE "myschema".workflow_status`)
+		assert.Contains(t, out, `INSERT INTO "myschema".dbos_migrations (version) VALUES (1);`)
+		assert.Regexp(t, `UPDATE "myschema"\.dbos_migrations SET version = \d+;`, out)
+		assert.Contains(t, out, `GRANT USAGE ON SCHEMA "myschema" TO "print_role";`)
+		assert.Contains(t, out, `ALTER DEFAULT PRIVILEGES IN SCHEMA "myschema" GRANT EXECUTE ON FUNCTIONS TO "print_role";`)
+		// stdout must be SQL only: no JSON log lines
+		assert.NotContains(t, out, `{"time"`)
+	})
+
+	t.Run("SkipsConfigMigrateCommands", func(t *testing.T) {
+		configDir := t.TempDir()
+		configContent := "name: printonly-app\ndatabase:\n  migrate:\n    - echo should-not-run\n"
+		require.NoError(t, os.WriteFile(filepath.Join(configDir, "dbos-config.yaml"), []byte(configContent), 0644))
+
+		cmd := exec.Command(cliPath, "migrate", "--print-only")
+		cmd.Dir = configDir
+		cmd.Env = env
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		require.NoError(t, cmd.Run(), "stderr: %s", stderr.String())
+
+		assert.Contains(t, stderr.String(), "Skipping migration commands")
+		assert.Contains(t, stdout.String(), `CREATE SCHEMA IF NOT EXISTS "dbos";`)
+		assert.NotContains(t, stdout.String(), "should-not-run")
+	})
 }

--- a/cmd/dbos/cli_integration_test.go
+++ b/cmd/dbos/cli_integration_test.go
@@ -1141,6 +1141,28 @@ func TestMigratePrintFlags(t *testing.T) {
 		assert.Equal(t, 1, code)
 		assert.Contains(t, errOut, "Invalid --print-migrations value 'nope': expected 'all' or a migration number")
 		assert.Empty(t, out)
+
+		// An empty value is supplied-but-invalid, not unset: it must never fall
+		// through to the connect-and-migrate path.
+		out, errOut, code = run(t, env, "--print-migrations", "")
+		assert.Equal(t, 1, code)
+		assert.Contains(t, errOut, "Invalid --print-migrations value '': expected 'all' or a migration number")
+		assert.Empty(t, out)
+	})
+
+	t.Run("PrintMigrationsWithoutDatabaseURL", func(t *testing.T) {
+		noURL := []string{}
+		for _, e := range os.Environ() {
+			if !strings.HasPrefix(e, "DBOS_SYSTEM_DATABASE_URL=") {
+				noURL = append(noURL, e)
+			}
+		}
+		out, errOut, code := run(t, noURL, "--print-migrations", "all")
+		require.Equal(t, 0, code, "stderr: %s", errOut)
+		assert.Empty(t, errOut)
+		assert.Contains(t, out, "-- DBOS system database migrations\n")
+		assert.NotContains(t, out, "-- DBOS system database migrations for")
+		assert.Contains(t, out, `CREATE SCHEMA IF NOT EXISTS "dbos";`)
 	})
 
 	t.Run("PrintMigrationsFunnySchema", func(t *testing.T) {

--- a/cmd/dbos/cli_integration_test.go
+++ b/cmd/dbos/cli_integration_test.go
@@ -1063,50 +1063,135 @@ func buildCLI(t *testing.T) string {
 	return absPath
 }
 
-// TestMigratePrintOnly verifies `dbos migrate --print-only` prints clean SQL
-// to stdout without connecting to a database. The DB URL points at an
-// unreachable host so any connection attempt would fail the test.
-func TestMigratePrintOnly(t *testing.T) {
+// TestMigratePrintFlags verifies `dbos migrate --print-migrations` and
+// `--print-user-role` print clean SQL to stdout without connecting to a
+// database. The DB URL points at an unreachable host so any connection
+// attempt would fail the test.
+func TestMigratePrintFlags(t *testing.T) {
 	cliPath := buildCLI(t)
 	dir := t.TempDir()
 	env := append(os.Environ(), "DBOS_SYSTEM_DATABASE_URL=postgres://nouser:nopass@unreachable-host.invalid:5432/nodb")
 
-	t.Run("PrintsSQLWithoutConnecting", func(t *testing.T) {
-		cmd := exec.Command(cliPath, "migrate", "--print-only", "--app-role", "print_role", "--schema", "myschema")
+	run := func(t *testing.T, env []string, args ...string) (stdout, stderr string, exitCode int) {
+		t.Helper()
+		cmd := exec.Command(cliPath, append([]string{"migrate"}, args...)...)
 		cmd.Dir = dir
 		cmd.Env = env
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		require.NoError(t, cmd.Run(), "stderr: %s", stderr.String())
+		var out, errOut bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &errOut
+		if err := cmd.Run(); err != nil {
+			exitErr, ok := err.(*exec.ExitError)
+			require.True(t, ok, "unexpected error: %v", err)
+			exitCode = exitErr.ExitCode()
+		}
+		return out.String(), errOut.String(), exitCode
+	}
 
-		out := stdout.String()
-		assert.Contains(t, out, `CREATE SCHEMA IF NOT EXISTS "myschema";`)
-		assert.Contains(t, out, `CREATE TABLE IF NOT EXISTS "myschema".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY);`)
-		assert.Contains(t, out, `CREATE TABLE "myschema".workflow_status`)
-		assert.Contains(t, out, `INSERT INTO "myschema".dbos_migrations (version) VALUES (1);`)
-		assert.Regexp(t, `UPDATE "myschema"\.dbos_migrations SET version = \d+;`, out)
-		assert.Contains(t, out, `GRANT USAGE ON SCHEMA "myschema" TO "print_role";`)
-		assert.Contains(t, out, `ALTER DEFAULT PRIVILEGES IN SCHEMA "myschema" GRANT EXECUTE ON FUNCTIONS TO "print_role";`)
-		// stdout must be SQL only: no JSON log lines
+	t.Run("PrintMigrationsAll", func(t *testing.T) {
+		out, errOut, code := run(t, env, "--print-migrations", "all")
+		require.Equal(t, 0, code, "stderr: %s", errOut)
+		assert.Empty(t, errOut)
+		assert.Contains(t, out, "-- DBOS system database migrations for postgres://nouser:***@unreachable-host.invalid:5432/nodb")
+		assert.Contains(t, out, "-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql --single-transaction).")
+		assert.Contains(t, out, "-- This script is for FRESH databases only.")
+		assert.Contains(t, out, `CREATE SCHEMA IF NOT EXISTS "dbos";`)
+		assert.Contains(t, out, `CREATE TABLE IF NOT EXISTS "dbos".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY);`)
+		assert.Contains(t, out, `INSERT INTO "dbos".dbos_migrations (version) VALUES (1);`)
+		assert.Regexp(t, `UPDATE "dbos"\.dbos_migrations SET version = \d+;`, out)
+		assert.Contains(t, out, "-- Migration 10 skipped: not applicable on fresh databases")
+		assert.NotContains(t, out, "ADD PRIMARY KEY (message_uuid)")
+		assert.NotContains(t, out, "DO $$")
+		// Role grants are only printed by --print-user-role
+		assert.NotContains(t, out, "GRANT")
+		// stdout must be SQL only: no JSON log lines, no raw password
 		assert.NotContains(t, out, `{"time"`)
+		assert.NotContains(t, out, "nopass")
 	})
 
-	t.Run("SkipsConfigMigrateCommands", func(t *testing.T) {
-		configDir := t.TempDir()
-		configContent := "name: printonly-app\ndatabase:\n  migrate:\n    - echo should-not-run\n"
-		require.NoError(t, os.WriteFile(filepath.Join(configDir, "dbos-config.yaml"), []byte(configContent), 0644))
+	t.Run("PrintMigrationsFromOneEqualsAll", func(t *testing.T) {
+		all, _, code := run(t, env, "--print-migrations", "all")
+		require.Equal(t, 0, code)
+		fromOne, _, code := run(t, env, "--print-migrations", "1")
+		require.Equal(t, 0, code)
+		assert.Equal(t, all, fromOne)
+	})
 
-		cmd := exec.Command(cliPath, "migrate", "--print-only")
-		cmd.Dir = configDir
-		cmd.Env = env
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		require.NoError(t, cmd.Run(), "stderr: %s", stderr.String())
+	t.Run("PrintMigrationsMidway", func(t *testing.T) {
+		out, errOut, code := run(t, env, "--print-migrations", "10")
+		require.Equal(t, 0, code, "stderr: %s", errOut)
+		assert.Empty(t, errOut)
+		assert.NotContains(t, out, "CREATE SCHEMA")
+		assert.NotContains(t, out, "FRESH databases only")
+		assert.NotContains(t, out, "-- Migration 9\n")
+		assert.NotContains(t, out, `INSERT INTO "dbos".dbos_migrations`)
+		assert.Contains(t, out, "-- Migration 10 skipped: not applicable on fresh databases")
+		assert.Contains(t, out, `UPDATE "dbos".dbos_migrations SET version = 10;`)
+		assert.Contains(t, out, "-- Migration 11\n")
+	})
 
-		assert.Contains(t, stderr.String(), "Skipping migration commands")
-		assert.Contains(t, stdout.String(), `CREATE SCHEMA IF NOT EXISTS "dbos";`)
-		assert.NotContains(t, stdout.String(), "should-not-run")
+	t.Run("PrintMigrationsInvalidValues", func(t *testing.T) {
+		for _, bad := range []string{"0", "9999", "-1"} {
+			out, errOut, code := run(t, env, "--print-migrations", bad)
+			assert.Equal(t, 1, code)
+			assert.Contains(t, errOut, "does not exist: valid migrations are 1 through")
+			assert.Empty(t, out)
+		}
+		out, errOut, code := run(t, env, "--print-migrations", "nope")
+		assert.Equal(t, 1, code)
+		assert.Contains(t, errOut, "Invalid --print-migrations value 'nope': expected 'all' or a migration number")
+		assert.Empty(t, out)
+	})
+
+	t.Run("PrintMigrationsFunnySchema", func(t *testing.T) {
+		out, _, code := run(t, env, "--schema", "F8nny_sCHem@-n@m3", "--print-migrations", "all")
+		require.Equal(t, 0, code)
+		assert.Contains(t, out, `CREATE SCHEMA IF NOT EXISTS "F8nny_sCHem@-n@m3";`)
+		assert.NotContains(t, out, "CREATE TABLE F8nny_sCHem@-n@m3.")
+	})
+
+	t.Run("PrintUserRole", func(t *testing.T) {
+		out, errOut, code := run(t, env, "--schema", "F8nny_sCHem@-n@m3", "--print-user-role", "-r", "my-app-role")
+		require.Equal(t, 0, code, "stderr: %s", errOut)
+		assert.Empty(t, errOut)
+		assert.Contains(t, out, "-- Permissions on DBOS schema F8nny_sCHem@-n@m3 for role my-app-role")
+		assert.Contains(t, out, `GRANT USAGE ON SCHEMA "F8nny_sCHem@-n@m3" TO "my-app-role";`)
+		for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+			assert.True(t, strings.HasPrefix(line, "--") || strings.HasPrefix(line, "GRANT") || strings.HasPrefix(line, "ALTER"), "unexpected line: %s", line)
+		}
+	})
+
+	t.Run("PrintUserRoleRequiresAppRole", func(t *testing.T) {
+		out, errOut, code := run(t, env, "--print-user-role")
+		assert.Equal(t, 1, code)
+		assert.Contains(t, errOut, "--print-user-role requires --app-role")
+		assert.Empty(t, out)
+	})
+
+	t.Run("MutuallyExclusive", func(t *testing.T) {
+		out, errOut, code := run(t, env, "--print-migrations", "all", "--print-user-role", "-r", "my-app-role")
+		assert.Equal(t, 1, code)
+		assert.Contains(t, errOut, "--print-user-role cannot be combined with --print-migrations")
+		assert.Empty(t, out)
+	})
+
+	t.Run("QuotedNamesRejected", func(t *testing.T) {
+		out, errOut, code := run(t, env, "--schema", `bad"schema`, "--print-migrations", "all")
+		assert.Equal(t, 1, code)
+		assert.Contains(t, errOut, "Schema names containing quotes are not supported")
+		assert.Empty(t, out)
+
+		out, errOut, code = run(t, env, "--print-user-role", "-r", "bad'role")
+		assert.Equal(t, 1, code)
+		assert.Contains(t, errOut, "Role names containing quotes are not supported")
+		assert.Empty(t, out)
+	})
+
+	t.Run("SqliteRejected", func(t *testing.T) {
+		sqliteEnv := append(os.Environ(), "DBOS_SYSTEM_DATABASE_URL=sqlite:"+filepath.Join(t.TempDir(), "dbos.db"))
+		out, errOut, code := run(t, sqliteEnv, "--print-migrations", "all")
+		assert.Equal(t, 1, code)
+		assert.Contains(t, errOut, "--print-migrations is only supported for Postgres databases")
+		assert.Empty(t, out)
 	})
 }

--- a/cmd/dbos/migrate.go
+++ b/cmd/dbos/migrate.go
@@ -3,9 +3,13 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dbos-inc/dbos-transact-golang/dbos"
@@ -22,12 +26,14 @@ var migrateCmd = &cobra.Command{
 
 var (
 	applicationRole string
-	printOnly       bool
+	printMigrations string
+	printUserRole   bool
 )
 
 func init() {
 	migrateCmd.Flags().StringVarP(&applicationRole, "app-role", "r", "", "The role with which you will run your DBOS application")
-	migrateCmd.Flags().BoolVar(&printOnly, "print-only", false, "Print the migration SQL to stdout without executing anything")
+	migrateCmd.Flags().StringVar(&printMigrations, "print-migrations", "", "Print the SQL of all migrations ('all') or of migrations from a number onward ('3') instead of running them")
+	migrateCmd.Flags().BoolVar(&printUserRole, "print-user-role", false, "Print the SQL granting the application role (--app-role) access to DBOS system tables instead of executing it")
 }
 
 func runMigrate(cmd *cobra.Command, args []string) error {
@@ -37,8 +43,13 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 		dbSchema = schema
 	}
 
-	if printOnly {
-		return printMigrationSQL(dbSchema)
+	if printMigrations != "" || printUserRole {
+		// Print modes never touch a database; stdout is pure SQL and comments.
+		if err := runMigratePrint(dbSchema); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return nil
 	}
 
 	// Get database URL
@@ -88,24 +99,70 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// printMigrationSQL writes the full migration SQL to stdout without touching
-// the database. Logging goes to stderr.
-func printMigrationSQL(schemaName string) error {
-	if config != nil && len(config.Database.Migrate) > 0 {
-		logger.Warn("Skipping migration commands from 'dbos-config.yaml' in print-only mode", "commands", config.Database.Migrate)
+func runMigratePrint(schemaName string) error {
+	if printMigrations != "" && printUserRole {
+		return errors.New("--print-user-role cannot be combined with --print-migrations")
 	}
-
-	fmt.Println("-- DBOS system database migration")
-	fmt.Printf("-- Schema: %s\n", schemaName)
-	for _, stmt := range dbos.MigrationStatements(schemaName) {
-		fmt.Println(stmt)
-	}
-
-	if applicationRole != "" {
-		fmt.Printf("-- Permissions for application role: %s\n", applicationRole)
+	if printUserRole {
+		if applicationRole == "" {
+			return errors.New("--print-user-role requires --app-role")
+		}
+		if strings.ContainsAny(schemaName, `"'`) {
+			return errors.New("Schema names containing quotes are not supported")
+		}
+		if strings.ContainsAny(applicationRole, `"'`) {
+			return errors.New("Role names containing quotes are not supported")
+		}
+		fmt.Printf("-- Permissions on DBOS schema %s for role %s\n", schemaName, applicationRole)
 		for _, query := range grantQueries(applicationRole, schemaName) {
 			fmt.Printf("%s;\n", query)
 		}
+		return nil
+	}
+	return printDBOSMigrations(schemaName, printMigrations)
+}
+
+func printDBOSMigrations(schemaName, value string) error {
+	dbURL, err := getDBURL()
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(dbURL, "sqlite") {
+		return errors.New("--print-migrations is only supported for Postgres databases")
+	}
+	if strings.ContainsAny(schemaName, `"'`) {
+		return errors.New("Schema names containing quotes are not supported")
+	}
+
+	latest := dbos.NumMigrations()
+	from := 1
+	if value != "all" {
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("Invalid --print-migrations value '%s': expected 'all' or a migration number", value)
+		}
+		if n < 1 || n > latest {
+			return fmt.Errorf("Migration %d does not exist: valid migrations are 1 through %d", n, latest)
+		}
+		from = n
+	}
+
+	statements, err := dbos.MigrationStatements(schemaName, from)
+	if err != nil {
+		return err
+	}
+
+	maskedURL, err := maskPassword(dbURL)
+	if err != nil {
+		maskedURL = dbURL
+	}
+	fmt.Printf("-- DBOS system database migrations for %s\n", maskedURL)
+	fmt.Println("-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql --single-transaction).")
+	if from == 1 {
+		fmt.Println("-- This script is for FRESH databases only.")
+	}
+	for _, stmt := range statements {
+		fmt.Println(stmt)
 	}
 	return nil
 }

--- a/cmd/dbos/migrate.go
+++ b/cmd/dbos/migrate.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/dbos-inc/dbos-transact-golang/dbos"
 	"github.com/jackc/pgx/v5"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/spf13/cobra"
@@ -21,13 +22,25 @@ var migrateCmd = &cobra.Command{
 
 var (
 	applicationRole string
+	printOnly       bool
 )
 
 func init() {
 	migrateCmd.Flags().StringVarP(&applicationRole, "app-role", "r", "", "The role with which you will run your DBOS application")
+	migrateCmd.Flags().BoolVar(&printOnly, "print-only", false, "Print the migration SQL to stdout without executing anything")
 }
 
 func runMigrate(cmd *cobra.Command, args []string) error {
+	// Determine the schema to use (from flag or default)
+	dbSchema := "dbos"
+	if schema != "" {
+		dbSchema = schema
+	}
+
+	if printOnly {
+		return printMigrationSQL(dbSchema)
+	}
+
 	// Get database URL
 	dbURL, err := getDBURL()
 	if err != nil {
@@ -40,12 +53,6 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 	_, err = createContext(ctx, dbURL)
 	if err != nil {
 		return err
-	}
-
-	// Determine the schema to use (from flag or default)
-	dbSchema := "dbos"
-	if schema != "" {
-		dbSchema = schema
 	}
 
 	// Grant permissions to application role if specified
@@ -81,6 +88,43 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// printMigrationSQL writes the full migration SQL to stdout without touching
+// the database. Logging goes to stderr.
+func printMigrationSQL(schemaName string) error {
+	if config != nil && len(config.Database.Migrate) > 0 {
+		logger.Warn("Skipping migration commands from 'dbos-config.yaml' in print-only mode", "commands", config.Database.Migrate)
+	}
+
+	fmt.Println("-- DBOS system database migration")
+	fmt.Printf("-- Schema: %s\n", schemaName)
+	for _, stmt := range dbos.MigrationStatements(schemaName) {
+		fmt.Println(stmt)
+	}
+
+	if applicationRole != "" {
+		fmt.Printf("-- Permissions for application role: %s\n", applicationRole)
+		for _, query := range grantQueries(applicationRole, schemaName) {
+			fmt.Printf("%s;\n", query)
+		}
+	}
+	return nil
+}
+
+func grantQueries(roleName, schemaName string) []string {
+	schemaSQL := pgx.Identifier{schemaName}.Sanitize()
+	roleSQL := pgx.Identifier{roleName}.Sanitize()
+
+	return []string{
+		fmt.Sprintf(`GRANT USAGE ON SCHEMA %s TO %s`, schemaSQL, roleSQL),
+		fmt.Sprintf(`GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s TO %s`, schemaSQL, roleSQL),
+		fmt.Sprintf(`GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %s TO %s`, schemaSQL, roleSQL),
+		fmt.Sprintf(`GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %s TO %s`, schemaSQL, roleSQL),
+		fmt.Sprintf(`ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT ALL ON TABLES TO %s`, schemaSQL, roleSQL),
+		fmt.Sprintf(`ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT ALL ON SEQUENCES TO %s`, schemaSQL, roleSQL),
+		fmt.Sprintf(`ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT EXECUTE ON FUNCTIONS TO %s`, schemaSQL, roleSQL),
+	}
+}
+
 func grantDBOSSchemaPermissions(databaseURL, roleName, schemaName string) error {
 	logger.Info("Granting permissions for schema", "role", roleName, "schema", schemaName)
 
@@ -93,21 +137,7 @@ func grantDBOSSchemaPermissions(databaseURL, roleName, schemaName string) error 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Grant usage on the specified schema
-	schemaSQL := pgx.Identifier{schemaName}.Sanitize()
-	roleSQL := pgx.Identifier{roleName}.Sanitize()
-
-	queries := []string{
-		fmt.Sprintf(`GRANT USAGE ON SCHEMA %s TO %s`, schemaSQL, roleSQL),
-		fmt.Sprintf(`GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s TO %s`, schemaSQL, roleSQL),
-		fmt.Sprintf(`GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %s TO %s`, schemaSQL, roleSQL),
-		fmt.Sprintf(`GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %s TO %s`, schemaSQL, roleSQL),
-		fmt.Sprintf(`ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT ALL ON TABLES TO %s`, schemaSQL, roleSQL),
-		fmt.Sprintf(`ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT ALL ON SEQUENCES TO %s`, schemaSQL, roleSQL),
-		fmt.Sprintf(`ALTER DEFAULT PRIVILEGES IN SCHEMA %s GRANT EXECUTE ON FUNCTIONS TO %s`, schemaSQL, roleSQL),
-	}
-
-	for _, query := range queries {
+	for _, query := range grantQueries(roleName, schemaName) {
 		logger.Debug("Executing grant query", "query", query)
 		if _, err := db.ExecContext(ctx, query); err != nil {
 			return fmt.Errorf("failed to execute grant: %w", err)

--- a/cmd/dbos/migrate.go
+++ b/cmd/dbos/migrate.go
@@ -32,7 +32,7 @@ var (
 
 func init() {
 	migrateCmd.Flags().StringVarP(&applicationRole, "app-role", "r", "", "The role with which you will run your DBOS application")
-	migrateCmd.Flags().StringVar(&printMigrations, "print-migrations", "", "Print the SQL of all migrations ('all') or of migrations from a number onward ('3') instead of running them")
+	migrateCmd.Flags().StringVar(&printMigrations, "print-migrations", "", "Print the SQL of all migrations ('--print-migrations all') or of migrations from a number onward ('--print-migrations 3') instead of running them")
 	migrateCmd.Flags().BoolVar(&printUserRole, "print-user-role", false, "Print the SQL granting the application role (--app-role) access to DBOS system tables instead of executing it")
 }
 
@@ -43,9 +43,10 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 		dbSchema = schema
 	}
 
-	if printMigrations != "" || printUserRole {
+	printMigrationsSet := cmd.Flags().Changed("print-migrations")
+	if printMigrationsSet || printUserRole {
 		// Print modes never touch a database; stdout is pure SQL and comments.
-		if err := runMigratePrint(dbSchema); err != nil {
+		if err := runMigratePrint(dbSchema, printMigrationsSet); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
@@ -99,8 +100,8 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runMigratePrint(schemaName string) error {
-	if printMigrations != "" && printUserRole {
+func runMigratePrint(schemaName string, printMigrationsSet bool) error {
+	if printMigrationsSet && printUserRole {
 		return errors.New("--print-user-role cannot be combined with --print-migrations")
 	}
 	if printUserRole {
@@ -123,10 +124,9 @@ func runMigratePrint(schemaName string) error {
 }
 
 func printDBOSMigrations(schemaName, value string) error {
-	dbURL, err := getDBURL()
-	if err != nil {
-		return err
-	}
+	// This mode never connects, so a missing database URL is not an error: it
+	// only leaves the URL out of the header comment.
+	dbURL, _ := getDBURL()
 	if strings.HasPrefix(dbURL, "sqlite") {
 		return errors.New("--print-migrations is only supported for Postgres databases")
 	}
@@ -134,15 +134,11 @@ func printDBOSMigrations(schemaName, value string) error {
 		return errors.New("Schema names containing quotes are not supported")
 	}
 
-	latest := dbos.NumMigrations()
 	from := 1
 	if value != "all" {
 		n, err := strconv.Atoi(value)
 		if err != nil {
 			return fmt.Errorf("Invalid --print-migrations value '%s': expected 'all' or a migration number", value)
-		}
-		if n < 1 || n > latest {
-			return fmt.Errorf("Migration %d does not exist: valid migrations are 1 through %d", n, latest)
 		}
 		from = n
 	}
@@ -152,11 +148,15 @@ func printDBOSMigrations(schemaName, value string) error {
 		return err
 	}
 
-	maskedURL, err := maskPassword(dbURL)
-	if err != nil {
-		maskedURL = dbURL
+	header := "-- DBOS system database migrations"
+	if dbURL != "" {
+		maskedURL, err := maskPassword(dbURL)
+		if err != nil {
+			maskedURL = dbURL
+		}
+		header += " for " + maskedURL
 	}
-	fmt.Printf("-- DBOS system database migrations for %s\n", maskedURL)
+	fmt.Println(header)
 	fmt.Println("-- Contains CREATE/DROP INDEX CONCURRENTLY: run outside a transaction block (e.g. plain psql, not psql --single-transaction).")
 	if from == 1 {
 		fmt.Println("-- This script is for FRESH databases only.")

--- a/dbos/migration_test.go
+++ b/dbos/migration_test.go
@@ -247,8 +247,8 @@ func TestNewSystemDatabaseErrorPathNoDeadlock(t *testing.T) {
 }
 
 // TestMigrationStatements verifies the printable migration SQL (used by
-// `dbos migrate --print-only`) is complete: executing it on a fresh database
-// leaves the schema fully migrated.
+// `dbos migrate --print-migrations`) is complete: executing it on a fresh
+// database leaves the schema fully migrated.
 func TestMigrationStatements(t *testing.T) {
 	skipIfSqlite(t, "printable migration SQL targets Postgres")
 	skipIfCockroach(t, "printable migration SQL is built with isCockroach=false")
@@ -259,13 +259,35 @@ func TestMigrationStatements(t *testing.T) {
 	migs := sysdb.BuildMigrations("dbos", false)
 	latest := migs[len(migs)-1].Version
 
-	stmts := MigrationStatements("")
+	// Invalid migration numbers are rejected.
+	_, err := MigrationStatements("", 0)
+	require.Error(t, err)
+	_, err = MigrationStatements("", int(latest)+1)
+	require.Error(t, err)
+
+	stmts, err := MigrationStatements("", 1)
+	require.NoError(t, err)
 	require.Greater(t, len(stmts), 2)
 	assert.Equal(t, `CREATE SCHEMA IF NOT EXISTS "dbos";`, stmts[0])
 	assert.Equal(t, `CREATE TABLE IF NOT EXISTS "dbos".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY);`, stmts[1])
+	assert.Contains(t, stmts, `INSERT INTO "dbos".dbos_migrations (version) VALUES (1);`)
 	assert.Equal(t, fmt.Sprintf(`UPDATE "dbos".dbos_migrations SET version = %d;`, latest), stmts[len(stmts)-1])
+	assert.Contains(t, stmts, "-- Migration 10 skipped: not applicable on fresh databases")
+	for _, stmt := range stmts {
+		assert.NotContains(t, stmt, "DO $$")
+		assert.NotContains(t, stmt, "ADD PRIMARY KEY (message_uuid)")
+	}
 
-	_, err := pool.Exec(bg, "DROP SCHEMA dbos CASCADE")
+	// Starting mid-way omits the prelude and earlier migrations.
+	mid, err := MigrationStatements("", 10)
+	require.NoError(t, err)
+	assert.Equal(t, "-- Migration 10 skipped: not applicable on fresh databases", mid[0])
+	assert.Equal(t, `UPDATE "dbos".dbos_migrations SET version = 10;`, mid[1])
+	assert.Contains(t, mid, "-- Migration 11")
+	assert.NotContains(t, mid, stmts[0])
+	assert.NotContains(t, mid, "-- Migration 9")
+
+	_, err = pool.Exec(bg, "DROP SCHEMA dbos CASCADE")
 	require.NoError(t, err)
 
 	for _, stmt := range stmts {
@@ -276,4 +298,25 @@ func TestMigrationStatements(t *testing.T) {
 	need, err := sysdb.ShouldMigrate(bg, pool, "dbos", false)
 	require.NoError(t, err)
 	assert.False(t, need, "SQL from MigrationStatements should leave the schema fully migrated")
+	var version int64
+	require.NoError(t, pool.QueryRow(bg, "SELECT version FROM dbos.dbos_migrations").Scan(&version))
+	assert.Equal(t, latest, version)
+
+	// A funny schema name is quoted throughout and applies cleanly.
+	funny := "F8nny_sCHem@-n@m3"
+	fstmts, err := MigrationStatements(funny, 1)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS "%s";`, funny), fstmts[0])
+	for _, stmt := range fstmts {
+		assert.NotContains(t, stmt, "CREATE TABLE "+funny+".")
+	}
+	for _, stmt := range fstmts {
+		_, err := pool.Exec(bg, stmt)
+		require.NoError(t, err, "statement failed: %s", stmt)
+	}
+	need, err = sysdb.ShouldMigrate(bg, pool, funny, false)
+	require.NoError(t, err)
+	assert.False(t, need)
+	_, err = pool.Exec(bg, fmt.Sprintf(`DROP SCHEMA "%s" CASCADE`, funny))
+	require.NoError(t, err)
 }

--- a/dbos/migration_test.go
+++ b/dbos/migration_test.go
@@ -245,3 +245,35 @@ func TestNewSystemDatabaseErrorPathNoDeadlock(t *testing.T) {
 		t.Fatal("newSystemDatabase deadlocked on its error path: pool.Close() waits on the still-acquired CockroachDB-detection connection")
 	}
 }
+
+// TestMigrationStatements verifies the printable migration SQL (used by
+// `dbos migrate --print-only`) is complete: executing it on a fresh database
+// leaves the schema fully migrated.
+func TestMigrationStatements(t *testing.T) {
+	skipIfSqlite(t, "printable migration SQL targets Postgres")
+	skipIfCockroach(t, "printable migration SQL is built with isCockroach=false")
+	ctx := setupDBOS(t, setupDBOSOptions{dropDB: true})
+	pool := poolFromContext(t, ctx)
+	bg := context.Background()
+
+	migs := sysdb.BuildMigrations("dbos", false)
+	latest := migs[len(migs)-1].Version
+
+	stmts := MigrationStatements("")
+	require.Greater(t, len(stmts), 2)
+	assert.Equal(t, `CREATE SCHEMA IF NOT EXISTS "dbos";`, stmts[0])
+	assert.Equal(t, `CREATE TABLE IF NOT EXISTS "dbos".dbos_migrations (version BIGINT NOT NULL PRIMARY KEY);`, stmts[1])
+	assert.Equal(t, fmt.Sprintf(`UPDATE "dbos".dbos_migrations SET version = %d;`, latest), stmts[len(stmts)-1])
+
+	_, err := pool.Exec(bg, "DROP SCHEMA dbos CASCADE")
+	require.NoError(t, err)
+
+	for _, stmt := range stmts {
+		_, err := pool.Exec(bg, stmt)
+		require.NoError(t, err, "statement failed: %s", stmt)
+	}
+
+	need, err := sysdb.ShouldMigrate(bg, pool, "dbos", false)
+	require.NoError(t, err)
+	assert.False(t, need, "SQL from MigrationStatements should leave the schema fully migrated")
+}

--- a/dbos/migrations.go
+++ b/dbos/migrations.go
@@ -9,33 +9,60 @@ import (
 	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/sysdb"
 )
 
-// MigrationStatements returns the ordered SQL statements a system database
-// migration executes against a fresh PostgreSQL database for the given
-// schema, including schema creation and migration-version bookkeeping.
-// Each entry is a semicolon-terminated statement (or batch of statements)
-// suitable for execution with psql. An empty schemaName uses the default
-// ("dbos").
-func MigrationStatements(schemaName string) []string {
+// NumMigrations returns the number of DBOS system database migrations.
+func NumMigrations() int {
+	return len(sysdb.BuildMigrations(_DEFAULT_SYSTEM_DB_SCHEMA, false))
+}
+
+// MigrationStatements returns the SQL the system database migrations execute
+// against a PostgreSQL database for the given schema, as an ordered list of
+// semicolon-terminated statements and "--" comment lines suitable for
+// execution with psql. It never connects to a database.
+//
+// from is a 1-based migration number: pass 1 for the full fresh-database
+// script (including schema creation, the dbos_migrations table, and the
+// initial version row), or a later number for migrations from through
+// NumMigrations() only. Each migration is followed by its version
+// bookkeeping, mirroring the runner. The SQL contains CREATE/DROP INDEX
+// CONCURRENTLY, so it must run outside a transaction block. An empty
+// schemaName uses the default ("dbos").
+func MigrationStatements(schemaName string, from int) ([]string, error) {
 	if schemaName == "" {
 		schemaName = _DEFAULT_SYSTEM_DB_SCHEMA
 	}
+	migrations := sysdb.BuildMigrations(schemaName, false)
+	if from < 1 || from > len(migrations) {
+		return nil, fmt.Errorf("migration %d does not exist: valid migrations are 1 through %d", from, len(migrations))
+	}
 	sanitizedSchema := pgx.Identifier{schemaName}.Sanitize()
 
-	statements := []string{
-		fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s;", sanitizedSchema),
-		fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (version BIGINT NOT NULL PRIMARY KEY);", sanitizedSchema, sysdb.MigrationTable),
+	var statements []string
+	if from == 1 {
+		statements = append(statements,
+			fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s;", sanitizedSchema),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (version BIGINT NOT NULL PRIMARY KEY);", sanitizedSchema, sysdb.MigrationTable),
+		)
 	}
 
-	for i, migration := range sysdb.BuildMigrations(schemaName, false) {
-		if sql := strings.TrimSpace(migration.SQL); sql != "" {
-			statements = append(statements, sql)
+	versionRowExists := from > 1
+	for _, migration := range migrations[from-1:] {
+		if migration.Version == 10 {
+			// Migration 10 backfills the notifications primary key, which
+			// migration 1 already creates on a fresh database.
+			statements = append(statements, "-- Migration 10 skipped: not applicable on fresh databases")
+		} else if sql := strings.TrimSpace(migration.SQL); sql != "" {
+			if !strings.HasSuffix(sql, ";") {
+				sql += ";"
+			}
+			statements = append(statements, fmt.Sprintf("-- Migration %d", migration.Version), sql)
 		}
 		// Mirror the runner's per-migration version bookkeeping.
-		if i == 0 {
-			statements = append(statements, fmt.Sprintf("INSERT INTO %s.%s (version) VALUES (%d);", sanitizedSchema, sysdb.MigrationTable, migration.Version))
-		} else {
+		if versionRowExists {
 			statements = append(statements, fmt.Sprintf("UPDATE %s.%s SET version = %d;", sanitizedSchema, sysdb.MigrationTable, migration.Version))
+		} else {
+			statements = append(statements, fmt.Sprintf("INSERT INTO %s.%s (version) VALUES (%d);", sanitizedSchema, sysdb.MigrationTable, migration.Version))
+			versionRowExists = true
 		}
 	}
-	return statements
+	return statements, nil
 }

--- a/dbos/migrations.go
+++ b/dbos/migrations.go
@@ -9,11 +9,6 @@ import (
 	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/sysdb"
 )
 
-// NumMigrations returns the number of DBOS system database migrations.
-func NumMigrations() int {
-	return len(sysdb.BuildMigrations(_DEFAULT_SYSTEM_DB_SCHEMA, false))
-}
-
 // MigrationStatements returns the SQL the system database migrations execute
 // against a PostgreSQL database for the given schema, as an ordered list of
 // semicolon-terminated statements and "--" comment lines suitable for
@@ -21,18 +16,19 @@ func NumMigrations() int {
 //
 // from is a 1-based migration number: pass 1 for the full fresh-database
 // script (including schema creation, the dbos_migrations table, and the
-// initial version row), or a later number for migrations from through
-// NumMigrations() only. Each migration is followed by its version
-// bookkeeping, mirroring the runner. The SQL contains CREATE/DROP INDEX
-// CONCURRENTLY, so it must run outside a transaction block. An empty
-// schemaName uses the default ("dbos").
+// initial version row), or a later number for migrations from through the
+// latest only. Each migration is followed by its version bookkeeping,
+// mirroring the runner. The SQL contains CREATE/DROP INDEX CONCURRENTLY, so it
+// must run outside a transaction block. An empty schemaName uses the default
+// ("dbos").
 func MigrationStatements(schemaName string, from int) ([]string, error) {
 	if schemaName == "" {
 		schemaName = _DEFAULT_SYSTEM_DB_SCHEMA
 	}
 	migrations := sysdb.BuildMigrations(schemaName, false)
 	if from < 1 || from > len(migrations) {
-		return nil, fmt.Errorf("migration %d does not exist: valid migrations are 1 through %d", from, len(migrations))
+		// Printed verbatim by the CLI, so worded for the end user.
+		return nil, fmt.Errorf("Migration %d does not exist: valid migrations are 1 through %d", from, len(migrations))
 	}
 	sanitizedSchema := pgx.Identifier{schemaName}.Sanitize()
 

--- a/dbos/migrations.go
+++ b/dbos/migrations.go
@@ -1,0 +1,41 @@
+package dbos
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/sysdb"
+)
+
+// MigrationStatements returns the ordered SQL statements a system database
+// migration executes against a fresh PostgreSQL database for the given
+// schema, including schema creation and migration-version bookkeeping.
+// Each entry is a semicolon-terminated statement (or batch of statements)
+// suitable for execution with psql. An empty schemaName uses the default
+// ("dbos").
+func MigrationStatements(schemaName string) []string {
+	if schemaName == "" {
+		schemaName = _DEFAULT_SYSTEM_DB_SCHEMA
+	}
+	sanitizedSchema := pgx.Identifier{schemaName}.Sanitize()
+
+	statements := []string{
+		fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s;", sanitizedSchema),
+		fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (version BIGINT NOT NULL PRIMARY KEY);", sanitizedSchema, sysdb.MigrationTable),
+	}
+
+	for i, migration := range sysdb.BuildMigrations(schemaName, false) {
+		if sql := strings.TrimSpace(migration.SQL); sql != "" {
+			statements = append(statements, sql)
+		}
+		// Mirror the runner's per-migration version bookkeeping.
+		if i == 0 {
+			statements = append(statements, fmt.Sprintf("INSERT INTO %s.%s (version) VALUES (%d);", sanitizedSchema, sysdb.MigrationTable, migration.Version))
+		} else {
+			statements = append(statements, fmt.Sprintf("UPDATE %s.%s SET version = %d;", sanitizedSchema, sysdb.MigrationTable, migration.Version))
+		}
+	}
+	return statements
+}


### PR DESCRIPTION
```shell
dbos migrate --print-migrations all > migrations.sql   # fresh-database script
dbos migrate --print-migrations 10                     # migrations 10..latest
dbos migrate --print-user-role -r my_app_role          # grant SQL only
```