### PR TITLE
Driver registration

### DIFF
--- a/cmd/dbos/main.go
+++ b/cmd/dbos/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	_ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
+	_ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite"
 )
 
 func main() {

--- a/cmd/dbos/main.go
+++ b/cmd/dbos/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"os"
+
+	_ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
 )
 
 func main() {

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -43,9 +43,11 @@ type Config struct {
 	// key=value DSNs (e.g. postgres://user:pass@host:5432/dbname; CockroachDB uses the
 	// same form) and sqlite URLs (sqlite:/path/to.db, sqlite:relative.db, or
 	// sqlite::memory:). Exactly one of DatabaseURL, SystemDBPool, or SQLiteSystemDB must be set.
+	// SQLite URLs additionally require importing the driver package:
+	// import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
 	DatabaseURL               string
 	SystemDBPool              *pgxpool.Pool   // SystemDBPool is a custom pg/CRDB pool. Optional; takes precedence over DatabaseURL. Mutually exclusive with SQLiteSystemDB.
-	SQLiteSystemDB            *sql.DB         // SQLiteSystemDB is a custom sqlite handle (e.g. from modernc.org/sqlite). Optional; takes precedence over DatabaseURL. Mutually exclusive with SystemDBPool.
+	SQLiteSystemDB            *sql.DB         // SQLiteSystemDB is a custom sqlite handle. Optional; takes precedence over DatabaseURL. Mutually exclusive with SystemDBPool. Requires importing dbos/sqlite.
 	DatabaseSchema            string          // Database schema name (defaults to "dbos")
 	Logger                    *slog.Logger    // Custom logger instance (defaults to a new slog logger)
 	AdminServer               bool            // Enable Transact admin HTTP server (disabled by default)
@@ -674,9 +676,11 @@ type ClientConfig struct {
 	// DatabaseURL is the system-database connection string: a Postgres URL or key=value
 	// DSN, or a sqlite URL (sqlite:/path/to.db, sqlite:relative.db, or sqlite::memory:).
 	// Exactly one of DatabaseURL, SystemDBPool, or SQLiteSystemDB must be set.
+	// SQLite URLs additionally require importing the driver package:
+	// import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
 	DatabaseURL            string
 	SystemDBPool           *pgxpool.Pool   // SystemDBPool is a custom pg/CRDB pool. Optional; takes precedence over DatabaseURL. Mutually exclusive with SQLiteSystemDB.
-	SQLiteSystemDB         *sql.DB         // SQLiteSystemDB is a custom sqlite handle (e.g. from modernc.org/sqlite). Optional; takes precedence over DatabaseURL. Mutually exclusive with SystemDBPool.
+	SQLiteSystemDB         *sql.DB         // SQLiteSystemDB is a custom sqlite handle. Optional; takes precedence over DatabaseURL. Mutually exclusive with SystemDBPool. Requires importing dbos/sqlite.
 	DatabaseSchema         string          // Database schema name (defaults to "dbos")
 	Logger                 *slog.Logger    // Optional custom logger
 	Serializer             Serializer[any] // Optional custom serializer (defaults to JSON)

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -44,10 +44,10 @@ type Config struct {
 	// same form) and sqlite URLs (sqlite:/path/to.db, sqlite:relative.db, or
 	// sqlite::memory:). Exactly one of DatabaseURL, SystemDBPool, or SQLiteSystemDB must be set.
 	// SQLite URLs additionally require importing the driver package:
-	// import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
+	// import _ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite"
 	DatabaseURL               string
 	SystemDBPool              *pgxpool.Pool   // SystemDBPool is a custom pg/CRDB pool. Optional; takes precedence over DatabaseURL. Mutually exclusive with SQLiteSystemDB.
-	SQLiteSystemDB            *sql.DB         // SQLiteSystemDB is a custom sqlite handle. Optional; takes precedence over DatabaseURL. Mutually exclusive with SystemDBPool. Requires importing dbos/sqlite.
+	SQLiteSystemDB            *sql.DB         // SQLiteSystemDB is a custom sqlite handle. Optional; takes precedence over DatabaseURL. Mutually exclusive with SystemDBPool. Requires importing dbos/driver/sqlite.
 	DatabaseSchema            string          // Database schema name (defaults to "dbos")
 	Logger                    *slog.Logger    // Custom logger instance (defaults to a new slog logger)
 	AdminServer               bool            // Enable Transact admin HTTP server (disabled by default)
@@ -677,10 +677,10 @@ type ClientConfig struct {
 	// DSN, or a sqlite URL (sqlite:/path/to.db, sqlite:relative.db, or sqlite::memory:).
 	// Exactly one of DatabaseURL, SystemDBPool, or SQLiteSystemDB must be set.
 	// SQLite URLs additionally require importing the driver package:
-	// import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
+	// import _ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite"
 	DatabaseURL            string
 	SystemDBPool           *pgxpool.Pool   // SystemDBPool is a custom pg/CRDB pool. Optional; takes precedence over DatabaseURL. Mutually exclusive with SQLiteSystemDB.
-	SQLiteSystemDB         *sql.DB         // SQLiteSystemDB is a custom sqlite handle. Optional; takes precedence over DatabaseURL. Mutually exclusive with SystemDBPool. Requires importing dbos/sqlite.
+	SQLiteSystemDB         *sql.DB         // SQLiteSystemDB is a custom sqlite handle. Optional; takes precedence over DatabaseURL. Mutually exclusive with SystemDBPool. Requires importing dbos/driver/sqlite.
 	DatabaseSchema         string          // Database schema name (defaults to "dbos")
 	Logger                 *slog.Logger    // Optional custom logger
 	Serializer             Serializer[any] // Optional custom serializer (defaults to JSON)

--- a/dbos/driver/sqlite/sqlite.go
+++ b/dbos/driver/sqlite/sqlite.go
@@ -3,7 +3,7 @@
 //
 // It is imported for its side effects only, like a database/sql driver:
 //
-//	import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
+//	import _ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite"
 //
 // With this import in place, sqlite: database URLs (and the SQLiteSystemDB
 // config field) work everywhere in dbos. Without it, SQLite is not compiled

--- a/dbos/driver/sqlite/sqlite.go
+++ b/dbos/driver/sqlite/sqlite.go
@@ -1,14 +1,5 @@
 // Package sqlite registers SQLite support for DBOS, backed by the pure-Go
 // modernc.org/sqlite driver.
-//
-// It is imported for its side effects only, like a database/sql driver:
-//
-//	import _ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite"
-//
-// With this import in place, sqlite: database URLs (and the SQLiteSystemDB
-// config field) work everywhere in dbos. Without it, SQLite is not compiled
-// into the binary — PostgreSQL-only applications need nothing but the dbos
-// package and stay free of the SQLite dependency.
 package sqlite
 
 import (

--- a/dbos/internal/sysdb/dialect.go
+++ b/dbos/internal/sysdb/dialect.go
@@ -14,8 +14,6 @@ import (
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-	sqlitelib "modernc.org/sqlite"
-	sqlite3 "modernc.org/sqlite/lib"
 )
 
 // dialect.go: per-backend SQL fragments and behaviours.
@@ -345,32 +343,44 @@ func (SqliteDialect) SupportsArrayParameters() bool         { return false }
 func (SqliteDialect) SupportsDataModifyingCTE() bool        { return false }
 func (SqliteDialect) SupportsAttributesContainment() bool   { return false }
 
-// Classify sqlite errors via modernc's typed *sqlite.Error and the extended
-// result code constants in modernc.org/sqlite/lib. The Code() return is the
-// extended code (high byte = subcode, low byte = primary code); for retryable
+// Classify sqlite errors via the registered driver's ErrorCode extractor
+// (see sqlite_driver.go). The extracted value is the extended result code
+// (high byte = subcode, low byte = primary code); for retryable
 // classification we mask down to the primary code so all SQLITE_BUSY_* /
 // SQLITE_LOCKED_* variants match.
+//
+// The result codes are defined by SQLite itself and stable across drivers,
+// so they are spelled out here rather than imported from a driver package.
+const (
+	sqliteBusy                 = 5    // SQLITE_BUSY
+	sqliteLocked               = 6    // SQLITE_LOCKED
+	sqliteConstraintForeignKey = 787  // SQLITE_CONSTRAINT_FOREIGNKEY (19 | 3<<8)
+	sqliteConstraintPrimaryKey = 1555 // SQLITE_CONSTRAINT_PRIMARYKEY (19 | 6<<8)
+	sqliteConstraintUnique     = 2067 // SQLITE_CONSTRAINT_UNIQUE (19 | 8<<8)
+)
 
-// sqliteCode extracts the extended result code from err, or -1 if err is not
-// a modernc *sqlite.Error.
+// sqliteCode extracts the extended result code from err via the registered
+// driver, or -1 if no driver is registered or err is not a driver error.
 func sqliteCode(err error) int {
-	var se *sqlitelib.Error
-	if errors.As(err, &se) {
-		return se.Code()
+	sqliteDriverMu.RLock()
+	d := sqliteDriver
+	sqliteDriverMu.RUnlock()
+	if d == nil {
+		return -1
 	}
-	return -1
+	return d.ErrorCode(err)
 }
 
 func (SqliteDialect) IsUniqueViolation(err error) bool {
 	switch sqliteCode(err) {
-	case sqlite3.SQLITE_CONSTRAINT_UNIQUE, sqlite3.SQLITE_CONSTRAINT_PRIMARYKEY:
+	case sqliteConstraintUnique, sqliteConstraintPrimaryKey:
 		return true
 	}
 	return false
 }
 
 func (SqliteDialect) IsForeignKeyViolation(err error) bool {
-	return sqliteCode(err) == sqlite3.SQLITE_CONSTRAINT_FOREIGNKEY
+	return sqliteCode(err) == sqliteConstraintForeignKey
 }
 
 // IsRetryable matches SQLITE_BUSY / SQLITE_LOCKED and their extended variants
@@ -382,7 +392,7 @@ func (SqliteDialect) IsRetryable(err error, logger *slog.Logger) bool {
 		return false
 	}
 	switch code & 0xFF {
-	case sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED:
+	case sqliteBusy, sqliteLocked:
 		if logger != nil {
 			logger.Warn("Retrying transient sqlite error", "error", err)
 		}

--- a/dbos/internal/sysdb/sqlite_driver.go
+++ b/dbos/internal/sysdb/sqlite_driver.go
@@ -11,7 +11,7 @@ import (
 // package. SQLite support is linked in only when the user blank-imports the
 // public driver package, whose init() calls RegisterSQLiteDriver:
 //
-//	import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
+//	import _ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite"
 //
 // PostgreSQL-only builds therefore never compile or link the SQLite driver.
 
@@ -48,7 +48,7 @@ func registeredSQLiteDriver() (*SQLiteDriver, error) {
 	sqliteDriverMu.RLock()
 	defer sqliteDriverMu.RUnlock()
 	if sqliteDriver == nil {
-		return nil, fmt.Errorf(`SQLite support is not linked into this binary: add import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite" to register the SQLite driver`)
+		return nil, fmt.Errorf(`SQLite support is not linked into this binary: add import _ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite" to register the SQLite driver`)
 	}
 	return sqliteDriver, nil
 }

--- a/dbos/internal/sysdb/sqlite_driver.go
+++ b/dbos/internal/sysdb/sqlite_driver.go
@@ -1,0 +1,54 @@
+package sysdb
+
+import (
+	"fmt"
+	"sync"
+)
+
+// sqlite_driver.go: database/sql-style SQLite driver registration.
+//
+// The heavyweight SQLite driver (modernc.org/sqlite) is not imported by this
+// package. SQLite support is linked in only when the user blank-imports the
+// public driver package, whose init() calls RegisterSQLiteDriver:
+//
+//	import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
+//
+// PostgreSQL-only builds therefore never compile or link the SQLite driver.
+
+// SQLiteDriver describes a registered SQLite driver implementation.
+type SQLiteDriver struct {
+	// DriverName is the name the driver registered with database/sql
+	// (e.g. "sqlite" for modernc.org/sqlite).
+	DriverName string
+	// ErrorCode extracts the extended SQLite result code from a driver error,
+	// or returns -1 if err does not originate from the driver.
+	ErrorCode func(err error) int
+}
+
+var (
+	sqliteDriverMu sync.RWMutex
+	sqliteDriver   *SQLiteDriver
+)
+
+// RegisterSQLiteDriver makes a SQLite driver available to the system database.
+// It is called from the init() of a driver package and panics on invalid input,
+// mirroring database/sql.Register semantics.
+func RegisterSQLiteDriver(d SQLiteDriver) {
+	if d.DriverName == "" || d.ErrorCode == nil {
+		panic("sysdb: RegisterSQLiteDriver requires a driver name and an ErrorCode function")
+	}
+	sqliteDriverMu.Lock()
+	defer sqliteDriverMu.Unlock()
+	sqliteDriver = &d
+}
+
+// registeredSQLiteDriver returns the registered driver, or an error telling
+// the user which package to import.
+func registeredSQLiteDriver() (*SQLiteDriver, error) {
+	sqliteDriverMu.RLock()
+	defer sqliteDriverMu.RUnlock()
+	if sqliteDriver == nil {
+		return nil, fmt.Errorf(`SQLite support is not linked into this binary: add import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite" to register the SQLite driver`)
+	}
+	return sqliteDriver, nil
+}

--- a/dbos/internal/sysdb/sqlite_pool.go
+++ b/dbos/internal/sysdb/sqlite_pool.go
@@ -64,10 +64,15 @@ func SqliteDSN(raw string) (string, error) {
 	return dsn, nil
 }
 
-// OpenSQLitePool opens a *sql.DB backed by modernc.org/sqlite, ensures the
-// parent directory of file-backed databases exists, applies recommended
-// PRAGMAs, and returns the pool. The caller owns Close.
+// OpenSQLitePool opens a *sql.DB backed by the registered SQLite driver,
+// ensures the parent directory of file-backed databases exists, applies
+// recommended PRAGMAs, and returns the pool. The caller owns Close. It
+// errors if no SQLite driver is registered (see RegisterSQLiteDriver).
 func OpenSQLitePool(ctx context.Context, databaseURL string) (*sql.DB, error) {
+	driver, err := registeredSQLiteDriver()
+	if err != nil {
+		return nil, err
+	}
 	dsn, err := SqliteDSN(databaseURL)
 	if err != nil {
 		return nil, err
@@ -103,7 +108,7 @@ func OpenSQLitePool(ctx context.Context, databaseURL string) (*sql.DB, error) {
 	dsn = withSqlitePragma(dsn, "foreign_keys(ON)")
 	dsn = withSqlitePragma(dsn, "synchronous(NORMAL)")
 
-	db, err := sql.Open("sqlite", dsn)
+	db, err := sql.Open(driver.DriverName, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open sqlite database %q: %v", dsn, err)
 	}
@@ -130,6 +135,11 @@ func newSqliteSystemDatabase(encodeScheduledInput func(context.Context, time.Tim
 	customDB *sql.DB,
 	logger *slog.Logger,
 ) (SystemDatabase, error) {
+	// The driver is required even with a custom handle: error classification
+	// (retryable/contention/constraint) needs its ErrorCode extractor.
+	if _, err := registeredSQLiteDriver(); err != nil {
+		return nil, err
+	}
 	var (
 		db    *sql.DB
 		owned bool

--- a/dbos/sqlite/sqlite.go
+++ b/dbos/sqlite/sqlite.go
@@ -1,0 +1,33 @@
+// Package sqlite registers SQLite support for DBOS, backed by the pure-Go
+// modernc.org/sqlite driver.
+//
+// It is imported for its side effects only, like a database/sql driver:
+//
+//	import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
+//
+// With this import in place, sqlite: database URLs (and the SQLiteSystemDB
+// config field) work everywhere in dbos. Without it, SQLite is not compiled
+// into the binary — PostgreSQL-only applications need nothing but the dbos
+// package and stay free of the SQLite dependency.
+package sqlite
+
+import (
+	"errors"
+
+	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/sysdb"
+	sqlitelib "modernc.org/sqlite"
+)
+
+func init() {
+	sysdb.RegisterSQLiteDriver(sysdb.SQLiteDriver{
+		// modernc.org/sqlite registers itself with database/sql as "sqlite".
+		DriverName: "sqlite",
+		ErrorCode: func(err error) int {
+			var se *sqlitelib.Error
+			if errors.As(err, &se) {
+				return se.Code()
+			}
+			return -1
+		},
+	})
+}

--- a/dbos/utils_test.go
+++ b/dbos/utils_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/models"
 	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/sysdb"
-	_ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
+	_ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"

--- a/dbos/utils_test.go
+++ b/dbos/utils_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/models"
 	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/sysdb"
+	_ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"

--- a/docs/go-v1-migration-guide.md
+++ b/docs/go-v1-migration-guide.md
@@ -275,7 +275,16 @@ Slice-taking filters became variadic — call sites passing a literal slice need
 - `ClearRegistries` removed from the public API (was testing-only).
 - New package-level accessors: `dbos.GetApplicationVersion(ctx)`, `dbos.GetExecutorID(ctx)`, `dbos.GetApplicationID(ctx)`.
 - `Config.DatabaseURL` accepts Postgres/CockroachDB URLs or key=value DSNs, and sqlite URLs (`sqlite:/path/to.db`, `sqlite:relative.db`, `sqlite::memory:`).
+- **SQLite now requires a driver import.** The SQLite driver moved out of the core package into `dbos/sqlite`, registered database/sql-style. Apps using a sqlite URL or `Config.SQLiteSystemDB` must add `import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"` (one blank import, anywhere in the binary); without it, startup fails with an error naming this import. Postgres-only apps need no change and no longer compile or link `modernc.org/sqlite`.
 - **No system-database schema changes.** v1 makes no changes to the system schema relative to the last v0.x release: nothing migrates at `Launch()`, existing workflows (including long-DELAYED ones), queues, and schedule rows carry over as-is, and v0.x and v1 executors can share a system database during a rolling upgrade.
+
+### Custom serializers must handle non-user values
+
+Every checkpoint written to the system database is encoded with the configured custom serializer — including engine-internal step outputs: the `int64` deadline recorded by `DBOS.sleep` (written by `Sleep` and, new in v1, by `Recv`/`GetEvent` timeouts), `DBOS.writeStream`'s empty-string step output, and the `ScheduledWorkflowInput` struct for DB-backed schedule firings. This keeps every row in one format when inspecting the database from another program.
+
+A `Serializer[any]` must therefore be total: it must encode and decode arbitrary Go values, and decoding must preserve concrete types (decoded step results are type-asserted, so an `int64` must round-trip as `int64`, not `float64`). Strictly-typed serializers need a mapping for bare Go scalars — see `golang/protobuf-serializer` in dbos-demo-apps, which packs `proto.Message` values into `anypb.Any` directly and wraps scalars in the protobuf well-known wrapper types (`wrapperspb.Int64Value`, `StringValue`, …), unwrapping them back to native scalars on decode. This keeps every stored row decodable by standard proto tooling in any language.
+
+One deliberate exception: `Recv` and `GetEvent` checkpoint the *sender's* encoded payload verbatim under the sender's recorded format — the receiver's serializer is never asked to re-encode a message or event it didn't produce.
 
 ## 8. Mocks / tests
 

--- a/docs/go-v1-migration-guide.md
+++ b/docs/go-v1-migration-guide.md
@@ -275,7 +275,7 @@ Slice-taking filters became variadic — call sites passing a literal slice need
 - `ClearRegistries` removed from the public API (was testing-only).
 - New package-level accessors: `dbos.GetApplicationVersion(ctx)`, `dbos.GetExecutorID(ctx)`, `dbos.GetApplicationID(ctx)`.
 - `Config.DatabaseURL` accepts Postgres/CockroachDB URLs or key=value DSNs, and sqlite URLs (`sqlite:/path/to.db`, `sqlite:relative.db`, `sqlite::memory:`).
-- **SQLite now requires a driver import.** The SQLite driver moved out of the core package into `dbos/sqlite`, registered database/sql-style. Apps using a sqlite URL or `Config.SQLiteSystemDB` must add `import _ "github.com/dbos-inc/dbos-transact-golang/dbos/sqlite"` (one blank import, anywhere in the binary); without it, startup fails with an error naming this import. Postgres-only apps need no change and no longer compile or link `modernc.org/sqlite`.
+- **SQLite now requires a driver import.** The SQLite driver moved out of the core package into `dbos/driver/sqlite`, registered database/sql-style. Apps using a sqlite URL or `Config.SQLiteSystemDB` must add `import _ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite"` (one blank import, anywhere in the binary); without it, startup fails with an error naming this import. Postgres-only apps need no change and no longer compile or link `modernc.org/sqlite`.
 - **No system-database schema changes.** v1 makes no changes to the system schema relative to the last v0.x release: nothing migrates at `Launch()`, existing workflows (including long-DELAYED ones), queues, and schedule rows carry over as-is, and v0.x and v1 executors can share a system database during a rolling upgrade.
 
 ### Custom serializers must handle non-user values


### PR DESCRIPTION
To avoid building unrequired dependencies for unused database backends (e.g., modernc for sqlite) this PR adds a db driver registration mechanisms. Pgx and Postgres stay the default.

Here's how it works.
- Add a new subpackage for db drivers, in this first example,  `dbos/driver/sqlite`
- Users import them (here, `_ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite"`)
- These packages simply import the package they need (here, `modernc.org/sqlite`), which will cause the triggering of an init() function at startup, exposing the driver to the dbos package.
- Without the import, SQLite URLs fail at startup with an error naming the import to add.

Most of the code is unchanged, i.e., the bulk of understanding a driver and using it are still in `dbq.go` and `dialect.go`