### PR TITLE
Update workflow status with a final result only when status is PENDING

### DIFF
--- a/dbos/datasource.go
+++ b/dbos/datasource.go
@@ -522,8 +522,10 @@ func (c *dbosContext) RunAsTransaction(dbosCtx Context, ds *DataSource, fn TxnFu
 	// OUTER: the user-facing step retry policy (maxRetries + predicate).
 	stepOutput, stepError := executeStepWithRetry(c, stepState.workflowID, stepOpts, runTxnResilient)
 
-	if stepInterruptedByCancellation(stepState, stepError) {
-		return stepOutput, models.NewWorkflowCancelledError(stepState.workflowID, stepError)
+	// The workflow being cancelled mid-step interrupts the step, whatever its
+	// outcome: nothing is checkpointed, so a resume re-executes the step.
+	if isWorkflowCtxCancelled(stepState) {
+		return stepOutput, interruptedStepError(stepState, stepError)
 	}
 
 	// txn2: checkpoint the outcome into the system database.

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -42,7 +42,7 @@ type SystemDatabase interface {
 	// Workflows
 	InsertWorkflowStatus(ctx context.Context, input InsertWorkflowStatusDBInput) (*InsertWorkflowResult, error)
 	ListWorkflows(ctx context.Context, input ListWorkflowsDBInput) ([]models.WorkflowStatus, error)
-	UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) error
+	UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) (OutcomeWriteAction, error)
 	SetWorkflowAttributes(ctx context.Context, input SetWorkflowAttributesDBInput) error
 	AwaitWorkflowResult(ctx context.Context, workflowID string, pollInterval time.Duration) (*AwaitWorkflowResultOutput, error)
 	CancelWorkflows(ctx context.Context, input CancelWorkflowsDBInput) ([]string, error)
@@ -1660,14 +1660,39 @@ type UpdateWorkflowOutcomeDBInput struct {
 	Tx         Tx
 }
 
-// UpdateWorkflowOutcome records a workflow's terminal outcome. The write is refused
-// when the row is already terminal (CANCELLED/SUCCESS/ERROR). A refusal is an error
-// only when the workflow was cancelled, so the caller ends as cancelled instead of
-// reporting a completion that was never recorded; other refusals are silent no-ops.
-func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) error {
+type OutcomeWriteAction int
+
+const (
+	// OutcomeWriteUnknown is the zero value, returned only together with an error.
+	OutcomeWriteUnknown OutcomeWriteAction = iota
+	// OutcomeWriteRecorded means the write landed: the caller's outcome is durable.
+	OutcomeWriteRecorded
+	// OutcomeWriteDeferred means the row was not PENDING, so the caller no longer
+	// owns the outcome: either another execution is running or is about to run the
+	// workflow (ENQUEUED/DELAYED, e.g. a concurrent resume), or a terminal outcome
+	// (SUCCESS/ERROR) is already recorded. Either way the recorded outcome wins and
+	// the caller must adopt it, waiting for it to become terminal if it isn't yet.
+	OutcomeWriteDeferred
+	// OutcomeWriteNoRow means the workflow_status row no longer exists: there is
+	// nothing to record and nothing to wait for, so the caller keeps its outcome.
+	OutcomeWriteNoRow
+)
+
+// UpdateWorkflowOutcome records a workflow's terminal outcome. The write applies
+// only to a PENDING row: a run owns its workflow's outcome exactly as long as the
+// row says that run is what the workflow is doing. (Note: this does not prevent
+// a write when another concurrent execution is already running and the status is PENDING.
+// However, both execution should be deterministic and idempotent.)
+//
+// When the guarded UPDATE matches no row, the current status decides what the caller must do:
+//   - CANCELLED: a cancellation error.
+//   - MAX_RECOVERY_ATTEMPTS_EXCEEDED: a dead-letter-queue error.
+//   - anything else: OutcomeWriteDeferred (see above) or, if the row is gone,
+//     OutcomeWriteNoRow (this can only happen when the workflow was garbage collected or manually deleted.)
+func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) (OutcomeWriteAction, error) {
 	query := s.RenderSQL(`UPDATE %sworkflow_status
 			  SET status = $1, output = $2, error = $3, updated_at = $4, completed_at = $4, deduplication_id = NULL
-			  WHERE workflow_uuid = $5 AND status NOT IN ($6, $7, $8)`, s.dialect.SchemaPrefix(s.schema))
+			  WHERE workflow_uuid = $5 AND status = $6`, s.dialect.SchemaPrefix(s.schema))
 
 	var runner Querier = s.pool
 	if input.Tx != nil {
@@ -1675,30 +1700,37 @@ func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowO
 	}
 
 	// input.output is already a *string from the database layer
-	res, err := runner.Exec(ctx, query, input.Status, input.Output, input.ErrStr, time.Now().UnixMilli(), input.WorkflowID, models.WorkflowStatusCancelled, models.WorkflowStatusSuccess, models.WorkflowStatusError)
+	res, err := runner.Exec(ctx, query, input.Status, input.Output, input.ErrStr, time.Now().UnixMilli(), input.WorkflowID, models.WorkflowStatusPending)
 	if err != nil {
-		return fmt.Errorf("failed to update workflow status: %w", err)
+		return OutcomeWriteUnknown, fmt.Errorf("failed to update workflow status: %w", err)
 	}
 	rowsAffected, err := res.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("failed to check workflow status update: %w", err)
+		return OutcomeWriteUnknown, fmt.Errorf("failed to check workflow status update: %w", err)
 	}
-	if rowsAffected == 0 {
-		// The guarded UPDATE matched no rows. Re-read the status (only on this rare
-		// no-op path): only a cancelled workflow surfaces an error to the caller.
-		statusQuery := s.RenderSQL(`SELECT status FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
-		var currentStatus models.WorkflowStatusType
-		if err := runner.QueryRow(ctx, statusQuery, input.WorkflowID).Scan(&currentStatus); err != nil {
-			if errors.Is(err, ErrNoRows) {
-				return nil
-			}
-			return fmt.Errorf("failed to read workflow status after refused outcome update: %w", err)
-		}
-		if currentStatus == models.WorkflowStatusCancelled {
-			return models.NewWorkflowCancelledError(input.WorkflowID, nil)
-		}
+	if rowsAffected > 0 {
+		return OutcomeWriteRecorded, nil
 	}
-	return nil
+
+	// The guarded UPDATE matched no rows. Re-read the status to tell the caller what to do with the outcome it computed.
+	statusQuery := s.RenderSQL(`SELECT status, recovery_attempts FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
+	var currentStatus models.WorkflowStatusType
+	var attempts int
+	if err := runner.QueryRow(ctx, statusQuery, input.WorkflowID).Scan(&currentStatus, &attempts); err != nil {
+		if errors.Is(err, ErrNoRows) {
+			// This can only happen if the workflow was garbage collected or manually deleted.
+			return OutcomeWriteNoRow, nil
+		}
+		return OutcomeWriteUnknown, fmt.Errorf("failed to read workflow status after refused outcome update: %w", err)
+	}
+	switch currentStatus {
+	case models.WorkflowStatusCancelled:
+		return OutcomeWriteUnknown, models.NewWorkflowCancelledError(input.WorkflowID, nil)
+	case models.WorkflowStatusMaxRecoveryAttemptsExceeded:
+		return OutcomeWriteUnknown, models.NewDeadLetterQueueError(input.WorkflowID, attempts-2)
+	}
+	// This means status is ENQUEUED/DELAYED or already SUCCESS/ERROR
+	return OutcomeWriteDeferred, nil
 }
 
 type SetWorkflowAttributesDBInput struct {

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -1668,7 +1668,8 @@ type UpdateWorkflowOutcomeDBInput struct {
 // deterministic and idempotent.)
 //
 // Returning false means the row was CANCELLED, dead-lettered, already terminal, or
-// handed to another execution (ENQUEUED/DELAYED, e.g. by a concurrent resume).
+// handed to another execution (ENQUEUED/DELAYED, e.g. by a concurrent resume). If
+// the row does not exist at all, a NonExistentWorkflow error is returned.
 func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) (bool, error) {
 	query := s.RenderSQL(`UPDATE %sworkflow_status
 			  SET status = $1, output = $2, error = $3, updated_at = $4, completed_at = $4, deduplication_id = NULL
@@ -1688,7 +1689,19 @@ func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowO
 	if err != nil {
 		return false, fmt.Errorf("failed to check workflow status update: %w", err)
 	}
-	return rowsAffected > 0, nil
+	if rowsAffected == 0 {
+		// The guarded UPDATE matched no rows. Re-read to distinguish a row this run no longer owns from a row that is gone.
+		statusQuery := s.RenderSQL(`SELECT status FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
+		var currentStatus models.WorkflowStatusType
+		if err := runner.QueryRow(ctx, statusQuery, input.WorkflowID).Scan(&currentStatus); err != nil {
+			if errors.Is(err, ErrNoRows) {
+				return false, models.NewNonExistentWorkflowError(input.WorkflowID)
+			}
+			return false, fmt.Errorf("failed to read workflow status after refused outcome update: %w", err)
+		}
+		return false, nil
+	}
+	return true, nil
 }
 
 type SetWorkflowAttributesDBInput struct {

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -42,7 +42,7 @@ type SystemDatabase interface {
 	// Workflows
 	InsertWorkflowStatus(ctx context.Context, input InsertWorkflowStatusDBInput) (*InsertWorkflowResult, error)
 	ListWorkflows(ctx context.Context, input ListWorkflowsDBInput) ([]models.WorkflowStatus, error)
-	UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) (OutcomeWriteAction, error)
+	UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) (bool, error)
 	SetWorkflowAttributes(ctx context.Context, input SetWorkflowAttributesDBInput) error
 	AwaitWorkflowResult(ctx context.Context, workflowID string, pollInterval time.Duration) (*AwaitWorkflowResultOutput, error)
 	CancelWorkflows(ctx context.Context, input CancelWorkflowsDBInput) ([]string, error)
@@ -1660,34 +1660,16 @@ type UpdateWorkflowOutcomeDBInput struct {
 	Tx         Tx
 }
 
-type OutcomeWriteAction int
-
-const (
-	// OutcomeWriteUnknown is the zero value, returned only together with an error.
-	OutcomeWriteUnknown OutcomeWriteAction = iota
-	// OutcomeWriteRecorded means the write landed: the caller's outcome is durable.
-	OutcomeWriteRecorded
-	// OutcomeWriteDeferred means the row was not PENDING, so the caller no longer
-	// owns the outcome: either another execution is running or is about to run the
-	// workflow (ENQUEUED/DELAYED, e.g. a concurrent resume), or a terminal outcome
-	// (SUCCESS/ERROR) is already recorded. Either way the recorded outcome wins and
-	// the caller must adopt it, waiting for it to become terminal if it isn't yet.
-	OutcomeWriteDeferred
-)
-
-// UpdateWorkflowOutcome records a workflow's terminal outcome. The write applies
-// only to a PENDING row: a run owns its workflow's outcome exactly as long as the
-// row says that run is what the workflow is doing. (Note: this does not prevent
-// a write when another concurrent execution is already running and the status is PENDING.
-// However, both execution should be deterministic and idempotent.)
+// UpdateWorkflowOutcome records a workflow's terminal outcome, reporting whether
+// the write landed. The write applies only to a PENDING row: a run owns its
+// workflow's outcome exactly as long as the row says that run is what the workflow
+// is doing. (Note: this does not prevent a write when another concurrent execution
+// is already running and the status is PENDING. However, both execution should be
+// deterministic and idempotent.)
 //
-// When the guarded UPDATE matches no row, the current status decides what the caller must do:
-//   - CANCELLED: a cancellation error.
-//   - MAX_RECOVERY_ATTEMPTS_EXCEEDED: a dead-letter-queue error.
-//   - the row is gone: a non-existent-workflow error (this can only happen when the
-//     workflow was garbage collected or manually deleted.)
-//   - anything else: OutcomeWriteDeferred (see above).
-func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) (OutcomeWriteAction, error) {
+// Returning false means the row was CANCELLED, dead-lettered, already terminal, or
+// handed to another execution (ENQUEUED/DELAYED, e.g. by a concurrent resume).
+func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) (bool, error) {
 	query := s.RenderSQL(`UPDATE %sworkflow_status
 			  SET status = $1, output = $2, error = $3, updated_at = $4, completed_at = $4, deduplication_id = NULL
 			  WHERE workflow_uuid = $5 AND status = $6`, s.dialect.SchemaPrefix(s.schema))
@@ -1700,35 +1682,13 @@ func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowO
 	// input.output is already a *string from the database layer
 	res, err := runner.Exec(ctx, query, input.Status, input.Output, input.ErrStr, time.Now().UnixMilli(), input.WorkflowID, models.WorkflowStatusPending)
 	if err != nil {
-		return OutcomeWriteUnknown, fmt.Errorf("failed to update workflow status: %w", err)
+		return false, fmt.Errorf("failed to update workflow status: %w", err)
 	}
 	rowsAffected, err := res.RowsAffected()
 	if err != nil {
-		return OutcomeWriteUnknown, fmt.Errorf("failed to check workflow status update: %w", err)
+		return false, fmt.Errorf("failed to check workflow status update: %w", err)
 	}
-	if rowsAffected > 0 {
-		return OutcomeWriteRecorded, nil
-	}
-
-	// The guarded UPDATE matched no rows. Re-read the status to tell the caller what to do with the outcome it computed.
-	statusQuery := s.RenderSQL(`SELECT status, recovery_attempts FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
-	var currentStatus models.WorkflowStatusType
-	var attempts int
-	if err := runner.QueryRow(ctx, statusQuery, input.WorkflowID).Scan(&currentStatus, &attempts); err != nil {
-		if errors.Is(err, ErrNoRows) {
-			// This can only happen if the workflow was garbage collected or manually deleted.
-			return OutcomeWriteUnknown, models.NewNonExistentWorkflowError(input.WorkflowID)
-		}
-		return OutcomeWriteUnknown, fmt.Errorf("failed to read workflow status after refused outcome update: %w", err)
-	}
-	switch currentStatus {
-	case models.WorkflowStatusCancelled:
-		return OutcomeWriteUnknown, models.NewWorkflowCancelledError(input.WorkflowID, nil)
-	case models.WorkflowStatusMaxRecoveryAttemptsExceeded:
-		return OutcomeWriteUnknown, models.NewDeadLetterQueueError(input.WorkflowID, attempts-2)
-	}
-	// This means status is ENQUEUED/DELAYED or already SUCCESS/ERROR
-	return OutcomeWriteDeferred, nil
+	return rowsAffected > 0, nil
 }
 
 type SetWorkflowAttributesDBInput struct {

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -1673,9 +1673,6 @@ const (
 	// (SUCCESS/ERROR) is already recorded. Either way the recorded outcome wins and
 	// the caller must adopt it, waiting for it to become terminal if it isn't yet.
 	OutcomeWriteDeferred
-	// OutcomeWriteNoRow means the workflow_status row no longer exists: there is
-	// nothing to record and nothing to wait for, so the caller keeps its outcome.
-	OutcomeWriteNoRow
 )
 
 // UpdateWorkflowOutcome records a workflow's terminal outcome. The write applies
@@ -1687,8 +1684,9 @@ const (
 // When the guarded UPDATE matches no row, the current status decides what the caller must do:
 //   - CANCELLED: a cancellation error.
 //   - MAX_RECOVERY_ATTEMPTS_EXCEEDED: a dead-letter-queue error.
-//   - anything else: OutcomeWriteDeferred (see above) or, if the row is gone,
-//     OutcomeWriteNoRow (this can only happen when the workflow was garbage collected or manually deleted.)
+//   - the row is gone: a non-existent-workflow error (this can only happen when the
+//     workflow was garbage collected or manually deleted.)
+//   - anything else: OutcomeWriteDeferred (see above).
 func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) (OutcomeWriteAction, error) {
 	query := s.RenderSQL(`UPDATE %sworkflow_status
 			  SET status = $1, output = $2, error = $3, updated_at = $4, completed_at = $4, deduplication_id = NULL
@@ -1719,7 +1717,7 @@ func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowO
 	if err := runner.QueryRow(ctx, statusQuery, input.WorkflowID).Scan(&currentStatus, &attempts); err != nil {
 		if errors.Is(err, ErrNoRows) {
 			// This can only happen if the workflow was garbage collected or manually deleted.
-			return OutcomeWriteNoRow, nil
+			return OutcomeWriteUnknown, models.NewNonExistentWorkflowError(input.WorkflowID)
 		}
 		return OutcomeWriteUnknown, fmt.Errorf("failed to read workflow status after refused outcome update: %w", err)
 	}

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -44,7 +44,7 @@ type SystemDatabase interface {
 	ListWorkflows(ctx context.Context, input ListWorkflowsDBInput) ([]models.WorkflowStatus, error)
 	UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) (bool, error)
 	SetWorkflowAttributes(ctx context.Context, input SetWorkflowAttributesDBInput) error
-	AwaitWorkflowResult(ctx context.Context, workflowID string, pollInterval time.Duration) (*AwaitWorkflowResultOutput, error)
+	AwaitWorkflowResult(ctx context.Context, workflowID string, pollInterval time.Duration, failIfMissing bool) (*AwaitWorkflowResultOutput, error)
 	CancelWorkflows(ctx context.Context, input CancelWorkflowsDBInput) ([]string, error)
 	CancelAllBefore(ctx context.Context, cutoffTime time.Time) error
 	DeleteWorkflows(ctx context.Context, input DeleteWorkflowsDBInput) error
@@ -1667,9 +1667,9 @@ type UpdateWorkflowOutcomeDBInput struct {
 // is already running and the status is PENDING. However, both execution should be
 // deterministic and idempotent.)
 //
-// Returning false means the row was CANCELLED, dead-lettered, already terminal, or
-// handed to another execution (ENQUEUED/DELAYED, e.g. by a concurrent resume). If
-// the row does not exist at all, a NonExistentWorkflow error is returned.
+// Returning false means the row was CANCELLED, dead-lettered, already terminal,
+// handed to another execution (ENQUEUED/DELAYED, e.g. by a concurrent resume), or
+// gone entirely.
 func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowOutcomeDBInput) (bool, error) {
 	query := s.RenderSQL(`UPDATE %sworkflow_status
 			  SET status = $1, output = $2, error = $3, updated_at = $4, completed_at = $4, deduplication_id = NULL
@@ -1689,19 +1689,7 @@ func (s *SysDB) UpdateWorkflowOutcome(ctx context.Context, input UpdateWorkflowO
 	if err != nil {
 		return false, fmt.Errorf("failed to check workflow status update: %w", err)
 	}
-	if rowsAffected == 0 {
-		// The guarded UPDATE matched no rows. Re-read to distinguish a row this run no longer owns from a row that is gone.
-		statusQuery := s.RenderSQL(`SELECT status FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
-		var currentStatus models.WorkflowStatusType
-		if err := runner.QueryRow(ctx, statusQuery, input.WorkflowID).Scan(&currentStatus); err != nil {
-			if errors.Is(err, ErrNoRows) {
-				return false, models.NewNonExistentWorkflowError(input.WorkflowID)
-			}
-			return false, fmt.Errorf("failed to read workflow status after refused outcome update: %w", err)
-		}
-		return false, nil
-	}
-	return true, nil
+	return rowsAffected > 0, nil
 }
 
 type SetWorkflowAttributesDBInput struct {
@@ -2554,7 +2542,12 @@ type AwaitWorkflowResultOutput struct {
 	ErrStr        *string
 }
 
-func (s *SysDB) AwaitWorkflowResult(ctx context.Context, workflowID string, pollInterval time.Duration) (*AwaitWorkflowResultOutput, error) {
+// AwaitWorkflowResult polls the workflow's row until it reaches a terminal
+// status. A missing row normally means the workflow has not been inserted yet,
+// so the poll keeps waiting for it to appear. Callers that know the row must
+// already exist (e.g. a run parking on an outcome it just failed to write) pass
+// failIfMissing to get a NonExistentWorkflow error instead of polling forever.
+func (s *SysDB) AwaitWorkflowResult(ctx context.Context, workflowID string, pollInterval time.Duration, failIfMissing bool) (*AwaitWorkflowResultOutput, error) {
 	query := s.RenderSQL(`SELECT status, output, error, recovery_attempts, serialization FROM %sworkflow_status WHERE workflow_uuid = $1`, s.dialect.SchemaPrefix(s.schema))
 	var status models.WorkflowStatusType
 	if pollInterval <= 0 {
@@ -2575,6 +2568,9 @@ func (s *SysDB) AwaitWorkflowResult(ctx context.Context, workflowID string, poll
 		err := row.Scan(&status, &outputString, &errorStr, &attempts, &serialization)
 		if err != nil {
 			if err == pgx.ErrNoRows {
+				if failIfMissing {
+					return nil, models.NewNonExistentWorkflowError(workflowID)
+				}
 				time.Sleep(pollInterval)
 				continue
 			}

--- a/dbos/queues_test.go
+++ b/dbos/queues_test.go
@@ -1276,10 +1276,14 @@ func TestQueueTimeouts(t *testing.T) {
 		handle, err := RunWorkflow(childCtx, detachedWorkflow, timeout*2, WithQueue(timeoutQueue), WithWorkflowID(childID))
 		require.NoError(t, err, "failed to start enqueued detached workflow")
 
-		// Wait for the enqueued workflow to complete
+		// Wait for the enqueued workflow to complete. The parent is cancelled
+		// mid-await, so getResult is interrupted (not checkpointed) even though
+		// the detached child completes successfully; a resume would replay the
+		// await and adopt the child's recorded success.
 		result, err := handle.GetResult()
-		require.NoError(t, err, "failed to get result from enqueued detached workflow")
-		assert.Equal(t, "detached-workflow-completed", result, "expected result to be 'detached-workflow-completed'")
+		if err != nil {
+			return "", err
+		}
 		return result, nil
 	}
 

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1666,7 +1666,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 			// visible, a resume→dequeue can re-dispatch this workflow to this executor,
 			// marking it PENDING. But a stale activeID entry would prevent the workflow from running.
 			removeActive()
-			recordErr := sysdb.Retry(c, func() error {
+			recordAction, recordErr := sysdb.RetryWithResult(c, func() (sysdb.OutcomeWriteAction, error) {
 				return c.systemDB.UpdateWorkflowOutcome(uncancellableCtx, sysdb.UpdateWorkflowOutcomeDBInput{
 					WorkflowID: workflowID,
 					Status:     status,
@@ -1677,17 +1677,36 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 			if recordErr != nil {
 				// A cancellation error means the write was refused because the workflow
 				// was cancelled (e.g. during the final step): end as cancelled, not
-				// complete. Deliver a cancellation outcome wrapping the workflow's own
-				// error so context.Canceled/DeadlineExceeded still match via errors.Is.
-				// Any other error is a genuine DB failure and is delivered as-is below.
+				// complete. The refusal is already a cancellation error for this
+				// workflow, so surface it as-is.
 				if errors.Is(recordErr, ErrWorkflowCancelled) {
-					outcomeChan <- workflowOutcome[any]{result: result, err: models.NewWorkflowCancelledError(workflowID, err), cancelled: true}
+					outcomeChan <- workflowOutcome[any]{result: result, err: recordErr, cancelled: true}
 					close(outcomeChan)
 					return
 				}
+				// The workflow was moved to the dead-letter queue while this run was
+				// executing (it exceeded its maximum recovery attempts). Report that
+				// rather than a completion that was never recorded.
+				if errors.Is(recordErr, ErrDeadLetterQueue) {
+					c.logger.Warn("Workflow outcome not recorded: workflow exceeded its maximum recovery attempts", "workflow_id", workflowID)
+					outcomeChan <- workflowOutcome[any]{result: nil, err: recordErr}
+					close(outcomeChan)
+					return
+				}
+				// Any other error is a genuine DB failure: deliver it as-is.
 				c.logger.Error("Error recording workflow outcome", "workflow_id", workflowID, "error", recordErr)
 				outcomeChan <- workflowOutcome[any]{result: nil, err: recordErr}
 				close(outcomeChan)
+				return
+			}
+			if recordAction == sysdb.OutcomeWriteDeferred {
+				// The row was not PENDING: this run no longer owns the workflow's
+				// outcome. Either another execution is running or about to run it (a
+				// concurrent resume re-enqueued it, or a recovery raced us), or a
+				// terminal outcome is already recorded. The recorded outcome wins:
+				// adopt it, waiting for it if it is not terminal yet.
+				c.logger.Warn("Workflow outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome", "workflow_id", workflowID)
+				awaitExistingOutcome()
 				return
 			}
 		}

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1677,8 +1677,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 			if recordErr != nil {
 				// A cancellation error means the write was refused because the workflow
 				// was cancelled (e.g. during the final step): end as cancelled, not
-				// complete. The refusal is already a cancellation error for this
-				// workflow, so surface it as-is.
+				// complete.
 				if errors.Is(recordErr, ErrWorkflowCancelled) {
 					outcomeChan <- workflowOutcome[any]{result: result, err: recordErr, cancelled: true}
 					close(outcomeChan)
@@ -1693,7 +1692,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 					close(outcomeChan)
 					return
 				}
-				// Any other error is a genuine DB failure: deliver it as-is.
+				// Rare not found error or some other DB failure: deliver it as-is.
 				c.logger.Error("Error recording workflow outcome", "workflow_id", workflowID, "error", recordErr)
 				outcomeChan <- workflowOutcome[any]{result: nil, err: recordErr}
 				close(outcomeChan)

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1566,9 +1566,16 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 			encodedResult = awaitOut.Output
 			ser = awaitOut.Serialization
 		}
+		cancelled := errors.Is(err, ErrAwaitedWorkflowCancelled)
+		if cancelled {
+			// AwaitWorkflowResult reports a CANCELLED row from an awaiter's point of
+			// view, but this outcome is delivered to the workflow's own handle: report
+			// the workflow's cancellation.
+			err = models.NewWorkflowCancelledError(workflowID, nil)
+		}
 		// Keep the encoded result - decoding will happen in RunWorkflow[P,R] when we know the target type
 		outcomeChan <- workflowOutcome[any]{result: encodedResult, err: err, needsDecoding: true, serialization: ser,
-			cancelled: errors.Is(err, ErrAwaitedWorkflowCancelled)}
+			cancelled: cancelled}
 		close(outcomeChan)
 	}
 

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -53,9 +53,6 @@ type workflowOutcome[R any] struct {
 	err           error
 	needsDecoding bool   // true if result came from awaitWorkflowResult (ID conflict path) and needs decoding
 	serialization string // serialization format of the encoded result (only used when needsDecoding is true)
-	// cancelled reports that the workflow settled in CANCELLED. An awaiting parent
-	// records it as an ErrorCodeAwaitedWorkflowCancelled outcome for its getResult step.
-	cancelled bool
 }
 
 type stepCheckpointedOutcome struct {
@@ -282,23 +279,29 @@ func (h *workflowHandle[R]) processOutcome(outcome workflowOutcome[R], startTime
 		if _, ok := h.dbosContext.(*dbosContext); !ok {
 			return *new(R), models.NewWorkflowExecutionError(workflowState.workflowID, fmt.Errorf("invalid Context: expected *dbosContext"))
 		}
-		// A parent that is itself cancelled never checkpoints the await, whatever
-		// the child's outcome: it reports its own cancellation, so a resume
-		// re-executes the await and observes the child's then-settled outcome.
+		// The awaiting workflow being cancelled interrupts the getResult step,
+		// whatever the child's outcome: nothing is checkpointed, so a resume
+		// re-executes the await against the child's then-settled row (a
+		// detached child's recorded success is adopted then).
 		if isWorkflowCtxCancelled(workflowState) {
-			return *new(R), models.NewWorkflowCancelledError(workflowState.workflowID, outcome.err)
+			return *new(R), interruptedStepError(workflowState, outcome.err)
 		}
-		// A cancelled child is a terminal outcome for the awaiting parent:
-		// checkpoint it like any other child error so replay is deterministic.
-		// Resuming the child later does not change what the parent saw.
-		if outcome.cancelled {
+		// Return "Awaited workflow cancelled" error when the child is cancelled.
+		// A cancelled child has no output value: record a NULL output, like the
+		// polling handle does.
+		childCancelled := errors.Is(outcome.err, ErrWorkflowCancelled)
+		if childCancelled {
 			decodedResult = *new(R)
 			outcome.err = models.NewAwaitedWorkflowCancelledError(h.workflowID)
 		}
 		ser := resolveEncoder(h.dbosContext)
-		encodedOutput, encErr := ser.Encode(decodedResult)
-		if encErr != nil {
-			return *new(R), models.NewWorkflowExecutionError(workflowState.workflowID, fmt.Errorf("serializing child workflow result: %w", encErr))
+		var encodedOutput *string
+		if !childCancelled {
+			var encErr error
+			encodedOutput, encErr = ser.Encode(decodedResult)
+			if encErr != nil {
+				return *new(R), models.NewWorkflowExecutionError(workflowState.workflowID, fmt.Errorf("serializing child workflow result: %w", encErr))
+			}
 		}
 		var serializedOutcomeErr *string
 		if outcome.err != nil {
@@ -325,11 +328,6 @@ func (h *workflowHandle[R]) processOutcome(outcome workflowOutcome[R], startTime
 			h.dbosContext.(*dbosContext).logger.Error("failed to record get result", "error", recordResultErr)
 			return *new(R), models.NewWorkflowExecutionError(workflowState.workflowID, fmt.Errorf("recording child workflow result: %w", recordResultErr))
 		}
-	} else if outcome.cancelled && !isCancellationError(outcome.err) {
-		// The workflow swallowed its cancellation (returned normally or with an
-		// unrelated error) but we triggered durable cancel and no output was
-		// recorded: report cancellation, not success.
-		return *new(R), models.NewWorkflowCancelledError(h.workflowID, outcome.err)
 	}
 	return decodedResult, outcome.err
 }
@@ -376,11 +374,12 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 
 	workflowState, ok := h.dbosContext.Value(workflowStateKey).(*workflowState)
 	isWithinWorkflow := ok && workflowState != nil
-	// A parent that is itself cancelled never checkpoints the await, whatever
-	// outcome arrived: it reports its own cancellation, so a resume re-executes
-	// the await and observes the child's then-settled outcome.
+	// The awaiting workflow being cancelled interrupts the getResult step,
+	// whatever outcome arrived: nothing is checkpointed, so a resume
+	// re-executes the await against the child's then-settled row (a detached
+	// child's recorded success is adopted then).
 	if isWithinWorkflow && isWorkflowCtxCancelled(workflowState) {
-		return *new(R), models.NewWorkflowCancelledError(workflowState.workflowID, err)
+		return *new(R), interruptedStepError(workflowState, err)
 	}
 
 	// A cancelled child is a terminal outcome for the awaiting parent: checkpoint
@@ -388,11 +387,12 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 	// Resuming the child later does not change what the parent saw.
 	childCancelled := errors.Is(awaitErr, ErrAwaitedWorkflowCancelled)
 
-	// Deserialize the result directly into the target type
+	// Deserialize the result directly into the target type. A cancelled child has
+	// no output value: return and checkpoint the zero value alongside the error.
 	var typedResult R
 	var encodedStr *string
 	var storedSerialization string
-	if awaitResult != nil {
+	if awaitResult != nil && !childCancelled {
 		encodedStr = awaitResult.Output
 		storedSerialization = awaitResult.Serialization
 	}
@@ -1082,9 +1082,8 @@ func RunWorkflow[P any, R any](ctx Context, fn Workflow[P, R], input P, opts ...
 			// Handle nil results - nil cannot be type-asserted to any interface
 			if outcome.result == nil {
 				typedOutcomeChan <- workflowOutcome[R]{
-					result:    typedResult,
-					err:       resultErr,
-					cancelled: outcome.cancelled,
+					result: typedResult,
+					err:    resultErr,
 				}
 				return
 			}
@@ -1092,9 +1091,8 @@ func RunWorkflow[P any, R any](ctx Context, fn Workflow[P, R], input P, opts ...
 			// Check if this is a mocked path
 			if _, ok := handle.dbosContext.(*dbosContext); !ok {
 				typedOutcomeChan <- workflowOutcome[R]{
-					result:    outcome.result.(R),
-					err:       resultErr,
-					cancelled: outcome.cancelled,
+					result: outcome.result.(R),
+					err:    resultErr,
 				}
 				return
 			}
@@ -1126,9 +1124,8 @@ func RunWorkflow[P any, R any](ctx Context, fn Workflow[P, R], input P, opts ...
 			}
 
 			typedOutcomeChan <- workflowOutcome[R]{
-				result:    typedResult,
-				err:       resultErr,
-				cancelled: outcome.cancelled,
+				result: typedResult,
+				err:    resultErr,
 			}
 		}()
 
@@ -1569,7 +1566,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 			// AwaitWorkflowResult reports a CANCELLED row from an awaiter's point of
 			// view, but this outcome is delivered to the workflow's own handle: report
 			// the workflow's cancellation.
-			outcomeChan <- workflowOutcome[any]{err: models.NewWorkflowCancelledError(workflowID, cancelCause), cancelled: true}
+			outcomeChan <- workflowOutcome[any]{err: models.NewWorkflowCancelledError(workflowID, cancelCause)}
 			close(outcomeChan)
 			return
 		}
@@ -2415,8 +2412,15 @@ func isWorkflowCtxCancelled(stepState *workflowState) bool {
 	return stepState.workflowCtx != nil && stepState.workflowCtx.Err() != nil
 }
 
-func stepInterruptedByCancellation(stepState *workflowState, stepError error) bool {
-	return isWorkflowCtxCancelled(stepState) && isCancellationError(stepError)
+// interruptedStepError builds the cancellation returned in place of a step
+// checkpoint when the workflow is cancelled mid-step. The step's own error is
+// the cause when it has one; fallback on the workflow context error otherwise.
+func interruptedStepError(stepState *workflowState, stepError error) error {
+	cause := stepError
+	if cause == nil {
+		cause = stepState.workflowCtx.Err()
+	}
+	return models.NewWorkflowCancelledError(stepState.workflowID, cause)
 }
 
 // RunAsStep executes a function as a durable step within a workflow.
@@ -2540,8 +2544,10 @@ func (c *dbosContext) RunAsStep(_ Context, fn StepFunc, opts ...StepOption) (any
 		return fn(stepCtx)
 	})
 
-	if stepInterruptedByCancellation(stepState, stepError) {
-		return stepOutput, models.NewWorkflowCancelledError(stepState.workflowID, stepError)
+	// The workflow being cancelled mid-step interrupts the step, whatever its
+	// outcome: nothing is checkpointed, so a resume re-executes the step.
+	if isWorkflowCtxCancelled(stepState) {
+		return stepOutput, interruptedStepError(stepState, stepError)
 	}
 
 	// Serialize step output before recording
@@ -2709,8 +2715,10 @@ func (c *dbosContext) runAsTxn(_ Context, fn TxnFunc, opts ...StepOption) (any, 
 			return output, nil
 		})
 
-		if stepInterruptedByCancellation(stepState, stepError) {
-			return stepOutput, models.NewWorkflowCancelledError(stepState.workflowID, stepError)
+		// The workflow being cancelled mid-step interrupts the step, whatever
+		// its outcome: nothing is checkpointed, so a resume re-executes the step.
+		if isWorkflowCtxCancelled(stepState) {
+			return stepOutput, interruptedStepError(stepState, stepError)
 		}
 
 		txnSer := resolveEncoder(c)

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1551,8 +1551,10 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 	outcomeChan := make(chan workflowOutcome[any], 1)
 
 	// awaitExistingOutcome delivers the result of another execution of this workflow
-	// (one this run does not own) to the outcome channel.
-	awaitExistingOutcome := func() {
+	// (one this run does not own) to the outcome channel. cancelCause is the run's
+	// own cancellation error, if it parked because it observed one: a CANCELLED row
+	// wraps it so context.Canceled/DeadlineExceeded still match via errors.Is.
+	awaitExistingOutcome := func(cancelCause error) {
 		awaitOut, awaitErr := sysdb.RetryWithResult(c, func() (*sysdb.AwaitWorkflowResultOutput, error) {
 			return c.systemDB.AwaitWorkflowResult(uncancellableCtx, workflowID, sysdb.DBRetryInterval)
 		}, sysdb.WithRetrierLogger(c.logger))
@@ -1571,7 +1573,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 			// AwaitWorkflowResult reports a CANCELLED row from an awaiter's point of
 			// view, but this outcome is delivered to the workflow's own handle: report
 			// the workflow's cancellation.
-			err = models.NewWorkflowCancelledError(workflowID, nil)
+			err = models.NewWorkflowCancelledError(workflowID, cancelCause)
 		}
 		// Keep the encoded result - decoding will happen in RunWorkflow[P,R] when we know the target type
 		outcomeChan <- workflowOutcome[any]{result: encodedResult, err: err, needsDecoding: true, serialization: ser,
@@ -1600,7 +1602,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 				// alone, disarm the durable cancel, and await the winner's result.
 				stopFunc()
 				c.logger.Warn("Workflow is already executing on this executor. Waiting for the existing execution to complete", "workflow_id", workflowID)
-				awaitExistingOutcome()
+				awaitExistingOutcome(nil)
 				return
 			}
 			var removeOnce sync.Once
@@ -1619,18 +1621,22 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 			// context must no longer durably cancel it. Disarm the cancel function.
 			stopFunc()
 			c.logger.Warn("Workflow ID conflict detected. Waiting for existing workflow to complete", "workflow_id", workflowID)
-			awaitExistingOutcome()
+			awaitExistingOutcome(nil)
 			return
 		} else {
 			// A cancelled run skips updateWorkflowOutcome entirely so it can never
-			// clobber the row (e.g., ENQUEUED written by a concurrent resume).
+			// clobber the row (e.g., ENQUEUED written by a concurrent resume). It
+			// parks instead of trusting its local view: normally the row is CANCELLED
+			// and the parked await reports the workflow's cancellation (wrapping the
+			// run's own error), but a concurrent resume may have taken the workflow
+			// back, in which case the recorded outcome is the truth.
 			if !stopFunc() {
-				// AfterFunc fired => context is cancelled. Wait for the DB cancel to finish.
+				// AfterFunc fired => context is cancelled. Wait for the DB cancel to
+				// finish so the row is settled before parking.
 				c.logger.Info("Workflow was cancelled. Waiting for cancel function to complete", "workflow_id", workflowID)
 				<-cancelFuncCompleted
 				removeActive()
-				outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: true}
-				close(outcomeChan)
+				awaitExistingOutcome(err)
 				return
 			}
 			if workflowCtx.Err() != nil && isCancellationError(err) {
@@ -1638,16 +1644,14 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 				// so we need to run the durable cancel ourselves.
 				workflowCancelFunction()
 				removeActive()
-				outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: true}
-				close(outcomeChan)
+				awaitExistingOutcome(err)
 				return
 			}
 			if errors.Is(err, ErrWorkflowCancelled) {
 				// The workflow observed its own cancellation in the DB (external
 				// cancel): the row is already CANCELLED. Skip the outcome write.
 				removeActive()
-				outcomeChan <- workflowOutcome[any]{result: result, err: err, cancelled: true}
-				close(outcomeChan)
+				awaitExistingOutcome(err)
 				return
 			}
 
@@ -1693,7 +1697,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 				// concurrent execution, or handed back to the queue by a resume.
 				// Park the execution and wait for the recorded outcome to become visible.
 				c.logger.Warn("Workflow outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome", "workflow_id", workflowID)
-				awaitExistingOutcome()
+				awaitExistingOutcome(nil)
 				return
 			}
 		}

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1562,22 +1562,22 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 		if awaitErr == nil && awaitOut != nil && awaitOut.ErrStr != nil {
 			err = deserializeWorkflowError(awaitOut.ErrStr)
 		}
+		if errors.Is(err, ErrAwaitedWorkflowCancelled) {
+			// AwaitWorkflowResult reports a CANCELLED row from an awaiter's point of
+			// view, but this outcome is delivered to the workflow's own handle: report
+			// the workflow's cancellation.
+			outcomeChan <- workflowOutcome[any]{err: models.NewWorkflowCancelledError(workflowID, cancelCause), cancelled: true}
+			close(outcomeChan)
+			return
+		}
 		var encodedResult any
 		var ser string
 		if awaitOut != nil {
 			encodedResult = awaitOut.Output
 			ser = awaitOut.Serialization
 		}
-		cancelled := errors.Is(err, ErrAwaitedWorkflowCancelled)
-		if cancelled {
-			// AwaitWorkflowResult reports a CANCELLED row from an awaiter's point of
-			// view, but this outcome is delivered to the workflow's own handle: report
-			// the workflow's cancellation.
-			err = models.NewWorkflowCancelledError(workflowID, cancelCause)
-		}
 		// Keep the encoded result - decoding will happen in RunWorkflow[P,R] when we know the target type
-		outcomeChan <- workflowOutcome[any]{result: encodedResult, err: err, needsDecoding: true, serialization: ser,
-			cancelled: cancelled}
+		outcomeChan <- workflowOutcome[any]{result: encodedResult, err: err, needsDecoding: true, serialization: ser}
 		close(outcomeChan)
 	}
 

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -282,18 +282,18 @@ func (h *workflowHandle[R]) processOutcome(outcome workflowOutcome[R], startTime
 		if _, ok := h.dbosContext.(*dbosContext); !ok {
 			return *new(R), models.NewWorkflowExecutionError(workflowState.workflowID, fmt.Errorf("invalid Context: expected *dbosContext"))
 		}
-		// A cancellation outcome delivered while the awaiting workflow is itself
-		// cancelled interrupts the getResult step: don't checkpoint it, so resume
-		// re-executes the await.
-		if stepInterruptedByCancellation(workflowState, outcome.err) {
-			return *new(R), models.NewWorkflowCancelledError(workflowState.workflowID, outcome.err)
-		}
-		// A cancelled child is a terminal outcome for the awaiting parent: checkpoint
-		// it like any other child error so replay is deterministic.
-		// Resuming the child later does not change what the parent saw.
+		// A cancelled child is a terminal outcome for the awaiting parent, even if
+		// the parent is itself cancelled: the outcome came from the child's settled
+		// CANCELLED row, so checkpoint it like any other child error so replay is
+		// deterministic. Resuming the child later does not change what the parent saw.
 		if outcome.cancelled {
 			decodedResult = *new(R)
 			outcome.err = models.NewAwaitedWorkflowCancelledError(h.workflowID)
+		} else if stepInterruptedByCancellation(workflowState, outcome.err) {
+			// A cancellation error delivered while the awaiting workflow is itself
+			// cancelled — without a settled cancelled outcome — interrupts the
+			// getResult step: don't checkpoint it, so resume re-executes the await.
+			return *new(R), models.NewWorkflowCancelledError(workflowState.workflowID, outcome.err)
 		}
 		ser := resolveEncoder(h.dbosContext)
 		encodedOutput, encErr := ser.Encode(decodedResult)

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1666,7 +1666,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 			// visible, a resume→dequeue can re-dispatch this workflow to this executor,
 			// marking it PENDING. But a stale activeID entry would prevent the workflow from running.
 			removeActive()
-			recordAction, recordErr := sysdb.RetryWithResult(c, func() (sysdb.OutcomeWriteAction, error) {
+			recorded, recordErr := sysdb.RetryWithResult(c, func() (bool, error) {
 				return c.systemDB.UpdateWorkflowOutcome(uncancellableCtx, sysdb.UpdateWorkflowOutcomeDBInput{
 					WorkflowID: workflowID,
 					Status:     status,
@@ -1675,35 +1675,16 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 				})
 			}, sysdb.WithRetrierLogger(c.logger))
 			if recordErr != nil {
-				// A cancellation error means the write was refused because the workflow
-				// was cancelled (e.g. during the final step): end as cancelled, not
-				// complete.
-				if errors.Is(recordErr, ErrWorkflowCancelled) {
-					outcomeChan <- workflowOutcome[any]{result: result, err: recordErr, cancelled: true}
-					close(outcomeChan)
-					return
-				}
-				// The workflow was moved to the dead-letter queue while this run was
-				// executing (it exceeded its maximum recovery attempts). Report that
-				// rather than a completion that was never recorded.
-				if errors.Is(recordErr, ErrDeadLetterQueue) {
-					c.logger.Warn("Workflow outcome not recorded: workflow exceeded its maximum recovery attempts", "workflow_id", workflowID)
-					outcomeChan <- workflowOutcome[any]{result: nil, err: recordErr}
-					close(outcomeChan)
-					return
-				}
-				// Rare not found error or some other DB failure: deliver it as-is.
 				c.logger.Error("Error recording workflow outcome", "workflow_id", workflowID, "error", recordErr)
 				outcomeChan <- workflowOutcome[any]{result: nil, err: recordErr}
 				close(outcomeChan)
 				return
 			}
-			if recordAction == sysdb.OutcomeWriteDeferred {
+			if !recorded {
 				// The row was not PENDING: this run no longer owns the workflow's
-				// outcome. Either another execution is running or about to run it (a
-				// concurrent resume re-enqueued it, or a recovery raced us), or a
-				// terminal outcome is already recorded. The recorded outcome wins:
-				// adopt it, waiting for it if it is not terminal yet.
+				// outcome. It may have been cancelled, dead-lettered, completed by a
+				// concurrent execution, or handed back to the queue by a resume.
+				// Park the execution and wait for the recorded outcome to become visible.
 				c.logger.Warn("Workflow outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome", "workflow_id", workflowID)
 				awaitExistingOutcome()
 				return

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -282,18 +282,18 @@ func (h *workflowHandle[R]) processOutcome(outcome workflowOutcome[R], startTime
 		if _, ok := h.dbosContext.(*dbosContext); !ok {
 			return *new(R), models.NewWorkflowExecutionError(workflowState.workflowID, fmt.Errorf("invalid Context: expected *dbosContext"))
 		}
-		// A cancelled child is a terminal outcome for the awaiting parent, even if
-		// the parent is itself cancelled: the outcome came from the child's settled
-		// CANCELLED row, so checkpoint it like any other child error so replay is
-		// deterministic. Resuming the child later does not change what the parent saw.
+		// A parent that is itself cancelled never checkpoints the await, whatever
+		// the child's outcome: it reports its own cancellation, so a resume
+		// re-executes the await and observes the child's then-settled outcome.
+		if isWorkflowCtxCancelled(workflowState) {
+			return *new(R), models.NewWorkflowCancelledError(workflowState.workflowID, outcome.err)
+		}
+		// A cancelled child is a terminal outcome for the awaiting parent:
+		// checkpoint it like any other child error so replay is deterministic.
+		// Resuming the child later does not change what the parent saw.
 		if outcome.cancelled {
 			decodedResult = *new(R)
 			outcome.err = models.NewAwaitedWorkflowCancelledError(h.workflowID)
-		} else if stepInterruptedByCancellation(workflowState, outcome.err) {
-			// A cancellation error delivered while the awaiting workflow is itself
-			// cancelled — without a settled cancelled outcome — interrupts the
-			// getResult step: don't checkpoint it, so resume re-executes the await.
-			return *new(R), models.NewWorkflowCancelledError(workflowState.workflowID, outcome.err)
 		}
 		ser := resolveEncoder(h.dbosContext)
 		encodedOutput, encErr := ser.Encode(decodedResult)
@@ -376,10 +376,10 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 
 	workflowState, ok := h.dbosContext.Value(workflowStateKey).(*workflowState)
 	isWithinWorkflow := ok && workflowState != nil
-	// A cancellation outcome delivered while the awaiting workflow is itself
-	// cancelled interrupts the getResult step: don't checkpoint it, so resume
-	// re-executes the await.
-	if isWithinWorkflow && stepInterruptedByCancellation(workflowState, err) {
+	// A parent that is itself cancelled never checkpoints the await, whatever
+	// outcome arrived: it reports its own cancellation, so a resume re-executes
+	// the await and observes the child's then-settled outcome.
+	if isWithinWorkflow && isWorkflowCtxCancelled(workflowState) {
 		return *new(R), models.NewWorkflowCancelledError(workflowState.workflowID, err)
 	}
 
@@ -2411,11 +2411,12 @@ func isCancellationError(err error) bool {
 		errors.Is(err, ErrWorkflowCancelled) || errors.Is(err, ErrAwaitedWorkflowCancelled)
 }
 
+func isWorkflowCtxCancelled(stepState *workflowState) bool {
+	return stepState.workflowCtx != nil && stepState.workflowCtx.Err() != nil
+}
+
 func stepInterruptedByCancellation(stepState *workflowState, stepError error) bool {
-	if stepState.workflowCtx == nil || stepState.workflowCtx.Err() == nil {
-		return false
-	}
-	return isCancellationError(stepError)
+	return isWorkflowCtxCancelled(stepState) && isCancellationError(stepError)
 }
 
 // RunAsStep executes a function as a durable step within a workflow.

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -363,7 +363,7 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 	}
 
 	awaitResult, awaitErr := sysdb.RetryWithResult(ctx, func() (*sysdb.AwaitWorkflowResultOutput, error) {
-		return h.dbosContext.(*dbosContext).systemDB.AwaitWorkflowResult(ctx, h.workflowID, options.pollInterval)
+		return h.dbosContext.(*dbosContext).systemDB.AwaitWorkflowResult(ctx, h.workflowID, options.pollInterval, false)
 	}, sysdb.WithRetrierLogger(h.dbosContext.(*dbosContext).logger))
 
 	completedTime := time.Now()
@@ -1554,9 +1554,12 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 	// (one this run does not own) to the outcome channel. cancelCause is the run's
 	// own cancellation error, if it parked because it observed one: a CANCELLED row
 	// wraps it so context.Canceled/DeadlineExceeded still match via errors.Is.
+	// The row is known to have existed (this run inserted or read it), so a missing
+	// row means it was deleted: fail fast with a NonExistentWorkflow error rather
+	// than polling for a row that will never reappear.
 	awaitExistingOutcome := func(cancelCause error) {
 		awaitOut, awaitErr := sysdb.RetryWithResult(c, func() (*sysdb.AwaitWorkflowResultOutput, error) {
-			return c.systemDB.AwaitWorkflowResult(uncancellableCtx, workflowID, sysdb.DBRetryInterval)
+			return c.systemDB.AwaitWorkflowResult(uncancellableCtx, workflowID, sysdb.DBRetryInterval, true)
 		}, sysdb.WithRetrierLogger(c.logger))
 		err := awaitErr
 		if awaitErr == nil && awaitOut != nil && awaitOut.ErrStr != nil {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -289,7 +289,8 @@ func (h *workflowHandle[R]) processOutcome(outcome workflowOutcome[R], startTime
 		// Return "Awaited workflow cancelled" error when the child is cancelled.
 		// A cancelled child has no output value: record a NULL output, like the
 		// polling handle does.
-		childCancelled := errors.Is(outcome.err, ErrWorkflowCancelled)
+		childErr, isDBOSErr := outcome.err.(*Error)
+		childCancelled := isDBOSErr && childErr.Code == ErrorCodeWorkflowCancelled
 		if childCancelled {
 			decodedResult = *new(R)
 			outcome.err = models.NewAwaitedWorkflowCancelledError(h.workflowID)

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1555,6 +1555,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 	// The row is known to have existed (this run inserted or read it), so a missing
 	// row means it was deleted: fail fast with a NonExistentWorkflow error rather
 	// than polling for a row that will never reappear.
+	// Parking is unbounded and relies on the outcome being eventually settled.
 	awaitExistingOutcome := func(cancelCause error) {
 		awaitOut, awaitErr := sysdb.RetryWithResult(c, func() (*sysdb.AwaitWorkflowResultOutput, error) {
 			return c.systemDB.AwaitWorkflowResult(uncancellableCtx, workflowID, sysdb.DBRetryInterval, true)
@@ -1625,12 +1626,12 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 			awaitExistingOutcome(nil)
 			return
 		} else {
-			// A cancelled run skips updateWorkflowOutcome entirely so it can never
-			// clobber the row (e.g., ENQUEUED written by a concurrent resume). It
-			// parks instead of trusting its local view: normally the row is CANCELLED
-			// and the parked await reports the workflow's cancellation (wrapping the
-			// run's own error), but a concurrent resume may have taken the workflow
-			// back, in which case the recorded outcome is the truth.
+			// A run whose context was cancelled skips updateWorkflowOutcome entirely so
+			// it can never clobber the row (e.g., ENQUEUED written by a concurrent
+			// resume). It parks instead of trusting its local view: normally the row is
+			// CANCELLED and the parked await reports the workflow's cancellation
+			// (wrapping the run's own error), but a concurrent resume may have taken the
+			// workflow back, in which case the recorded outcome is the truth.
 			if !stopFunc() {
 				// AfterFunc fired => context is cancelled. Wait for the DB cancel to
 				// finish so the row is settled before parking.
@@ -1648,14 +1649,6 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 				awaitExistingOutcome(err)
 				return
 			}
-			if errors.Is(err, ErrWorkflowCancelled) {
-				// The workflow observed its own cancellation in the DB (external
-				// cancel): the row is already CANCELLED. Skip the outcome write.
-				removeActive()
-				awaitExistingOutcome(err)
-				return
-			}
-
 			status := WorkflowStatusSuccess
 			if err != nil {
 				status = WorkflowStatusError
@@ -1698,7 +1691,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 				// concurrent execution, or handed back to the queue by a resume.
 				// Park the execution and wait for the recorded outcome to become visible.
 				c.logger.Warn("Workflow outcome was not recorded: the workflow is no longer owned by this execution. Waiting for the recorded outcome", "workflow_id", workflowID)
-				awaitExistingOutcome(nil)
+				awaitExistingOutcome(err)
 				return
 			}
 		}

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3,6 +3,7 @@ package dbos
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -3796,6 +3797,184 @@ func TestCancelWorkflows(t *testing.T) {
 		require.NoError(t, err, "resumed workflow should complete successfully")
 		require.Equal(t, "swallowed", result)
 		require.EqualValues(t, 2, swallowCancelAttempts.Load(), "expected the workflow to re-execute on resume")
+	})
+}
+
+// A run may record its outcome only while its workflow_status row is still
+// PENDING: that row is what says "this run is what the workflow is doing". Every
+// other status means the run lost ownership (a concurrent resume re-enqueued it,
+// a recovery raced it, it was cancelled or dead-lettered) and the recorded
+// outcome, not the one the run computed, is the workflow's outcome.
+func TestWorkflowOutcomeIsOwnedByThePendingRow(t *testing.T) {
+	dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+
+	// Each run blocks until the subtest has rewritten its row, then returns a
+	// result the subtest can tell apart from anything recorded out-of-band.
+	type runControl struct {
+		started *Event
+		release chan struct{}
+	}
+	var controls sync.Map
+	blockedWorkflow := func(ctx Context, id string) (string, error) {
+		v, ok := controls.Load(id)
+		if !ok {
+			return "", fmt.Errorf("no control registered for workflow %s", id)
+		}
+		ctrl := v.(*runControl)
+		ctrl.started.Set()
+		<-ctrl.release
+		return "own-result", nil
+	}
+	RegisterWorkflow(dbosCtx, blockedWorkflow)
+	require.NoError(t, Launch(dbosCtx), "failed to launch DBOS")
+
+	sysDB, ok := dbosCtx.(*dbosContext).systemDB.(*sysdb.SysDB)
+	require.True(t, ok, "expected systemDB to be *sysdb.SysDB")
+	schemaPrefix := sysDB.Dialect().SchemaPrefix(sysDB.Schema())
+
+	// startBlockedRun starts a run and returns once it is blocked inside the
+	// workflow function, with its row PENDING.
+	startBlockedRun := func(t *testing.T) (WorkflowHandle[string], *runControl) {
+		t.Helper()
+		id := "outcome-ownership-" + uuid.NewString()
+		ctrl := &runControl{started: NewEvent(), release: make(chan struct{})}
+		controls.Store(id, ctrl)
+		handle, err := RunWorkflow(dbosCtx, blockedWorkflow, id, WithWorkflowID(id))
+		require.NoError(t, err, "failed to start workflow")
+		ctrl.started.Wait()
+		return handle, ctrl
+	}
+
+	// encodeOutput mirrors the default (non-portable) workflow serializer.
+	encodeOutput := func(t *testing.T, value string) *string {
+		t.Helper()
+		jsonBytes, err := json.Marshal(value)
+		require.NoError(t, err, "failed to encode output")
+		encoded := base64.StdEncoding.EncodeToString(jsonBytes)
+		return &encoded
+	}
+
+	// rewriteRow takes the row away from the blocked run, standing in for the
+	// concurrent resume/recovery/cancel that would do it in production.
+	rewriteRow := func(t *testing.T, workflowID string, status WorkflowStatusType, output *string, errStr string) {
+		t.Helper()
+		q := sysDB.RenderSQL(`UPDATE %sworkflow_status SET status = $1, output = $2, error = $3 WHERE workflow_uuid = $4`, schemaPrefix)
+		_, err := sysDB.Pool().Exec(context.Background(), q, status, output, errStr, workflowID)
+		require.NoError(t, err, "failed to rewrite workflow row")
+	}
+
+	t.Run("RecordedSuccessSupersedesTheRunResult", func(t *testing.T) {
+		handle, ctrl := startBlockedRun(t)
+		rewriteRow(t, handle.GetWorkflowID(), WorkflowStatusSuccess, encodeOutput(t, "recorded-elsewhere"), "")
+		close(ctrl.release)
+
+		result, err := handle.GetResult()
+		require.NoError(t, err, "the recorded success must be adopted")
+		require.Equal(t, "recorded-elsewhere", result, "the run must report the recorded output, not its own")
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get workflow status")
+		require.Equal(t, WorkflowStatusSuccess, status.Status)
+		require.Equal(t, `"recorded-elsewhere"`, status.Output, "the recorded output must not be overwritten")
+	})
+
+	t.Run("RecordedErrorSupersedesTheRunResult", func(t *testing.T) {
+		handle, ctrl := startBlockedRun(t)
+		rewriteRow(t, handle.GetWorkflowID(), WorkflowStatusError, nil, "recorded failure")
+		close(ctrl.release)
+
+		result, err := handle.GetResult()
+		require.Error(t, err, "the recorded error must be adopted")
+		require.Contains(t, err.Error(), "recorded failure")
+		require.Equal(t, "", result, "no output may be reported for a recorded failure")
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get workflow status")
+		require.Equal(t, WorkflowStatusError, status.Status)
+	})
+
+	t.Run("NonTerminalRowParksTheRunUntilAnOutcomeIsRecorded", func(t *testing.T) {
+		handle, ctrl := startBlockedRun(t)
+		// ENQUEUED with no queue name: nothing dequeues it, so the run stays parked
+		// until this subtest records the outcome itself.
+		rewriteRow(t, handle.GetWorkflowID(), WorkflowStatusEnqueued, nil, "")
+		close(ctrl.release)
+
+		type outcome struct {
+			result string
+			err    error
+		}
+		done := make(chan outcome, 1)
+		go func() {
+			result, err := handle.GetResult()
+			done <- outcome{result: result, err: err}
+		}()
+
+		// The run leaves the active set immediately before it tries to record its
+		// outcome. Waiting for that makes the check below assert that the run parked,
+		// rather than merely that it had not gotten around to the write yet.
+		activeWorkflowIDs := dbosCtx.(*dbosContext).activeWorkflowIDs
+		require.Eventually(t, func() bool {
+			_, active := activeWorkflowIDs.Load(handle.GetWorkflowID())
+			return !active
+		}, 30*time.Second, 10*time.Millisecond, "the run never reached its outcome write")
+
+		select {
+		case got := <-done:
+			t.Fatalf("the run must wait for the owning execution, got result %q (err: %v)", got.result, got.err)
+		case <-time.After(2 * time.Second):
+		}
+
+		rewriteRow(t, handle.GetWorkflowID(), WorkflowStatusSuccess, encodeOutput(t, "recorded-by-owner"), "")
+
+		select {
+		case got := <-done:
+			require.NoError(t, got.err, "the parked run must adopt the recorded outcome")
+			require.Equal(t, "recorded-by-owner", got.result, "the run must report the recorded output, not its own")
+		case <-time.After(30 * time.Second):
+			t.Fatal("the parked run did not pick up the recorded outcome in time")
+		}
+	})
+
+	t.Run("DeadLetteredRowFailsTheRun", func(t *testing.T) {
+		handle, ctrl := startBlockedRun(t)
+		rewriteRow(t, handle.GetWorkflowID(), WorkflowStatusMaxRecoveryAttemptsExceeded, nil, "")
+		// A workflow is dead-lettered by the attempt that pushes recovery_attempts
+		// past maxRetries+1, so a dead-lettered row carries maxRetries+2 attempts.
+		// The retry budget is recovered from the row the same way AwaitWorkflowResult
+		// does it, by subtracting those two.
+		const maxRetries = 3
+		attemptsQuery := sysDB.RenderSQL(`UPDATE %sworkflow_status SET recovery_attempts = $1 WHERE workflow_uuid = $2`, schemaPrefix)
+		_, err := sysDB.Pool().Exec(context.Background(), attemptsQuery, maxRetries+2, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to set recovery attempts")
+		close(ctrl.release)
+
+		result, err := handle.GetResult()
+		require.Error(t, err, "a dead-lettered workflow must not report a completion")
+		require.True(t, errors.Is(err, ErrDeadLetterQueue), "expected ErrorCodeDeadLetterQueue error, got: %v", err)
+		require.Equal(t, "", result, "no output may be reported for a dead-lettered workflow")
+
+		var dbosErr *Error
+		require.True(t, errors.As(err, &dbosErr), "expected a *dbos.Error")
+		require.Equal(t, maxRetries, dbosErr.MaxRetries, "the error must report the exhausted retry budget")
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get workflow status")
+		require.Equal(t, WorkflowStatusMaxRecoveryAttemptsExceeded, status.Status)
+		require.Nil(t, status.Output, "the refused outcome must not record an output")
+	})
+
+	t.Run("MissingRowLeavesTheRunResultIntact", func(t *testing.T) {
+		handle, ctrl := startBlockedRun(t)
+		deleteQuery := sysDB.RenderSQL(`DELETE FROM %sworkflow_status WHERE workflow_uuid = $1`, schemaPrefix)
+		_, err := sysDB.Pool().Exec(context.Background(), deleteQuery, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to delete workflow row")
+		close(ctrl.release)
+
+		// Nothing to adopt and nothing to wait for: the run keeps its own result.
+		result, err := handle.GetResult()
+		require.NoError(t, err, "a missing row must not fail the run")
+		require.Equal(t, "own-result", result)
 	})
 }
 

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3704,8 +3704,9 @@ func TestCancelWorkflows(t *testing.T) {
 	t.Run("CancelledDuringFinalStepDoesNotComplete", func(t *testing.T) {
 		// A workflow API-cancelled while finishing its last work must end as
 		// CANCELLED, not complete: the refused outcome write sends the run to await
-		// the recorded outcome, which is the cancellation, and the workflow stays
-		// resumable (same semantics as the Python/TS/Java SDKs).
+		// the recorded outcome, which is the cancellation, so its own handle reports
+		// the workflow's cancellation and the workflow stays resumable (same
+		// semantics as the Python/TS/Java SDKs).
 		handle, err := RunWorkflow(dbosCtx, finalStepCancelWorkflow, "")
 		require.NoError(t, err, "failed to start workflow")
 		finalStepCancelStarted.Wait()
@@ -3715,7 +3716,7 @@ func TestCancelWorkflows(t *testing.T) {
 
 		_, err = handle.GetResult()
 		require.Error(t, err, "a cancelled workflow must not complete")
-		require.True(t, errors.Is(err, ErrAwaitedWorkflowCancelled), "expected ErrorCodeAwaitedWorkflowCancelled error, got: %v", err)
+		require.True(t, errors.Is(err, ErrWorkflowCancelled), "expected ErrorCodeWorkflowCancelled error, got: %v", err)
 
 		status, err := handle.GetStatus()
 		require.NoError(t, err, "failed to get workflow status")

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3703,9 +3703,9 @@ func TestCancelWorkflows(t *testing.T) {
 
 	t.Run("CancelledDuringFinalStepDoesNotComplete", func(t *testing.T) {
 		// A workflow API-cancelled while finishing its last work must end as
-		// CANCELLED, not complete: the refused outcome write is surfaced as a
-		// cancellation and the workflow stays resumable (same semantics as the
-		// Python/TS/Java SDKs).
+		// CANCELLED, not complete: the refused outcome write sends the run to await
+		// the recorded outcome, which is the cancellation, and the workflow stays
+		// resumable (same semantics as the Python/TS/Java SDKs).
 		handle, err := RunWorkflow(dbosCtx, finalStepCancelWorkflow, "")
 		require.NoError(t, err, "failed to start workflow")
 		finalStepCancelStarted.Wait()
@@ -3715,7 +3715,7 @@ func TestCancelWorkflows(t *testing.T) {
 
 		_, err = handle.GetResult()
 		require.Error(t, err, "a cancelled workflow must not complete")
-		require.True(t, errors.Is(err, ErrWorkflowCancelled), "expected ErrorCodeWorkflowCancelled error, got: %v", err)
+		require.True(t, errors.Is(err, ErrAwaitedWorkflowCancelled), "expected ErrorCodeAwaitedWorkflowCancelled error, got: %v", err)
 
 		status, err := handle.GetStatus()
 		require.NoError(t, err, "failed to get workflow status")
@@ -3962,21 +3962,6 @@ func TestWorkflowOutcomeIsOwnedByThePendingRow(t *testing.T) {
 		require.NoError(t, err, "failed to get workflow status")
 		require.Equal(t, WorkflowStatusMaxRecoveryAttemptsExceeded, status.Status)
 		require.Nil(t, status.Output, "the refused outcome must not record an output")
-	})
-
-	t.Run("MissingRowFailsTheRun", func(t *testing.T) {
-		handle, ctrl := startBlockedRun(t)
-		deleteQuery := sysDB.RenderSQL(`DELETE FROM %sworkflow_status WHERE workflow_uuid = $1`, schemaPrefix)
-		_, err := sysDB.Pool().Exec(context.Background(), deleteQuery, handle.GetWorkflowID())
-		require.NoError(t, err, "failed to delete workflow row")
-		close(ctrl.release)
-
-		// The row is gone (garbage collected or deleted by hand), so there is nowhere
-		// to record the outcome: report that rather than a completion nothing holds.
-		result, err := handle.GetResult()
-		require.Error(t, err, "a run whose row vanished must not report a completion")
-		require.True(t, errors.Is(err, ErrNonExistentWorkflow), "expected ErrorCodeNonExistentWorkflow error, got: %v", err)
-		require.Equal(t, "", result, "no output may be reported when the row is gone")
 	})
 }
 
@@ -7569,7 +7554,7 @@ func TestWorkflowHandleContextCancel(t *testing.T) {
 		getEventWorkflowStartedSignal.Wait()
 		getEventWorkflowStartedSignal.Clear()
 
-		dbosCtx.Shutdown(dbosCtx, 1 * time.Second)
+		dbosCtx.Shutdown(dbosCtx, 1*time.Second)
 
 		err = <-resultChan
 		require.Error(t, err, "expected error from cancelled context")
@@ -9439,7 +9424,7 @@ func TestWorkflowAttributes(t *testing.T) {
 		client, err := NewClient(dbosCtx, config)
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			client.Shutdown(client, 30 * time.Second)
+			client.Shutdown(client, 30*time.Second)
 		})
 
 		// Enqueue to a queue nothing consumes; the workflow stays ENQUEUED, which

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3827,20 +3827,34 @@ func TestWorkflowOutcomeIsOwnedByThePendingRow(t *testing.T) {
 		return "own-result", nil
 	}
 	RegisterWorkflow(dbosCtx, blockedWorkflow)
+
+	// Stands in for a run that observes its own cancellation mid-flight: the
+	// cancellation is returned only after the subtest has rewritten the row.
+	selfCancellingWorkflow := func(ctx Context, id string) (string, error) {
+		v, ok := controls.Load(id)
+		if !ok {
+			return "", fmt.Errorf("no control registered for workflow %s", id)
+		}
+		ctrl := v.(*runControl)
+		ctrl.started.Set()
+		<-ctrl.release
+		return "", models.NewWorkflowCancelledError(id, nil)
+	}
+	RegisterWorkflow(dbosCtx, selfCancellingWorkflow)
 	require.NoError(t, Launch(dbosCtx), "failed to launch DBOS")
 
 	sysDB, ok := dbosCtx.(*dbosContext).systemDB.(*sysdb.SysDB)
 	require.True(t, ok, "expected systemDB to be *sysdb.SysDB")
 	schemaPrefix := sysDB.Dialect().SchemaPrefix(sysDB.Schema())
 
-	// startBlockedRun starts a run and returns once it is blocked inside the
-	// workflow function, with its row PENDING.
-	startBlockedRun := func(t *testing.T) (WorkflowHandle[string], *runControl) {
+	// startBlockedRun starts a run of the given workflow and returns once it is
+	// blocked inside the workflow function, with its row PENDING.
+	startBlockedRun := func(t *testing.T, workflow func(Context, string) (string, error)) (WorkflowHandle[string], *runControl) {
 		t.Helper()
 		id := "outcome-ownership-" + uuid.NewString()
 		ctrl := &runControl{started: NewEvent(), release: make(chan struct{})}
 		controls.Store(id, ctrl)
-		handle, err := RunWorkflow(dbosCtx, blockedWorkflow, id, WithWorkflowID(id))
+		handle, err := RunWorkflow(dbosCtx, workflow, id, WithWorkflowID(id))
 		require.NoError(t, err, "failed to start workflow")
 		ctrl.started.Wait()
 		return handle, ctrl
@@ -3865,7 +3879,7 @@ func TestWorkflowOutcomeIsOwnedByThePendingRow(t *testing.T) {
 	}
 
 	t.Run("RecordedSuccessSupersedesTheRunResult", func(t *testing.T) {
-		handle, ctrl := startBlockedRun(t)
+		handle, ctrl := startBlockedRun(t, blockedWorkflow)
 		rewriteRow(t, handle.GetWorkflowID(), WorkflowStatusSuccess, encodeOutput(t, "recorded-elsewhere"), "")
 		close(ctrl.release)
 
@@ -3880,7 +3894,7 @@ func TestWorkflowOutcomeIsOwnedByThePendingRow(t *testing.T) {
 	})
 
 	t.Run("RecordedErrorSupersedesTheRunResult", func(t *testing.T) {
-		handle, ctrl := startBlockedRun(t)
+		handle, ctrl := startBlockedRun(t, blockedWorkflow)
 		rewriteRow(t, handle.GetWorkflowID(), WorkflowStatusError, nil, "recorded failure")
 		close(ctrl.release)
 
@@ -3895,7 +3909,7 @@ func TestWorkflowOutcomeIsOwnedByThePendingRow(t *testing.T) {
 	})
 
 	t.Run("NonTerminalRowParksTheRunUntilAnOutcomeIsRecorded", func(t *testing.T) {
-		handle, ctrl := startBlockedRun(t)
+		handle, ctrl := startBlockedRun(t, blockedWorkflow)
 		// ENQUEUED with no queue name: nothing dequeues it, so the run stays parked
 		// until this subtest records the outcome itself.
 		rewriteRow(t, handle.GetWorkflowID(), WorkflowStatusEnqueued, nil, "")
@@ -3938,7 +3952,7 @@ func TestWorkflowOutcomeIsOwnedByThePendingRow(t *testing.T) {
 	})
 
 	t.Run("DeadLetteredRowFailsTheRun", func(t *testing.T) {
-		handle, ctrl := startBlockedRun(t)
+		handle, ctrl := startBlockedRun(t, blockedWorkflow)
 		rewriteRow(t, handle.GetWorkflowID(), WorkflowStatusMaxRecoveryAttemptsExceeded, nil, "")
 		// A workflow is dead-lettered by the attempt that pushes recovery_attempts
 		// past maxRetries+1, so a dead-lettered row carries maxRetries+2 attempts.
@@ -3966,7 +3980,7 @@ func TestWorkflowOutcomeIsOwnedByThePendingRow(t *testing.T) {
 	})
 
 	t.Run("DeletedRowFailsTheRunWithNonExistentWorkflow", func(t *testing.T) {
-		handle, ctrl := startBlockedRun(t)
+		handle, ctrl := startBlockedRun(t, blockedWorkflow)
 		q := sysDB.RenderSQL(`DELETE FROM %sworkflow_status WHERE workflow_uuid = $1`, schemaPrefix)
 		_, err := sysDB.Pool().Exec(context.Background(), q, handle.GetWorkflowID())
 		require.NoError(t, err, "failed to delete workflow row")
@@ -3976,6 +3990,35 @@ func TestWorkflowOutcomeIsOwnedByThePendingRow(t *testing.T) {
 		require.Error(t, err, "a run whose row vanished must not report a completion")
 		require.True(t, errors.Is(err, ErrNonExistentWorkflow), "expected ErrorCodeNonExistentWorkflow error, got: %v", err)
 		require.Equal(t, "", result, "no output may be reported for a deleted workflow")
+	})
+
+	t.Run("CancelledRunAdoptsARecordedOutcome", func(t *testing.T) {
+		// A run that observes its own cancellation adopts the recorded outcome
+		// rather than trusting its local view: here a concurrent "resume" already
+		// rewrote the row to SUCCESS, so the handle reports that outcome instead
+		// of a cancellation that is no longer the workflow's state.
+		handle, ctrl := startBlockedRun(t, selfCancellingWorkflow)
+		rewriteRow(t, handle.GetWorkflowID(), WorkflowStatusSuccess, encodeOutput(t, "recorded-after-cancel"), "")
+		close(ctrl.release)
+
+		result, err := handle.GetResult()
+		require.NoError(t, err, "the run must adopt the recorded outcome, not report its cancellation")
+		require.Equal(t, "recorded-after-cancel", result, "the run must report the recorded output, not its own")
+	})
+
+	t.Run("CancelledRunStillReportsCancellationForACancelledRow", func(t *testing.T) {
+		handle, ctrl := startBlockedRun(t, selfCancellingWorkflow)
+		rewriteRow(t, handle.GetWorkflowID(), WorkflowStatusCancelled, nil, "")
+		close(ctrl.release)
+
+		result, err := handle.GetResult()
+		require.Error(t, err, "a genuinely cancelled workflow must still report its cancellation")
+		require.True(t, errors.Is(err, ErrWorkflowCancelled), "expected cancellation error, got: %v", err)
+		require.Equal(t, "", result, "no output may be reported for a cancelled workflow")
+
+		status, err := handle.GetStatus()
+		require.NoError(t, err, "failed to get workflow status")
+		require.Equal(t, WorkflowStatusCancelled, status.Status)
 	})
 }
 

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -5964,7 +5964,9 @@ func TestWorkflowTimeout(t *testing.T) {
 		// Wait for the workflow to complete and get the result
 		result, err := handle.GetResult()
 		assert.True(t, errors.Is(err, context.DeadlineExceeded), "Expected deadline exceeded error, got: %v", err)
-		assert.Equal(t, "detached-step-completed", result, "expected result to be 'detached-step-completed'")
+		// A cancelled workflow delivers no result, even one it computed: the
+		// CANCELLED row stores no outcome, and the run adopts the recorded outcome.
+		assert.Equal(t, "", result, "expected no result for a cancelled workflow")
 		// Check the workflow status: should be cancelled
 		status, err := handle.GetStatus()
 		require.NoError(t, err, "failed to get workflow status")
@@ -6063,7 +6065,9 @@ func TestWorkflowTimeout(t *testing.T) {
 		// Wait for the parent workflow to complete and get the result
 		result, err := handle.GetResult()
 		assert.True(t, errors.Is(err, context.DeadlineExceeded), "Expected deadline exceeded error, got: %v", err)
-		assert.Equal(t, "detached-step-completed", result, "expected result to be 'detached-step-completed'")
+		// A cancelled workflow delivers no result, even one it computed: the
+		// CANCELLED row stores no outcome, and the run adopts the recorded outcome.
+		assert.Equal(t, "", result, "expected no result for a cancelled workflow")
 
 		// Check the workflow status: should be cancelled
 		status, err := handle.GetStatus()

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3964,6 +3964,19 @@ func TestWorkflowOutcomeIsOwnedByThePendingRow(t *testing.T) {
 		require.Equal(t, WorkflowStatusMaxRecoveryAttemptsExceeded, status.Status)
 		require.Nil(t, status.Output, "the refused outcome must not record an output")
 	})
+
+	t.Run("DeletedRowFailsTheRunWithNonExistentWorkflow", func(t *testing.T) {
+		handle, ctrl := startBlockedRun(t)
+		q := sysDB.RenderSQL(`DELETE FROM %sworkflow_status WHERE workflow_uuid = $1`, schemaPrefix)
+		_, err := sysDB.Pool().Exec(context.Background(), q, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to delete workflow row")
+		close(ctrl.release)
+
+		result, err := handle.GetResult()
+		require.Error(t, err, "a run whose row vanished must not report a completion")
+		require.True(t, errors.Is(err, ErrNonExistentWorkflow), "expected ErrorCodeNonExistentWorkflow error, got: %v", err)
+		require.Equal(t, "", result, "no output may be reported for a deleted workflow")
+	})
 }
 
 func TestResumeWorkflows(t *testing.T) {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -2024,10 +2024,11 @@ func TestSelect(t *testing.T) {
 		// Wait for the workflow to reach the Select call (step has started and set the event)
 		selectBlockStartEvent.Wait()
 		selectBlockStartEvent.Clear()
-		// Wait for the Go step body to start: once it runs, its outcome is delivered
-		// and checkpointed even though the workflow is cancelled. Cancelling earlier
-		// would race the durable cancel against the step's checkpoint lookup, which
-		// can refuse to start the step at all (a valid outcome, but not this test's).
+		// Wait for the Go step body to start: the test cancels while it runs, and
+		// its outcome — delivered after the cancel — must be discarded, not
+		// checkpointed. Cancelling earlier would race the durable cancel against
+		// the step's checkpoint lookup, which can refuse to start the step at all
+		// (a valid outcome, but not the path this test pins).
 		selectGoStepStarted.Wait()
 		selectGoStepStarted.Clear()
 
@@ -2053,15 +2054,14 @@ func TestSelect(t *testing.T) {
 		require.NoError(t, err, "failed to get workflow status")
 		assert.Equal(t, WorkflowStatusCancelled, status.Status, "expected workflow status to be WorkflowStatusCancelled")
 
-		// The cancelled Select step must not be checkpointed (it would replay its
-		// cancellation error on resume); only the Go step, unblocked above, records.
-		require.Eventually(t, func() bool {
+		// The cancelled workflow must not checkpoint any step: neither the
+		// interrupted Select nor the Go step unblocked above, whose outcome is
+		// discarded at the checkpoint site because the workflow context is
+		// cancelled. On resume, both would replay.
+		require.Never(t, func() bool {
 			steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
-			if err != nil {
-				return false
-			}
-			return len(steps) == 1 && steps[0].StepID == 0
-		}, 5*time.Second, 100*time.Millisecond, "expected only the Go step to be recorded")
+			return err == nil && len(steps) > 0
+		}, 2*time.Second, 100*time.Millisecond, "no step may be checkpointed after the workflow is cancelled")
 	})
 
 	t.Run("Select idempotency", func(t *testing.T) {
@@ -5941,12 +5941,17 @@ func TestWorkflowTimeout(t *testing.T) {
 
 	detachedStepWorkflow := func(ctx Context, timeout time.Duration) (string, error) {
 		// This workflow will run a step that is not cancelable.
-		// What this means is the workflow *will* be cancelled, but the step will run normally
+		// What this means is the workflow *will* be cancelled, but the step will run normally.
+		// The workflow being cancelled mid-step interrupts the step checkpoint,
+		// so the step's success is reported as the workflow's cancellation; a
+		// resume would re-execute the step.
 		stepCtx := WithoutCancel(ctx)
 		res, err := RunAsStep(stepCtx, func(context context.Context) (string, error) {
 			return detachedStep(context, timeout*2)
 		})
-		require.NoError(t, err, "failed to run detached step")
+		if err != nil {
+			return "", err
+		}
 		assert.Equal(t, "detached-step-completed", res, "expected detached step result to be 'detached-step-completed'")
 		return res, ctx.Err()
 	}
@@ -6025,7 +6030,9 @@ func TestWorkflowTimeout(t *testing.T) {
 		}, 5*time.Second, 50*time.Millisecond, "expected child workflow status to be WorkflowStatusCancelled")
 	}
 
+	var detachedChildExecutions atomic.Int64
 	detachedChild := func(ctx Context, timeout time.Duration) (string, error) {
+		detachedChildExecutions.Add(1)
 		select {
 		case <-ctx.Done():
 			return "", ctx.Err()
@@ -6043,10 +6050,14 @@ func TestWorkflowTimeout(t *testing.T) {
 		childHandle, err := RunWorkflow(childCtx, detachedChild, timeout*2, WithWorkflowID(childWorkflowID))
 		require.NoError(t, err, "failed to start child workflow")
 
-		// Wait for the child workflow to complete
+		// Wait for the child workflow to complete. On the first execution the
+		// parent is cancelled mid-await, so getResult is interrupted (not
+		// checkpointed) even though the detached child succeeds; a resume
+		// replays the await and adopts the child's recorded success.
 		result, err := childHandle.GetResult()
-		require.NoError(t, err, "failed to get result from child workflow")
-		// The child spun for timeout*2 so ctx.Err() should be context.DeadlineExceeded
+		if err != nil {
+			return "", err
+		}
 		return result, ctx.Err()
 	}
 	RegisterWorkflow(dbosCtx, detachedChildWorkflowParent)
@@ -6086,6 +6097,15 @@ func TestWorkflowTimeout(t *testing.T) {
 		status, err = childHandle.GetStatus()
 		require.NoError(t, err, "failed to get child workflow status")
 		assert.Equal(t, WorkflowStatusSuccess, status.Status, "expected child workflow status to be WorkflowStatusSuccess")
+
+		// Resuming the parent replays the interrupted getResult step: this time
+		// it finds the detached child's recorded success and checkpoints it.
+		resumedHandle, err := ResumeWorkflow[string](dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to resume parent workflow")
+		result, err = resumedHandle.GetResult()
+		require.NoError(t, err, "resumed parent should adopt the detached child's recorded success")
+		assert.Equal(t, "detached-step-completed", result, "expected the resumed parent to report the child's result")
+		require.EqualValues(t, 1, detachedChildExecutions.Load(), "child must not re-execute on parent resume")
 	})
 
 	t.Run("RecoverWaitForCancelWorkflow", func(t *testing.T) {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1397,8 +1397,9 @@ func TestSteps(t *testing.T) {
 	t.Run("CancelledParentCancelsChild", func(t *testing.T) {
 		// Cancelling the parent durably cancels the child too: a cancelled run
 		// never writes its outcome, even if its function ignores cancellation and
-		// returns successfully. The parent checkpoints the child's cancellation
-		// via getResult; resuming the parent replays it deterministically.
+		// returns successfully. A cancelled parent never checkpoints the await:
+		// it reports its own cancellation, and only a later resume observes (and
+		// then checkpoints) the child's settled cancellation.
 		cancelCtx, cancelFunc := WithCancel(dbosCtx)
 		defer cancelFunc()
 		handle, err := RunWorkflow(cancelCtx, stubbornParentWorkflow, "")
@@ -1410,7 +1411,7 @@ func TestSteps(t *testing.T) {
 
 		_, err = handle.GetResult()
 		require.Error(t, err, "expected error from cancelled parent")
-		require.True(t, errors.Is(err, ErrAwaitedWorkflowCancelled), "expected ErrorCodeAwaitedWorkflowCancelled, got: %v", err)
+		require.True(t, errors.Is(err, ErrWorkflowCancelled), "expected ErrorCodeWorkflowCancelled, got: %v", err)
 
 		require.Eventually(t, func() bool {
 			status, err := handle.GetStatus()
@@ -1420,11 +1421,9 @@ func TestSteps(t *testing.T) {
 
 		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
 		require.NoError(t, err, "failed to get workflow steps")
-		require.Len(t, steps, 2, "expected child spawn and getResult recorded")
+		require.Len(t, steps, 1, "only the child spawn must be recorded, not the interrupted await")
 		childID := steps[0].ChildWorkflowID
-		require.NotEmpty(t, childID, "expected the first step to be the child spawn")
-		require.Equal(t, "DBOS.getResult", steps[1].StepName)
-		require.NotNil(t, steps[1].Error, "the child's cancellation must be checkpointed")
+		require.NotEmpty(t, childID, "expected the recorded step to be the child spawn")
 
 		childHandle, err := RetrieveWorkflow[string](dbosCtx, childID)
 		require.NoError(t, err, "failed to retrieve child workflow")
@@ -1432,18 +1431,25 @@ func TestSteps(t *testing.T) {
 		require.NoError(t, err, "failed to get child workflow status")
 		require.Equal(t, WorkflowStatusCancelled, childStatus.Status, "child cannot outlive the parent's cancellation")
 
-		// The checkpointed child cancellation is a terminal outcome for the
-		// parent: resuming replays it.
+		// Resuming the parent re-executes the await against the child's settled
+		// CANCELLED row: the parent is no longer cancelled, so the child's
+		// cancellation is now checkpointed as the await's terminal outcome.
 		resumedHandle, err := ResumeWorkflow[string](dbosCtx, handle.GetWorkflowID())
 		require.NoError(t, err, "failed to resume parent workflow")
 		_, err = resumedHandle.GetResult()
-		require.Error(t, err, "resumed parent must replay the checkpointed child cancellation")
-		require.True(t, errors.Is(err, ErrAwaitedWorkflowCancelled), "expected ErrorCodeAwaitedWorkflowCancelled on replay, got: %v", err)
+		require.Error(t, err, "resumed parent must observe the child's cancellation")
+		require.True(t, errors.Is(err, ErrAwaitedWorkflowCancelled), "expected ErrorCodeAwaitedWorkflowCancelled on resume, got: %v", err)
 		require.EqualValues(t, 1, stubbornChildExecutions.Load(), "child must not re-execute on parent resume")
+
+		steps, err = GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps after resume")
+		require.Len(t, steps, 2, "the re-executed await checkpoints the child's cancellation")
+		require.Equal(t, "DBOS.getResult", steps[1].StepName)
+		require.NotNil(t, steps[1].Error, "the child's cancellation must be checkpointed")
 
 		status, err := resumedHandle.GetStatus()
 		require.NoError(t, err, "failed to get resumed workflow status")
-		require.Equal(t, WorkflowStatusError, status.Status, "replayed child cancellation is a terminal error outcome")
+		require.Equal(t, WorkflowStatusError, status.Status, "the child cancellation observed on resume is a terminal error outcome")
 	})
 
 	t.Run("PreemptedChildCancellationNotCheckpointed", func(t *testing.T) {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3964,17 +3964,19 @@ func TestWorkflowOutcomeIsOwnedByThePendingRow(t *testing.T) {
 		require.Nil(t, status.Output, "the refused outcome must not record an output")
 	})
 
-	t.Run("MissingRowLeavesTheRunResultIntact", func(t *testing.T) {
+	t.Run("MissingRowFailsTheRun", func(t *testing.T) {
 		handle, ctrl := startBlockedRun(t)
 		deleteQuery := sysDB.RenderSQL(`DELETE FROM %sworkflow_status WHERE workflow_uuid = $1`, schemaPrefix)
 		_, err := sysDB.Pool().Exec(context.Background(), deleteQuery, handle.GetWorkflowID())
 		require.NoError(t, err, "failed to delete workflow row")
 		close(ctrl.release)
 
-		// Nothing to adopt and nothing to wait for: the run keeps its own result.
+		// The row is gone (garbage collected or deleted by hand), so there is nowhere
+		// to record the outcome: report that rather than a completion nothing holds.
 		result, err := handle.GetResult()
-		require.NoError(t, err, "a missing row must not fail the run")
-		require.Equal(t, "own-result", result)
+		require.Error(t, err, "a run whose row vanished must not report a completion")
+		require.True(t, errors.Is(err, ErrNonExistentWorkflow), "expected ErrorCodeNonExistentWorkflow error, got: %v", err)
+		require.Equal(t, "", result, "no output may be reported when the row is gone")
 	})
 }
 


### PR DESCRIPTION
Update the workflow outcome now results in 5 possible outcomes:
- outcome recorded, the common path
- Error: workflow doesn't exist (wf was garbage collected or deleted)
- Error: workflow was cancelled
- Error: workflow was DLQ-ed
- Park: workflow is DELAYED/ENQUEUED, or already SUCCESS/ERROR. Poll for an outcome.

This does not solve the race if another execution has resumed and the workflow is `PENDING` -- but in this case the outcome should be deterministic and idempotent.