### PR TITLE
Restrict nested steps

### DIFF
--- a/chaos_tests/chaos_test.go
+++ b/chaos_tests/chaos_test.go
@@ -203,6 +203,13 @@ func PostgresChaosMonkey(t *testing.T, ctx context.Context, wg *sync.WaitGroup) 
 			retryCLI(t, "stop postgres", func() error { return stopPostgres(cliPath) }, 60*time.Second)
 		}
 
+		// Let the caller launch DBOS and settle before the first kill.
+		select {
+		case <-time.After(2 * time.Second):
+		case <-ctx.Done():
+			return
+		}
+
 		for {
 			// Check for context cancellation first
 			select {
@@ -271,9 +278,10 @@ func setupDBOS(t *testing.T) dbos.Context {
 	require.NoError(t, err)
 
 	dbosCtx, err := dbos.NewContext(context.Background(), dbos.Config{
-		DatabaseURL: databaseURL,
-		AppName:     "chaos-test",
-		Logger:      slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		DatabaseURL:              databaseURL,
+		AppName:                  "chaos-test",
+		Logger:                   slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		SchedulerPollingInterval: time.Second,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, dbosCtx)
@@ -375,7 +383,9 @@ func TestChaosWorkflow(t *testing.T) {
 	)
 	require.NoError(t, err, "failed to list scheduled workflows")
 
-	assert.Equal(t, len(scheduledWorkflows), 1, "Expected exactly one scheduled workflow execution")
+	// require, not assert: the dereference below panics on an empty list, which
+	// aborts the whole test binary and takes the other chaos tests with it.
+	require.Len(t, scheduledWorkflows, 1, "Expected exactly one scheduled workflow execution")
 
 	// Check the last execution was within 10 seconds -- reasonable for a 1 second schedule and 2 seconds postgres downtime
 	latestWorkflow := scheduledWorkflows[0] // Sorted descending

--- a/dbos/datasource.go
+++ b/dbos/datasource.go
@@ -363,14 +363,16 @@ func RunAsTransaction[R any](ctx Context, ds *DataSource, fn Txn[R], opts ...Ste
 //
 // When the data source shares the system database's pool, the call collapses onto runAsTxn.
 func (c *dbosContext) RunAsTransaction(dbosCtx Context, ds *DataSource, fn TxnFunc, opts ...StepOption) (any, error) {
-	// Reject a transaction nested inside another transaction.
-	// (A transaction nested inside a plain RunAsStep is fine)
-	if ws, ok := c.Value(workflowStateKey).(*workflowState); ok && ws != nil && ws.isWithinTransaction {
+	if ws, ok := c.Value(workflowStateKey).(*workflowState); ok && ws != nil && (ws.isWithinTransaction || ws.isWithinStep) {
 		stepOpts := &stepOptions{}
 		for _, opt := range opts {
 			opt(stepOpts)
 		}
-		return nil, models.NewStepExecutionError(ws.workflowID, stepOpts.stepName, fmt.Errorf("cannot call RunAsTransaction within a transaction"))
+		enclosing := "a step"
+		if ws.isWithinTransaction {
+			enclosing = "a transaction"
+		}
+		return nil, models.NewStepExecutionError(ws.workflowID, stepOpts.stepName, fmt.Errorf("cannot call RunAsTransaction within %s", enclosing))
 	}
 
 	if ds.sameAsSystemDB {
@@ -385,29 +387,6 @@ func (c *dbosContext) RunAsTransaction(dbosCtx Context, ds *DataSource, fn TxnFu
 	}
 	if fn == nil {
 		return nil, models.NewStepExecutionError(prep.WorkflowID, prep.StepOpts.stepName, fmt.Errorf("transaction function cannot be nil"))
-	}
-
-	if prep.IsWithinStep {
-		// Invoked inside an enclosing step: open a real transaction on the user
-		// pool and manage its commit/rollback, but record no durability row.
-		txOpts := TxOptions{IsoLevel: IsoLevelReadCommitted}
-		if prep.StepOpts.txIsoLevel != nil {
-			txOpts.IsoLevel = *prep.StepOpts.txIsoLevel
-		}
-		uncancellableCtx := WithoutCancel(c)
-		tx, err := ds.pool.BeginTx(uncancellableCtx, txOpts)
-		if err != nil {
-			return nil, models.NewStepExecutionError(prep.WorkflowID, prep.StepOpts.stepName, fmt.Errorf("failed to begin transaction: %w", err))
-		}
-		defer tx.Rollback(uncancellableCtx)
-		output, err := fn(withinTransactionContext(c), tx)
-		if err != nil {
-			return nil, err
-		}
-		if err := tx.Commit(uncancellableCtx); err != nil {
-			return nil, models.NewStepExecutionError(prep.WorkflowID, prep.StepOpts.stepName, fmt.Errorf("failed to commit transaction: %w", err))
-		}
-		return output, nil
 	}
 
 	uncancellableCtx := WithoutCancel(c)

--- a/dbos/datasource_test.go
+++ b/dbos/datasource_test.go
@@ -671,18 +671,20 @@ func TestRunAsTransaction(t *testing.T) {
 			fmt.Sprintf(`SELECT count(*) FROM %s WHERE step_id = 2`, ub.completionTable())))
 	})
 
-	// One workflow exercises both ways a RunAsTransaction can be nested:
-	//   - inside a RunAsStep (allowed): the enclosing step holds no transaction,
-	//     so the within-step transaction is the only writer; it commits its
-	//     application write but records no durability row or step of its own.
-	//   - inside another RunAsTransaction (rejected): the inner would open a
-	//     second connection on the same database — deadlocking SQLite's single
-	//     writer, and committing independently of the outer elsewhere — so
-	//     RunAsTransaction returns an error instead. The outer reports it and
-	//     still commits its own write.
-	// The workflow therefore has two durable steps (the RunAsStep and the
-	// top-level transaction) and the user database holds a single completion row
-	// (the top-level transaction's).
+	// One workflow exercises both ways a RunAsTransaction can be nested, and both
+	// are rejected:
+	//   - inside a RunAsStep: passing through would open a real transaction and
+	//     commit its application write while recording no durability row, so the
+	//     enclosing step would re-run the write on every replay. RunAsTransaction
+	//     promises durable-transaction semantics; a position where it cannot
+	//     deliver them is an error rather than a silent downgrade.
+	//   - inside another RunAsTransaction: the inner would open a second
+	//     connection on the same database — deadlocking SQLite's single writer,
+	//     and committing independently of the outer elsewhere.
+	// Both rejections happen before the inner writes anything, and neither
+	// consumes a step ID. The workflow still has two durable steps (the RunAsStep
+	// and the top-level transaction), and the user database holds a single
+	// completion row (the top-level transaction's).
 	t.Run("Nesting", func(t *testing.T) {
 		ctx := setupDBOS(t, setupDBOSOptions{dropDB: true})
 		ub := openUserBackend(t)
@@ -697,16 +699,21 @@ func TestRunAsTransaction(t *testing.T) {
 			})
 		}
 		wf := func(dctx Context, _ string) (string, error) {
-			// Durable step 0: a RunAsStep wrapping a within-step transaction (allowed).
-			if _, err := RunAsStep(dctx, func(c context.Context) (string, error) {
-				return insertTxn(c.(Context), "k_step")
-			}); err != nil {
+			// Durable step 0: a RunAsStep whose body nests a transaction. The
+			// nested call is rejected; the step reports the error and succeeds.
+			stepRes, err := RunAsStep(dctx, func(c context.Context) (string, error) {
+				if _, nerr := insertTxn(c.(Context), "k_step"); nerr != nil {
+					return nerr.Error(), nil
+				}
+				return "unexpected", nil
+			})
+			if err != nil {
 				return "", err
 			}
 			// Durable step 1: a top-level transaction whose fn nests another
 			// transaction. The nested call is rejected; the outer reports the
 			// error but still commits its own write.
-			return RunAsTransaction(dctx, ds, func(c context.Context, tx Tx) (string, error) {
+			txnRes, err := RunAsTransaction(dctx, ds, func(c context.Context, tx Tx) (string, error) {
 				if _, err := tx.Exec(c, ub.rw(`INSERT INTO kv (k, v) VALUES ($1, $2)`), "k_outer", "outer"); err != nil {
 					return "", err
 				}
@@ -715,6 +722,10 @@ func TestRunAsTransaction(t *testing.T) {
 				}
 				return "unexpected", nil
 			})
+			if err != nil {
+				return "", err
+			}
+			return stepRes + "|" + txnRes, nil
 		}
 		RegisterWorkflow(ctx, wf)
 		require.NoError(t, Launch(ctx))
@@ -725,16 +736,17 @@ func TestRunAsTransaction(t *testing.T) {
 		require.NoError(t, err)
 		res, err := h.GetResult()
 		require.NoError(t, err)
+		require.Contains(t, res, "cannot call RunAsTransaction within a step")
 		require.Contains(t, res, "cannot call RunAsTransaction within a transaction")
 
-		// The RunAsStep-nested transaction and the top-level transaction committed;
-		// the transaction-nested one was rejected before it could write.
-		require.Equal(t, "inner", ub.queryString(t, `SELECT v FROM kv WHERE k = 'k_step'`))
+		// Only the top-level transaction committed; both rejected nested calls were
+		// stopped before they could write.
+		require.Equal(t, 0, ub.countRows(t, `SELECT count(*) FROM kv WHERE k = 'k_step'`))
 		require.Equal(t, "outer", ub.queryString(t, `SELECT v FROM kv WHERE k = 'k_outer'`))
 		require.Equal(t, 0, ub.countRows(t, `SELECT count(*) FROM kv WHERE k = 'k_inner'`))
 
-		// Two durable steps (RunAsStep + top-level transaction); the within-step
-		// transaction recorded none, and the rejected nested call consumed no step ID.
+		// Two durable steps (RunAsStep + top-level transaction); neither rejected
+		// nested call consumed a step ID.
 		steps, err := GetWorkflowSteps(ctx, wfID)
 		require.NoError(t, err)
 		require.Len(t, steps, 2)
@@ -965,25 +977,29 @@ func TestRunAsTransactionSharedSystemDB(t *testing.T) {
 		require.Equal(t, 1, ub.countRows(t, `SELECT count(*) FROM kv`))
 	})
 
-	// When a shared-pool data source's RunAsTransaction is invoked inside an
-	// enclosing step, the call routes through runAsTxn's within-step path: it must
-	// still give the user fn a real transaction (on the shared pool) and manage
-	// commit/rollback, while recording no durability row of its own. Runs on every
-	// backend — the enclosing step holds no transaction, so the within-step
-	// transaction is the only writer (no SQLite single-writer contention).
-	t.Run("WithinStep", func(t *testing.T) {
+	// A shared-pool data source's RunAsTransaction invoked inside an enclosing step
+	// is rejected, like the non-shared path. It used to route through runAsTxn's
+	// within-step path, which gave the user fn a real transaction but recorded no
+	// durability row, so the enclosing step re-ran the application write on every
+	// replay. The user fn never runs, so nothing is written and no step is
+	// recorded beyond the enclosing one. Runs on every backend.
+	t.Run("WithinStepRejected", func(t *testing.T) {
 		ctx, ds, ub := setupSharedDBOS(t)
 
 		var txRuns atomic.Int32
 		wf := func(dctx Context, _ string) (string, error) {
 			return RunAsStep(dctx, func(c context.Context) (string, error) {
-				return RunAsTransaction(c.(Context), ds, func(c context.Context, tx Tx) (string, error) {
+				_, nerr := RunAsTransaction(c.(Context), ds, func(c context.Context, tx Tx) (string, error) {
 					txRuns.Add(1)
 					if _, err := tx.Exec(c, ub.rw(`INSERT INTO kv (k, v) VALUES ($1, $2)`), "k1", "inner"); err != nil {
 						return "", err
 					}
 					return "ok", nil
 				})
+				if nerr != nil {
+					return nerr.Error(), nil
+				}
+				return "unexpected", nil
 			})
 		}
 		RegisterWorkflow(ctx, wf)
@@ -996,13 +1012,14 @@ func TestRunAsTransactionSharedSystemDB(t *testing.T) {
 		require.NoError(t, err)
 		res, err := h.GetResult()
 		require.NoError(t, err)
-		require.Equal(t, "ok", res)
-		require.Equal(t, int32(1), txRuns.Load())
+		require.Contains(t, res, "cannot call RunAsTransaction within a step")
 
-		// The within-step transaction committed the application write on the shared pool.
-		require.Equal(t, "inner", ub.queryString(t, `SELECT v FROM kv WHERE k = 'k1'`))
+		// The guard fires before the transaction is opened: the user fn never ran
+		// and nothing was written.
+		require.Equal(t, int32(0), txRuns.Load())
+		require.Equal(t, 0, ub.countRows(t, `SELECT count(*) FROM kv WHERE k = 'k1'`))
 
-		// Only the enclosing RunAsStep is durable; the within-step transaction recorded none.
+		// Only the enclosing RunAsStep is durable; the rejected call recorded none.
 		steps, err := GetWorkflowSteps(ctx, wfID)
 		require.NoError(t, err)
 		require.Len(t, steps, 1)

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -471,8 +471,10 @@ func WithCancelCause(ctx Context) (Context, context.CancelCauseFunc) {
 	return ctx.WithCancelCause()
 }
 
+var errDBOSContextTimeout = fmt.Errorf("DBOS context timeout: %w", context.DeadlineExceeded)
+
 func (c *dbosContext) WithTimeout(_ Context, timeout time.Duration) (Context, context.CancelFunc) {
-	newCtx, cancelFunc := context.WithTimeoutCause(c.ctx, timeout, errors.New("DBOS context timeout"))
+	newCtx, cancelFunc := context.WithTimeoutCause(c.ctx, timeout, errDBOSContextTimeout)
 	return c.clone(newCtx), cancelFunc
 }
 

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/sysdb"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -685,6 +687,60 @@ func TestShutdownJoinsScheduleReconciler(t *testing.T) {
 		t.Fatal("Shutdown did not complete after the schedule reconciler exited")
 	}
 	assert.False(t, dbosCtx.workflowSchedulerStarted.Load())
+}
+
+// flakyScheduleListDB fails the first failures calls to ListSchedules with a
+// retryable connection error, mimicking a Postgres restart, then delegates.
+type flakyScheduleListDB struct {
+	sysdb.SystemDatabase
+	mu       sync.Mutex
+	failures int
+	calls    int
+}
+
+func (s *flakyScheduleListDB) ListSchedules(ctx context.Context, input sysdb.ListSchedulesDBInput) ([]WorkflowSchedule, error) {
+	s.mu.Lock()
+	s.calls++
+	fail := s.calls <= s.failures
+	s.mu.Unlock()
+	if fail {
+		return nil, fmt.Errorf("failed to list schedules: %w", &pgconn.PgError{Code: pgerrcode.AdminShutdown})
+	}
+	return s.SystemDatabase.ListSchedules(ctx, input)
+}
+
+// A database outage overlapping a reconciler pass must not delay installing a
+// schedule until the next poll: with the 30s default interval, a chaos-style
+// restart could otherwise leave a schedule installed on no executor for a long
+// time. The polling interval here is an hour, so the entry can only appear if
+// the single pass retried through the failures itself.
+func TestScheduleReconcilerRetriesTransientListErrors(t *testing.T) {
+	ctx, err := NewContext(context.Background(), Config{
+		AppName:                  "test-reconciler-retry",
+		DatabaseURL:              "sqlite:" + filepath.Join(t.TempDir(), "dbos.db"),
+		SchedulerPollingInterval: time.Hour,
+	})
+	require.NoError(t, err)
+	dbosCtx := ctx.(*dbosContext)
+	t.Cleanup(func() { Shutdown(ctx, time.Second) })
+
+	require.NoError(t, dbosCtx.systemDB.CreateSchedule(dbosCtx, sysdb.CreateScheduleDBInput{
+		ScheduleID:   uuid.New().String(),
+		ScheduleName: "retry-schedule",
+		WorkflowName: "someWorkflow",
+		Schedule:     "* * * * * *",
+		Context:      "null",
+		Status:       ScheduleStatusActive,
+	}))
+
+	flakyDB := &flakyScheduleListDB{SystemDatabase: dbosCtx.systemDB, failures: 2}
+	dbosCtx.systemDB = flakyDB
+
+	dbosCtx.reconcileSchedules()
+
+	_, installed := dbosCtx.installedScheduleEntryID("retry-schedule")
+	assert.True(t, installed, "schedule was not installed after transient list failures")
+	assert.Equal(t, 3, flakyDB.calls, "expected two failed list attempts followed by a success")
 }
 
 func TestContext(t *testing.T) {

--- a/dbos/errors.go
+++ b/dbos/errors.go
@@ -28,9 +28,10 @@ var (
 	// recovery attempts and were moved to the dead-letter queue.
 	ErrDeadLetterQueue = &Error{Code: ErrorCodeDeadLetterQueue}
 	// ErrTimeout matches DBOS timeout errors (e.g. Recv/GetEvent timeouts, GetResult
-	// handle timeouts). A timeout error built from an expired context deadline also
-	// wraps that cause, so errors.Is(err, context.DeadlineExceeded) matches it too,
-	// including for errors read back from the database.
+	// handle timeouts on either handle flavor). Every such error also wraps a stdlib
+	// cause, so errors.Is(err, context.DeadlineExceeded) matches it too -- and
+	// errors.Is(err, context.Canceled) for a wait ended by cancellation rather than
+	// by a deadline -- including for errors read back from the database.
 	ErrTimeout = &Error{Code: ErrorCodeTimeout}
 	// ErrQueueNotFound matches errors referencing a queue that does not exist.
 	ErrQueueNotFound = &Error{Code: ErrorCodeQueueNotFound}

--- a/dbos/errors_test.go
+++ b/dbos/errors_test.go
@@ -1,0 +1,90 @@
+package dbos
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrUnexpectedWorkflowSentinel(t *testing.T) {
+	err := models.NewUnexpectedWorkflowError("wf-id", "Workflow already exists with a different name: a, but the provided name is: b")
+	assert.True(t, errors.Is(err, ErrUnexpectedWorkflow), "NewUnexpectedWorkflowError should match ErrUnexpectedWorkflow")
+	assert.False(t, errors.Is(err, ErrConflictingWorkflowID), "NewUnexpectedWorkflowError should not match ErrConflictingWorkflowID")
+
+	concurrentErr := models.NewWorkflowConflictIDError("wf-id")
+	assert.True(t, errors.Is(concurrentErr, ErrConflictingWorkflowID))
+	assert.False(t, errors.Is(concurrentErr, ErrUnexpectedWorkflow))
+}
+
+func TestInvalidOptionErrors(t *testing.T) {
+	ctx, err := NewContext(context.Background(), Config{
+		AppName:     "test-invalid-option",
+		DatabaseURL: "sqlite:" + filepath.Join(t.TempDir(), "dbos.db"),
+	})
+	require.NoError(t, err)
+	defer Shutdown(ctx, 5*time.Second)
+
+	wf := func(ctx Context, in string) (string, error) { return in, nil }
+	RegisterWorkflow(ctx, wf)
+
+	_, err = RunWorkflow(ctx, wf, "in", WithQueue(nil))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidOption)
+	var dbosErr *Error
+	require.ErrorAs(t, err, &dbosErr)
+	assert.Equal(t, ErrorCodeInvalidOption, dbosErr.Code)
+	assert.Contains(t, dbosErr.Message, "queue cannot be nil")
+
+	err = SetWorkflowDelay(ctx, "some-id", WithDelayDuration(time.Second), WithDelayUntil(time.Now().Add(time.Hour)))
+	require.ErrorIs(t, err, ErrInvalidOption)
+
+	_, err = Enqueue[string](ctx, "", "wf", "in")
+	require.ErrorIs(t, err, ErrInvalidOption)
+}
+
+func roundTripError(t *testing.T, err error) error {
+	t.Helper()
+	s := serializeWorkflowError(nil, err, NewGobSerializer().Name())
+	require.NotEmpty(t, s)
+	return deserializeWorkflowError(&s)
+}
+
+func TestWrappedCauseSurvivesDBRoundTrip(t *testing.T) {
+	t.Run("Canceled", func(t *testing.T) {
+		got := roundTripError(t, models.NewWorkflowCancelledError("wf-id", context.Canceled))
+		assert.True(t, errors.Is(got, ErrWorkflowCancelled))
+		assert.True(t, errors.Is(got, context.Canceled))
+		assert.False(t, errors.Is(got, context.DeadlineExceeded))
+	})
+
+	t.Run("DeadlineExceeded", func(t *testing.T) {
+		got := roundTripError(t, models.NewTimeoutError("wf-id", "step", "", context.DeadlineExceeded))
+		assert.True(t, errors.Is(got, ErrTimeout))
+		assert.True(t, errors.Is(got, context.DeadlineExceeded))
+		assert.False(t, errors.Is(got, context.Canceled))
+	})
+
+	t.Run("ArbitraryCauseNoFalsePositives", func(t *testing.T) {
+		got := roundTripError(t, models.NewWorkflowExecutionError("wf-id", errors.New("boom")))
+		assert.True(t, errors.Is(got, &Error{Code: ErrorCodeWorkflowExecution}))
+		assert.False(t, errors.Is(got, context.Canceled))
+		assert.False(t, errors.Is(got, context.DeadlineExceeded))
+		assert.Contains(t, got.Error(), "boom")
+	})
+
+	t.Run("OldPayloadWithoutCauseKind", func(t *testing.T) {
+		// Zero-value CauseKind gob-encodes identically to a pre-CauseKind payload.
+		old := &Error{Message: "Workflow wf-id was cancelled", Code: ErrorCodeWorkflowCancelled, WorkflowID: "wf-id"}
+		got := roundTripError(t, old)
+		require.NotNil(t, got)
+		assert.True(t, errors.Is(got, ErrWorkflowCancelled))
+		assert.False(t, errors.Is(got, context.Canceled))
+		assert.False(t, errors.Is(got, context.DeadlineExceeded))
+	})
+}

--- a/dbos/internal/models/errors.go
+++ b/dbos/internal/models/errors.go
@@ -372,9 +372,10 @@ func NewScheduleNotFoundError(scheduleName string) *Error {
 	}
 }
 
-// NewTimeoutError builds a timeout error. When the timeout came from an expired
-// context, pass context.Cause(ctx) as cause so errors.Is(err, context.DeadlineExceeded)
-// matches via Unwrap; pass nil for timeouts with no context deadline behind them.
+// NewTimeoutError builds a timeout error. Always pass a cause: it is what makes
+// errors.Is(err, context.DeadlineExceeded) match via Unwrap, and every DBOS
+// timeout is expected to match both ErrTimeout and a stdlib sentinel.
+// The causes considered are context.DeadlineExceeded or context.Canceled.
 func NewTimeoutError(workflowID, stepName, message string, cause error) *Error {
 	msg := "Operation timed out"
 	if stepName != "" {

--- a/dbos/internal/sysdb/dialect.go
+++ b/dbos/internal/sysdb/dialect.go
@@ -1,6 +1,7 @@
 package sysdb
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -232,6 +233,15 @@ func (PostgresDialect) IsForeignKeyViolation(err error) bool {
 // entire transaction and are opted in per call site via IsRetryableTransaction.
 func (PostgresDialect) IsRetryable(err error, logger *slog.Logger) bool {
 	if err == nil {
+		return false
+	}
+	// context.DeadlineExceeded satisfies net.Error, so it would fall through to the
+	// net.Error check below and read as a transient driver failure. It is not one:
+	// either a caller's context expired (retrying can only fail again), or a DBOS
+	// timeout error wraps it as its cause -- Recv/GetEvent/handle timeouts are
+	// semantic outcomes on their own deadline, and retrying them loops forever
+	// against a live context. context.Canceled is excluded for the same reason.
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return false
 	}
 	// pgx surfaces ErrTxClosed for ops on a tx that has already finalized

--- a/dbos/internal/sysdb/sysdb_test.go
+++ b/dbos/internal/sysdb/sysdb_test.go
@@ -182,3 +182,27 @@ func TestGetQueuePartitionsSurfacesRowsErr(t *testing.T) {
 		t.Fatalf("GetQueuePartitions error = %v; want wrapped %v", err, connErr)
 	}
 }
+
+// context.DeadlineExceeded satisfies net.Error, so IsRetryable's trailing
+// net.Error check used to classify it -- and anything wrapping it -- as a
+// transient driver failure. DBOS builds its own timeout errors on top of that
+// cause, so a Recv/GetEvent timeout would be retried forever by the infinite
+// system-database retrier while the workflow context was still live.
+func TestIsRetryableRejectsContextErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"deadline", context.DeadlineExceeded},
+		{"canceled", context.Canceled},
+		{"wrapped deadline", models.NewTimeoutError("wf", "DBOS.recv", "no message received", context.DeadlineExceeded)},
+		{"wrapped canceled", models.NewTimeoutError("wf", "", "interrupted", context.Canceled)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if (PostgresDialect{}).IsRetryable(tc.err, nil) {
+				t.Fatalf("IsRetryable(%v) = true; want false", tc.err)
+			}
+		})
+	}
+}

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -2542,6 +2542,19 @@ type AwaitWorkflowResultOutput struct {
 	ErrStr        *string
 }
 
+// contextInterruptionError restates a context interruption as a DBOS *Error that
+// carries a cause (ctx.Err() and context.Cause(ctx) in the message if it exists).
+func contextInterruptionError(ctx context.Context, workflowID, message string) error {
+	ctxErr := ctx.Err()
+	if ctxErr == nil {
+		return nil
+	}
+	if cause := context.Cause(ctx); cause != nil && !errors.Is(cause, ctxErr) {
+		message = fmt.Sprintf("%s (%s)", message, cause)
+	}
+	return models.NewTimeoutError(workflowID, "", message, ctxErr)
+}
+
 // AwaitWorkflowResult polls the workflow's row until it reaches a terminal
 // status. A missing row normally means the workflow has not been inserted yet,
 // so the poll keeps waiting for it to appear. Callers that know the row must
@@ -2556,7 +2569,7 @@ func (s *SysDB) AwaitWorkflowResult(ctx context.Context, workflowID string, poll
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, contextInterruptionError(ctx, workflowID, "timed out awaiting workflow result")
 		default:
 		}
 
@@ -2573,6 +2586,9 @@ func (s *SysDB) AwaitWorkflowResult(ctx context.Context, workflowID string, poll
 				}
 				time.Sleep(pollInterval)
 				continue
+			}
+			if ctx.Err() != nil {
+				return nil, contextInterruptionError(ctx, workflowID, "timed out awaiting workflow result")
 			}
 			return nil, fmt.Errorf("failed to query workflow status: %w", err)
 		}
@@ -6028,9 +6044,10 @@ func Retry(ctx context.Context, fn func() error, options ...RetryOption) error {
 
 	onCancel := func() error {
 		if config.logger != nil {
-			config.logger.Debug("Retry operation cancelled", "error", ctx.Err())
+			config.logger.Debug("Retry operation cancelled", "error", ctx.Err(), "cause", context.Cause(ctx))
 		}
-		return ctx.Err()
+		// Coded error rather than a bare ctx.Err(), so we can store the cause and restore it after a DB roundtrip
+		return contextInterruptionError(ctx, "", "retried operation interrupted")
 	}
 
 	return RetryLoop(ctx, sched, fn, decide, onRetry, onCancel)

--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -256,15 +256,6 @@ func WithQueueBasePollingInterval(interval time.Duration) QueueOption {
 	}
 }
 
-// WithQueueMaxPollingInterval sets the maximum polling interval for the queue.
-// The queue will never poll slower than this value, even when backing off due to errors.
-// If not set (0), the queue will use the default max polling interval during creation.
-func WithQueueMaxPollingInterval(interval time.Duration) QueueOption {
-	return func(q *workflowQueue) {
-		q.maxPollingInterval = interval
-	}
-}
-
 // WithQueueOnConflict sets the conflict resolution policy used by RegisterQueue
 // when a queue with the same name already exists in the system database.
 func WithQueueOnConflict(policy QueueConflictResolution) QueueOption {
@@ -329,13 +320,6 @@ func (c *dbosContext) RegisterQueue(_ Client, name string, options ...QueueOptio
 	}
 	for _, option := range options {
 		option(&q)
-	}
-	// The maximum polling interval is a worker-local backoff ceiling that is not
-	// persisted for database-backed queues (the worker derives it from the base
-	// interval). Ignore an explicit WithQueueMaxPollingInterval override and warn.
-	if q.maxPollingInterval != _DEFAULT_MAX_POLLING_INTERVAL {
-		c.logger.Warn("WithQueueMaxPollingInterval is ignored for database-backed queues; the maximum polling interval is derived from the base polling interval", "queue_name", name)
-		q.maxPollingInterval = _DEFAULT_MAX_POLLING_INTERVAL
 	}
 	if err := validateQueueConfig(&q); err != nil {
 		return nil, err

--- a/dbos/queues_test.go
+++ b/dbos/queues_test.go
@@ -1840,11 +1840,9 @@ func TestQueuePollingIntervals(t *testing.T) {
 		basePollingInterval := 2 * time.Second
 		// Database-backed queues persist only the base polling interval. The max
 		// polling interval is a worker-local backoff ceiling the queue worker derives
-		// from the base at runtime, so RegisterQueue ignores WithQueueMaxPollingInterval
-		// (logging a warning) and it never surfaces on the handle.
+		// from the base at runtime, so it never surfaces on the handle.
 		queue, err := registerWFQ(ctx, "polling-custom-queue",
-			WithQueueBasePollingInterval(basePollingInterval),
-			WithQueueMaxPollingInterval(5*time.Second))
+			WithQueueBasePollingInterval(basePollingInterval))
 		require.NoError(t, err)
 		require.Equal(t, basePollingInterval, queue.basePollingInterval)
 		require.Zero(t, queue.maxPollingInterval)

--- a/dbos/scheduler.go
+++ b/dbos/scheduler.go
@@ -342,19 +342,26 @@ func (c *dbosContext) maybeAutomaticBackfill(sched *WorkflowSchedule) {
 		return
 	}
 	c.logger.Info("performing automatic backfill", "schedule", sched.ScheduleName, "start", start, "end", end)
-	if _, err := c.systemDB.BackfillSchedule(c, sysdb.BackfillScheduleDBInput{
-		ScheduleName: sched.ScheduleName,
-		Schedule:     sched.Schedule,
-		StartTime:    start,
-		EndTime:      end,
-	}); err != nil {
+	if _, err := sysdb.RetryWithResult(c, func() ([]string, error) {
+		return c.systemDB.BackfillSchedule(c, sysdb.BackfillScheduleDBInput{
+			ScheduleName: sched.ScheduleName,
+			Schedule:     sched.Schedule,
+			StartTime:    start,
+			EndTime:      end,
+		})
+	}, sysdb.WithRetrierLogger(c.logger)); err != nil {
 		c.logger.Error("automatic backfill failed", "schedule", sched.ScheduleName, "error", err)
 	}
 }
 
 func (c *dbosContext) reconcileSchedules() {
-	schedules, err := c.systemDB.ListSchedules(c, sysdb.ListSchedulesDBInput{})
+	schedules, err := sysdb.RetryWithResult(c, func() ([]WorkflowSchedule, error) {
+		return c.systemDB.ListSchedules(c, sysdb.ListSchedulesDBInput{})
+	}, sysdb.WithRetrierLogger(c.logger))
 	if err != nil {
+		if c.Err() != nil {
+			return // shutting down
+		}
 		c.logger.Warn("failed to list schedules for reconciler", "error", err)
 		return
 	}

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -2737,6 +2737,7 @@ func (c *dbosContext) runAsTxn(_ Context, fn TxnFunc, opts ...StepOption) (any, 
 
 // Go runs a step inside a Go routine and returns a channel to receive the result.
 // Go generates a deterministic step ID for the step before running the step in a routine, since goroutines are not deterministic.
+// Go must be called from a workflow, not from inside a step body.
 // Example:
 //
 //	resultChan, err := dbos.Go(ctx, func(ctx context.Context) (string, error) {
@@ -2809,6 +2810,9 @@ func (c *dbosContext) Go(ctx Context, fn StepFunc, opts ...StepOption) (<-chan S
 	wfState, ok := ctx.Value(workflowStateKey).(*workflowState)
 	if !ok || wfState == nil {
 		return nil, models.NewStepExecutionError("", "", errors.New("workflow state not found in context: are you running this step within a workflow?"))
+	}
+	if wfState.isWithinStep {
+		return nil, models.NewStepExecutionError(wfState.workflowID, "DBOS.go", errors.New("cannot call Go within a step"))
 	}
 	opts = append(opts, withNextStepID(wfState.nextStepID()))
 

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -199,6 +199,9 @@ func checkGetResultExecution[R any](dbosCtx context.Context) (R, bool, error) {
 	if !isWithinWorkflow {
 		return *new(R), false, nil
 	}
+	if workflowState.isWithinStep {
+		return *new(R), false, models.NewStepExecutionError(workflowState.workflowID, "DBOS.getResult", fmt.Errorf("cannot call GetResult within a step"))
+	}
 	recordedOutputs, err := sysdb.RetryWithResult(dbosCtx, func() (*sysdb.RecordedResult, error) {
 		uncancellableCtx := context.WithoutCancel(dbosCtx)
 		return dbosCtx.(*dbosContext).systemDB.CheckOperationExecution(uncancellableCtx, sysdb.CheckOperationExecutionDBInput{

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1642,7 +1642,11 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 				c.logger.Info("Workflow was cancelled. Waiting for cancel function to complete", "workflow_id", workflowID)
 				<-cancelFuncCompleted
 				removeActive()
-				awaitExistingOutcome(err)
+				// Join the context error into the cause: fn may have learned about the
+				// cancellation by reading the CANCELLED row (a status carries no cause)
+				// rather than from the context, and the run's own reason must not depend
+				// on which of the two noticed first.
+				awaitExistingOutcome(errors.Join(err, workflowCtx.Err()))
 				return
 			}
 			if workflowCtx.Err() != nil && isCancellationError(err) {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -3260,6 +3260,19 @@ func (c *dbosContext) SetEvent(_ Context, key string, message any, opts ...SetEv
 		return fmt.Errorf("failed to serialize event value: %w", err)
 	}
 
+	if wfState, ok := c.Value(workflowStateKey).(*workflowState); ok && wfState != nil && wfState.isWithinStep {
+		uncancellableCtx := WithoutCancel(c)
+		return sysdb.Retry(c, func() error {
+			return c.systemDB.SetEvent(uncancellableCtx, sysdb.WorkflowSetEventInput{
+				Key:           key,
+				Message:       encodedMessage,
+				Serialization: evtSer.Name(),
+				WorkflowID:    wfState.workflowID,
+				StepID:        wfState.stepID,
+			})
+		}, sysdb.WithRetrierLogger(c.logger))
+	}
+
 	_, err = runAsTxn(c, func(ctx context.Context, tx Tx) (any, error) {
 		wfState, ok := ctx.Value(workflowStateKey).(*workflowState)
 		if !ok || wfState == nil {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -364,6 +364,7 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 		defer cancel()
 	}
 
+	// Here, both the transient DB errors and awaiting the workflow can timeout
 	awaitResult, awaitErr := sysdb.RetryWithResult(ctx, func() (*sysdb.AwaitWorkflowResultOutput, error) {
 		return h.dbosContext.(*dbosContext).systemDB.AwaitWorkflowResult(ctx, h.workflowID, options.pollInterval, false)
 	}, sysdb.WithRetrierLogger(h.dbosContext.(*dbosContext).logger))
@@ -3144,7 +3145,7 @@ func (c *dbosContext) Recv(_ Context, topic string, timeout time.Duration) (any,
 		}
 		output := rawStepOutput{value: message, serialization: serialization}
 		if message == nil && timeoutOccurred {
-			return output, models.NewTimeoutError(workflowID, "DBOS.recv", fmt.Sprintf("no message received within %v", timeout), nil)
+			return output, models.NewTimeoutError(workflowID, "DBOS.recv", fmt.Sprintf("no message received within %v", timeout), context.DeadlineExceeded)
 		}
 		return output, nil
 	}, WithStepName("DBOS.recv"), withNextStepID(stepID))
@@ -3396,7 +3397,7 @@ func (c *dbosContext) GetEvent(_ Client, targetWorkflowID, key string, timeout t
 			serialization = *evtSerialization
 		}
 		if value == nil && timeoutOccurred {
-			return nil, models.NewTimeoutError("", "DBOS.getEvent", fmt.Sprintf("no event found for key '%s' within %v", key, timeout), nil)
+			return nil, models.NewTimeoutError("", "DBOS.getEvent", fmt.Sprintf("no event found for key '%s' within %v", key, timeout), context.DeadlineExceeded)
 		}
 		return &getEventResult{value: value, serialization: serialization}, nil
 	}
@@ -3414,7 +3415,7 @@ func (c *dbosContext) GetEvent(_ Client, targetWorkflowID, key string, timeout t
 		}
 		output := rawStepOutput{value: value, serialization: serialization}
 		if value == nil && timeoutOccurred {
-			return output, models.NewTimeoutError(workflowID, "DBOS.getEvent", fmt.Sprintf("no event found for key '%s' within %v", key, timeout), nil)
+			return output, models.NewTimeoutError(workflowID, "DBOS.getEvent", fmt.Sprintf("no event found for key '%s' within %v", key, timeout), context.DeadlineExceeded)
 		}
 		return output, nil
 	}, WithStepName("DBOS.getEvent"), withNextStepID(stepID))

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -5398,10 +5398,10 @@ func (c *dbosContext) GetWorkflowAggregates(_ Client, input GetWorkflowAggregate
 	workflowState, ok := c.Value(workflowStateKey).(*workflowState)
 	isWithinWorkflow := ok && workflowState != nil
 	if isWithinWorkflow {
-		return runAsTxn(c, func(ctx context.Context, tx Tx) ([]WorkflowAggregateRow, error) {
-			in := dbInput
-			in.Tx = tx
-			return c.systemDB.GetWorkflowAggregates(ctx, in)
+		return RunAsStep(c, func(ctx context.Context) ([]WorkflowAggregateRow, error) {
+			return sysdb.RetryWithResult(ctx, func() ([]WorkflowAggregateRow, error) {
+				return c.systemDB.GetWorkflowAggregates(ctx, dbInput)
+			}, sysdb.WithRetrierLogger(c.logger))
 		}, WithStepName("DBOS.getWorkflowAggregates"))
 	}
 	return sysdb.RetryWithResult(c, func() ([]WorkflowAggregateRow, error) {
@@ -5465,10 +5465,10 @@ func (c *dbosContext) GetStepAggregates(_ Client, input GetStepAggregatesInput) 
 	workflowState, ok := c.Value(workflowStateKey).(*workflowState)
 	isWithinWorkflow := ok && workflowState != nil
 	if isWithinWorkflow {
-		return runAsTxn(c, func(ctx context.Context, tx Tx) ([]StepAggregateRow, error) {
-			in := dbInput
-			in.Tx = tx
-			return c.systemDB.GetStepAggregates(ctx, in)
+		return RunAsStep(c, func(ctx context.Context) ([]StepAggregateRow, error) {
+			return sysdb.RetryWithResult(ctx, func() ([]StepAggregateRow, error) {
+				return c.systemDB.GetStepAggregates(ctx, dbInput)
+			}, sysdb.WithRetrierLogger(c.logger))
 		}, WithStepName("DBOS.getStepAggregates"))
 	}
 	return sysdb.RetryWithResult(c, func() ([]StepAggregateRow, error) {
@@ -5888,10 +5888,10 @@ func (c *dbosContext) GetSchedule(_ Client, scheduleName string) (WorkflowSchedu
 	var schedules []WorkflowSchedule
 	var err error
 	if state, inWorkflow := c.Value(workflowStateKey).(*workflowState); inWorkflow && state != nil {
-		schedules, err = runAsTxn(c, func(ctx context.Context, tx Tx) ([]WorkflowSchedule, error) {
-			in := dbInput
-			in.Tx = tx
-			return c.systemDB.ListSchedules(ctx, in)
+		schedules, err = RunAsStep(c, func(ctx context.Context) ([]WorkflowSchedule, error) {
+			return sysdb.RetryWithResult(ctx, func() ([]WorkflowSchedule, error) {
+				return c.systemDB.ListSchedules(ctx, dbInput)
+			}, sysdb.WithRetrierLogger(c.logger))
 		}, WithStepName("DBOS.getSchedule"))
 	} else {
 		schedules, err = sysdb.RetryWithResult(c, func() ([]WorkflowSchedule, error) {
@@ -5933,10 +5933,10 @@ func (c *dbosContext) ListSchedules(_ Client, opts ...ListSchedulesOption) ([]Wo
 		ScheduleNamePrefixes: o.ScheduleNamePrefixes,
 	}
 	if state, inWorkflow := c.Value(workflowStateKey).(*workflowState); inWorkflow && state != nil {
-		return runAsTxn(c, func(ctx context.Context, tx Tx) ([]WorkflowSchedule, error) {
-			in := dbInput
-			in.Tx = tx
-			return c.systemDB.ListSchedules(ctx, in)
+		return RunAsStep(c, func(ctx context.Context) ([]WorkflowSchedule, error) {
+			return sysdb.RetryWithResult(ctx, func() ([]WorkflowSchedule, error) {
+				return c.systemDB.ListSchedules(ctx, dbInput)
+			}, sysdb.WithRetrierLogger(c.logger))
 		}, WithStepName("DBOS.listSchedules"))
 	}
 	return sysdb.RetryWithResult(c, func() ([]WorkflowSchedule, error) {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -3520,6 +3520,19 @@ func (c *dbosContext) WriteStream(_ Context, key string, value any, opts ...Writ
 		return fmt.Errorf("failed to serialize stream value: %w", err)
 	}
 
+	if wfState, ok := c.Value(workflowStateKey).(*workflowState); ok && wfState != nil && wfState.isWithinStep {
+		uncancellableCtx := WithoutCancel(c)
+		return sysdb.Retry(c, func() error {
+			return c.systemDB.WriteStream(uncancellableCtx, sysdb.WriteStreamDBInput{
+				Key:           key,
+				Value:         encodedValue,
+				Serialization: ser.Name(),
+				WorkflowID:    wfState.workflowID,
+				StepID:        wfState.stepID,
+			})
+		}, sysdb.WithRetrierLogger(c.logger))
+	}
+
 	_, err = runAsTxn(c, func(ctx context.Context, tx Tx) (any, error) {
 		wfState, ok := ctx.Value(workflowStateKey).(*workflowState)
 		if !ok || wfState == nil {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -2615,18 +2615,6 @@ func runAsTxn[R any](ctx Context, fn Txn[R], opts ...StepOption) (R, error) {
 	return typedResult, err
 }
 
-// withinTransactionContext returns a child context whose workflow state is
-// flagged as executing inside a data source transaction.
-func withinTransactionContext(c *dbosContext) Context {
-	var state workflowState
-	if existing, ok := c.Value(workflowStateKey).(*workflowState); ok && existing != nil {
-		state = *existing
-	}
-	state.isWithinStep = true
-	state.isWithinTransaction = true
-	return WithValue(c, workflowStateKey, &state)
-}
-
 func (c *dbosContext) runAsTxn(_ Context, fn TxnFunc, opts ...StepOption) (any, error) {
 	prep, err := prepareStepExecution(c, opts)
 	if err != nil {
@@ -2635,26 +2623,9 @@ func (c *dbosContext) runAsTxn(_ Context, fn TxnFunc, opts ...StepOption) (any, 
 	if fn == nil {
 		return nil, models.NewStepExecutionError(prep.WorkflowID, prep.StepOpts.stepName, fmt.Errorf("step function cannot be nil"))
 	}
+
 	if prep.IsWithinStep {
-		// Invoked inside an enclosing step: manage the transaction but record no durability
-		txOpts := TxOptions{IsoLevel: IsoLevelReadCommitted}
-		if prep.StepOpts.txIsoLevel != nil {
-			txOpts.IsoLevel = *prep.StepOpts.txIsoLevel
-		}
-		uncancellableCtx := WithoutCancel(c)
-		tx, err := c.systemDB.Pool().BeginTx(uncancellableCtx, txOpts)
-		if err != nil {
-			return nil, models.NewStepExecutionError(prep.WorkflowID, prep.StepOpts.stepName, fmt.Errorf("failed to begin transaction: %w", err))
-		}
-		defer tx.Rollback(uncancellableCtx)
-		output, err := fn(withinTransactionContext(c), tx)
-		if err != nil {
-			return nil, err
-		}
-		if err := tx.Commit(uncancellableCtx); err != nil {
-			return nil, models.NewStepExecutionError(prep.WorkflowID, prep.StepOpts.stepName, fmt.Errorf("failed to commit transaction: %w", err))
-		}
-		return output, nil
+		return nil, models.NewStepExecutionError(prep.WorkflowID, prep.StepOpts.stepName, fmt.Errorf("cannot call %s within a step", prep.StepOpts.stepName))
 	}
 
 	uncancellableCtx := WithoutCancel(c)

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -940,8 +940,6 @@ func TestSteps(t *testing.T) {
 			switch input.Op {
 			case "setEvent":
 				err = SetEvent(dbosStepCtx, "evt-key", "evt-value")
-			case "writeStream":
-				err = WriteStream(dbosStepCtx, "stream-key", "stream-value")
 			case "closeStream":
 				err = CloseStream(dbosStepCtx, "stream-key")
 			case "cancelWorkflow":
@@ -1020,6 +1018,9 @@ func TestSteps(t *testing.T) {
 			}
 			if _, err := GetSchedule(dbosStepCtx, scheduleForStepTests); err != nil {
 				return "", fmt.Errorf("getSchedule: %w", err)
+			}
+			if err := WriteStream(dbosStepCtx, "stream-from-step", "v"); err != nil {
+				return "", fmt.Errorf("writeStream: %w", err)
 			}
 			return "reads-ok", nil
 		}, WithStepName("readsInStep"))
@@ -1366,9 +1367,10 @@ func TestSteps(t *testing.T) {
 		require.NotNil(t, steps[0].Error, "expected the enclosing step to record the guard error")
 	})
 
-	// Read-only system-database operations all go through RunAsStep, so nesting one
-	// inside a step body is a plain function call: it runs, records no checkpoint of
-	// its own, and consumes no step ID -- exactly like a step within a step.
+	// Operations that are allowed inside a step body: every read (they go through
+	// RunAsStep) plus WriteStream (a dedicated from-step path). Nesting one is a
+	// plain function call: it runs, records no checkpoint of its own, and consumes
+	// no step ID -- exactly like a step within a step.
 	t.Run("ReadOnlyOpsAllowedWithinStep", func(t *testing.T) {
 		handle, err := RunWorkflow(dbosCtx, readsInStepWf, "")
 		require.NoError(t, err, "failed to start workflow")
@@ -1394,7 +1396,6 @@ func TestSteps(t *testing.T) {
 
 		for _, tc := range []struct{ op, stepName string }{
 			{"setEvent", "DBOS.setEvent"},
-			{"writeStream", "DBOS.writeStream"},
 			{"closeStream", "DBOS.closeStream"},
 			{"cancelWorkflow", "DBOS.cancelWorkflow"},
 			{"cancelWorkflows", "DBOS.cancelWorkflows"},

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -880,6 +880,43 @@ func TestSteps(t *testing.T) {
 
 	RegisterWorkflow(dbosCtx, customNameWorkflow)
 
+	// Fixtures for GetResultWithinStepIsNotACheckpoint: getResultTargetWf is the
+	// workflow whose result is awaited from inside a step body; awaitInStepWf does
+	// the awaiting and then runs an ordinary sibling step after it.
+	getResultTargetWf := func(_ Context, input string) (string, error) {
+		return input + "-done", nil
+	}
+	RegisterWorkflow(dbosCtx, getResultTargetWf)
+
+	awaitInStepWf := func(ctx Context, targetID string) (string, error) {
+		awaited, err := RunAsStep(ctx, func(stepCtx context.Context) (string, error) {
+			// A step body only receives a context.Context; reaching a DBOS
+			// operation from there means asserting it back to dbos.Context,
+			// which hands RetrieveWorkflow the step-scoped workflow state.
+			dbosStepCtx, ok := stepCtx.(Context)
+			if !ok {
+				return "", fmt.Errorf("expected step context to be a dbos.Context, got %T", stepCtx)
+			}
+			handle, err := RetrieveWorkflow[string](dbosStepCtx, targetID)
+			if err != nil {
+				return "", fmt.Errorf("failed to retrieve target workflow: %w", err)
+			}
+			return handle.GetResult()
+		}, WithStepName("awaitInStep"))
+		if err != nil {
+			return "", fmt.Errorf("awaitInStep failed: %w", err)
+		}
+
+		sibling, err := RunAsStep(ctx, func(_ context.Context) (string, error) {
+			return "sibling", nil
+		}, WithStepName("siblingStep"))
+		if err != nil {
+			return "", fmt.Errorf("siblingStep failed: %w", err)
+		}
+		return awaited + "/" + sibling, nil
+	}
+	RegisterWorkflow(dbosCtx, awaitInStepWf)
+
 	// A workflow that mistakenly runs its step with the outer executor context
 	// (captured from the closure) instead of the workflow context it is handed.
 	wrongCtxWorkflow := func(_ Context, input string) (string, error) {
@@ -1163,6 +1200,54 @@ func TestSteps(t *testing.T) {
 		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
 		require.NoError(t, err, "failed to list steps")
 		require.Len(t, steps, 1, "expected 1 step, got %d", len(steps))
+	})
+
+	// Awaiting a workflow handle from inside a step body is rejected, like Send,
+	// Recv and Debounce are.
+	//
+	// Spawning a child from within a step is blocked, but RetrieveWorkflow is
+	// allowed -- RunAsStep passes straight through when isWithinStep -- and the
+	// polling handle it returns is bound to the context it was called with. Called
+	// with the step context, that handle's workflow state is the *step's* own
+	// state, whose stepID is the enclosing step's function_id, not the workflow's
+	// step counter. Checkpointing DBOS.getResult at stepID+1 from there would
+	// collide twice over:
+	//
+	//   - nextStepID() mutates the step's own stepID in place from N to N+1, and
+	//     RunAsStep reads it only after the body returns, so the enclosing step
+	//     would checkpoint itself at N+1, on top of the DBOS.getResult row.
+	//   - N+1 is also the ID the next sibling step of the workflow claims.
+	//
+	// Rejecting the await keeps both IDs intact, so the workflow fails with a clear
+	// ErrorCodeStepExecution instead of an ErrorCodeUnexpectedStep determinism
+	// error from the collision.
+	t.Run("GetResultWithinStepIsRejected", func(t *testing.T) {
+		targetHandle, err := RunWorkflow(dbosCtx, getResultTargetWf, "target")
+		require.NoError(t, err, "failed to start target workflow")
+		targetResult, err := targetHandle.GetResult()
+		require.NoError(t, err, "failed to get target workflow result")
+		require.Equal(t, "target-done", targetResult)
+
+		handle, err := RunWorkflow(dbosCtx, awaitInStepWf, targetHandle.GetWorkflowID())
+		require.NoError(t, err, "failed to start awaiting workflow")
+		_, err = handle.GetResult()
+		require.Error(t, err, "expected awaiting a handle inside a step to be rejected")
+
+		var dbosErr *Error
+		require.ErrorAs(t, err, &dbosErr)
+		require.Equal(t, ErrorCodeStepExecution, dbosErr.Code)
+		require.ErrorContains(t, err, "cannot call GetResult within a step")
+
+		// The guard fires before any checkpoint, so the only recorded step is the
+		// enclosing one, still at function_id 0 and carrying the error. Nothing was
+		// written at function_id 1: no DBOS.getResult row, and the sibling step is
+		// never reached because the workflow fails first.
+		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps")
+		require.Len(t, steps, 1, "expected exactly 1 recorded step, got %+v", steps)
+		require.Equal(t, 0, steps[0].StepID)
+		require.Equal(t, "awaitInStep", steps[0].StepName)
+		require.NotNil(t, steps[0].Error, "expected the enclosing step to record the guard error")
 	})
 
 	t.Run("StepRetryWithExponentialBackoff", func(t *testing.T) {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -938,8 +938,6 @@ func TestSteps(t *testing.T) {
 			}
 			var err error
 			switch input.Op {
-			case "setEvent":
-				err = SetEvent(dbosStepCtx, "evt-key", "evt-value")
 			case "closeStream":
 				err = CloseStream(dbosStepCtx, "stream-key")
 			case "cancelWorkflow":
@@ -1025,6 +1023,9 @@ func TestSteps(t *testing.T) {
 			}
 			if err := WriteStream(dbosStepCtx, "stream-from-step", "v"); err != nil {
 				return "", fmt.Errorf("writeStream: %w", err)
+			}
+			if err := SetEvent(dbosStepCtx, "event-from-step", "v"); err != nil {
+				return "", fmt.Errorf("setEvent: %w", err)
 			}
 			return "reads-ok", nil
 		}, WithStepName("readsInStep"))
@@ -1372,9 +1373,9 @@ func TestSteps(t *testing.T) {
 	})
 
 	// Operations that are allowed inside a step body: every read (they go through
-	// RunAsStep) plus WriteStream (a dedicated from-step path). Nesting one is a
-	// plain function call: it runs, records no checkpoint of its own, and consumes
-	// no step ID -- exactly like a step within a step.
+	// RunAsStep) plus WriteStream and SetEvent (dedicated from-step paths). Nesting
+	// one is a plain function call: it runs, records no checkpoint of its own, and
+	// consumes no step ID -- exactly like a step within a step.
 	t.Run("ReadOnlyOpsAllowedWithinStep", func(t *testing.T) {
 		handle, err := RunWorkflow(dbosCtx, readsInStepWf, "")
 		require.NoError(t, err, "failed to start workflow")
@@ -1406,7 +1407,6 @@ func TestSteps(t *testing.T) {
 		// opName is the name the rejection message reports: the internal step name
 		// for the runAsTxn ops, the exported API name for Go.
 		for _, tc := range []struct{ op, opName string }{
-			{"setEvent", "DBOS.setEvent"},
 			{"closeStream", "DBOS.closeStream"},
 			{"cancelWorkflow", "DBOS.cancelWorkflow"},
 			{"cancelWorkflows", "DBOS.cancelWorkflows"},

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -917,6 +917,115 @@ func TestSteps(t *testing.T) {
 	}
 	RegisterWorkflow(dbosCtx, awaitInStepWf)
 
+	// A schedule the within-step tests can read and update. PauseSchedule and
+	// ResumeSchedule read it before writing, and GetSchedule needs a real target, so
+	// it must exist before either test runs. The cron is a once-a-year date so the
+	// scheduler never fires it during the test.
+	const scheduleForStepTests = "sched-in-step"
+
+	// Fixture for TransactionalOpsRejectedWithinStep: invokes one system-database
+	// operation from inside a step body and reports the error it gets back, so the
+	// step itself succeeds and the assertions can read the message.
+	type opInStepInput struct {
+		Op       string
+		TargetID string
+	}
+	opInStepWf := func(ctx Context, input opInStepInput) (string, error) {
+		return RunAsStep(ctx, func(stepCtx context.Context) (string, error) {
+			dbosStepCtx, ok := stepCtx.(Context)
+			if !ok {
+				return "", fmt.Errorf("expected step context to be a dbos.Context, got %T", stepCtx)
+			}
+			var err error
+			switch input.Op {
+			case "setEvent":
+				err = SetEvent(dbosStepCtx, "evt-key", "evt-value")
+			case "writeStream":
+				err = WriteStream(dbosStepCtx, "stream-key", "stream-value")
+			case "closeStream":
+				err = CloseStream(dbosStepCtx, "stream-key")
+			case "cancelWorkflow":
+				err = CancelWorkflow(dbosStepCtx, input.TargetID)
+			case "cancelWorkflows":
+				err = CancelWorkflows(dbosStepCtx, []string{input.TargetID})
+			case "setWorkflowAttributes":
+				err = SetWorkflowAttributes(dbosStepCtx, input.TargetID, map[string]any{"k": "v"})
+			case "setWorkflowDelay":
+				err = SetWorkflowDelay(dbosStepCtx, input.TargetID, WithDelayDuration(time.Second))
+			case "deleteWorkflows":
+				err = DeleteWorkflows(dbosStepCtx, []string{input.TargetID})
+			case "resumeWorkflow":
+				_, err = ResumeWorkflow[string](dbosStepCtx, input.TargetID)
+			case "forkWorkflow":
+				_, err = ForkWorkflow[string](dbosStepCtx, ForkWorkflowInput{OriginalWorkflowID: input.TargetID})
+			case "createSchedule":
+				err = CreateSchedule(dbosStepCtx, ScheduleSpec{
+					ScheduleName: scheduleForStepTests,
+					Schedule:     "*/1 * * * * *",
+					WorkflowName: "some-workflow",
+				})
+			case "pauseSchedule":
+				err = PauseSchedule(dbosStepCtx, scheduleForStepTests)
+			case "resumeSchedule":
+				err = ResumeSchedule(dbosStepCtx, scheduleForStepTests)
+			case "deleteSchedule":
+				err = DeleteSchedule(dbosStepCtx, scheduleForStepTests)
+			default:
+				return "", fmt.Errorf("unknown op %q", input.Op)
+			}
+			if err != nil {
+				return err.Error(), nil
+			}
+			return "unexpected: no error", nil
+		}, WithStepName("opInStep"))
+	}
+	RegisterWorkflow(dbosCtx, opInStepWf)
+
+	// Fixture for ReadOnlyOpsAllowedWithinStep: calls every read-only system-database
+	// operation from inside a step body. All go through RunAsStep, so nesting them is
+	// a plain function call.
+	readsInStepWf := func(ctx Context, _ string) (string, error) {
+		return RunAsStep(ctx, func(stepCtx context.Context) (string, error) {
+			dbosStepCtx, ok := stepCtx.(Context)
+			if !ok {
+				return "", fmt.Errorf("expected step context to be a dbos.Context, got %T", stepCtx)
+			}
+			wfID, err := GetWorkflowID(dbosStepCtx)
+			if err != nil {
+				return "", err
+			}
+			if _, err := ListWorkflows(dbosStepCtx, WithFilterWorkflowIDs(wfID)); err != nil {
+				return "", fmt.Errorf("listWorkflows: %w", err)
+			}
+			if _, err := GetWorkflowSteps(dbosStepCtx, wfID); err != nil {
+				return "", fmt.Errorf("getWorkflowSteps: %w", err)
+			}
+			if _, err := RetrieveWorkflow[string](dbosStepCtx, wfID); err != nil {
+				return "", fmt.Errorf("retrieveWorkflow: %w", err)
+			}
+			if _, err := GetWorkflowAggregates(dbosStepCtx, GetWorkflowAggregatesInput{
+				GroupByStatus: true,
+				SelectCount:   true,
+			}); err != nil {
+				return "", fmt.Errorf("getWorkflowAggregates: %w", err)
+			}
+			if _, err := GetStepAggregates(dbosStepCtx, GetStepAggregatesInput{
+				GroupByFunctionName: true,
+				SelectCount:         true,
+			}); err != nil {
+				return "", fmt.Errorf("getStepAggregates: %w", err)
+			}
+			if _, err := ListSchedules(dbosStepCtx); err != nil {
+				return "", fmt.Errorf("listSchedules: %w", err)
+			}
+			if _, err := GetSchedule(dbosStepCtx, scheduleForStepTests); err != nil {
+				return "", fmt.Errorf("getSchedule: %w", err)
+			}
+			return "reads-ok", nil
+		}, WithStepName("readsInStep"))
+	}
+	RegisterWorkflow(dbosCtx, readsInStepWf)
+
 	// A workflow that mistakenly runs its step with the outer executor context
 	// (captured from the closure) instead of the workflow context it is handed.
 	wrongCtxWorkflow := func(_ Context, input string) (string, error) {
@@ -1136,6 +1245,13 @@ func TestSteps(t *testing.T) {
 	err := Launch(dbosCtx)
 	require.NoError(t, err, "failed to launch DBOS")
 
+	// Once-a-year cron, so the scheduler never fires it while the tests run.
+	require.NoError(t, CreateSchedule(dbosCtx, ScheduleSpec{
+		ScheduleName: scheduleForStepTests,
+		Schedule:     "0 0 0 1 1 *",
+		WorkflowName: "some-workflow",
+	}), "failed to create the schedule the within-step tests read")
+
 	t.Run("StepsMustRunInsideWorkflows", func(t *testing.T) {
 		// Attempt to run a step outside of a workflow context
 		_, err := RunAsStep(dbosCtx, func(ctx context.Context) (string, error) {
@@ -1248,6 +1364,70 @@ func TestSteps(t *testing.T) {
 		require.Equal(t, 0, steps[0].StepID)
 		require.Equal(t, "awaitInStep", steps[0].StepName)
 		require.NotNil(t, steps[0].Error, "expected the enclosing step to record the guard error")
+	})
+
+	// Read-only system-database operations all go through RunAsStep, so nesting one
+	// inside a step body is a plain function call: it runs, records no checkpoint of
+	// its own, and consumes no step ID -- exactly like a step within a step.
+	t.Run("ReadOnlyOpsAllowedWithinStep", func(t *testing.T) {
+		handle, err := RunWorkflow(dbosCtx, readsInStepWf, "")
+		require.NoError(t, err, "failed to start workflow")
+		result, err := handle.GetResult()
+		require.NoError(t, err, "read-only operations must be callable from inside a step")
+		require.Equal(t, "reads-ok", result)
+
+		// Only the enclosing step is recorded: the nested reads checkpointed nothing.
+		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps")
+		require.Len(t, steps, 1, "expected exactly 1 recorded step, got %+v", steps)
+		require.Equal(t, 0, steps[0].StepID)
+		require.Equal(t, "readsInStep", steps[0].StepName)
+	})
+
+	// Operations that write to the system database go through runAsTxn, which
+	// rejects them inside a step body rather than passing through.
+	t.Run("TransactionalOpsRejectedWithinStep", func(t *testing.T) {
+		forkTarget, err := RunWorkflow(dbosCtx, getResultTargetWf, "fork-target")
+		require.NoError(t, err, "failed to start fork target workflow")
+		_, err = forkTarget.GetResult()
+		require.NoError(t, err, "failed to complete fork target workflow")
+
+		for _, tc := range []struct{ op, stepName string }{
+			{"setEvent", "DBOS.setEvent"},
+			{"writeStream", "DBOS.writeStream"},
+			{"closeStream", "DBOS.closeStream"},
+			{"cancelWorkflow", "DBOS.cancelWorkflow"},
+			{"cancelWorkflows", "DBOS.cancelWorkflows"},
+			{"setWorkflowAttributes", "DBOS.updateWorkflowAttributes"},
+			{"setWorkflowDelay", "DBOS.setWorkflowDelay"},
+			{"deleteWorkflows", "DBOS.deleteWorkflows"},
+			{"resumeWorkflow", "DBOS.resumeWorkflow"},
+			{"forkWorkflow", "DBOS.forkWorkflow"},
+			{"createSchedule", "DBOS.createSchedule"},
+			{"pauseSchedule", "DBOS.pauseSchedule"},
+			{"resumeSchedule", "DBOS.resumeSchedule"},
+			{"deleteSchedule", "DBOS.deleteSchedule"},
+		} {
+			t.Run(tc.op, func(t *testing.T) {
+				handle, err := RunWorkflow(dbosCtx, opInStepWf, opInStepInput{
+					Op:       tc.op,
+					TargetID: forkTarget.GetWorkflowID(),
+				})
+				require.NoError(t, err, "failed to start workflow")
+				result, err := handle.GetResult()
+				require.NoError(t, err, "the enclosing step reports the error, so the workflow succeeds")
+				require.Contains(t, result, fmt.Sprintf("cannot call %s within a step", tc.stepName),
+					"expected %s to be rejected inside a step", tc.op)
+
+				// The rejection is the enclosing step's only outcome: the operation
+				// itself never got a checkpoint, and consumed no step ID.
+				steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+				require.NoError(t, err, "failed to get workflow steps")
+				require.Len(t, steps, 1, "expected exactly 1 recorded step, got %+v", steps)
+				require.Equal(t, 0, steps[0].StepID)
+				require.Equal(t, "opInStep", steps[0].StepName)
+			})
+		}
 	})
 
 	t.Run("StepRetryWithExponentialBackoff", func(t *testing.T) {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -923,9 +923,9 @@ func TestSteps(t *testing.T) {
 	// scheduler never fires it during the test.
 	const scheduleForStepTests = "sched-in-step"
 
-	// Fixture for TransactionalOpsRejectedWithinStep: invokes one system-database
-	// operation from inside a step body and reports the error it gets back, so the
-	// step itself succeeds and the assertions can read the message.
+	// Fixture for OpsRejectedWithinStep: invokes one rejected operation from inside
+	// a step body and reports the error it gets back, so the step itself succeeds
+	// and the assertions can read the message.
 	type opInStepInput struct {
 		Op       string
 		TargetID string
@@ -968,6 +968,10 @@ func TestSteps(t *testing.T) {
 				err = ResumeSchedule(dbosStepCtx, scheduleForStepTests)
 			case "deleteSchedule":
 				err = DeleteSchedule(dbosStepCtx, scheduleForStepTests)
+			case "go":
+				_, err = Go(dbosStepCtx, func(context.Context) (string, error) {
+					return "nested", nil
+				})
 			default:
 				return "", fmt.Errorf("unknown op %q", input.Op)
 			}
@@ -1386,15 +1390,22 @@ func TestSteps(t *testing.T) {
 		require.Equal(t, "readsInStep", steps[0].StepName)
 	})
 
-	// Operations that write to the system database go through runAsTxn, which
-	// rejects them inside a step body rather than passing through.
-	t.Run("TransactionalOpsRejectedWithinStep", func(t *testing.T) {
+	// Operations that are refused inside a step body rather than passing through
+	// like the reads above. Writes to the system database go through runAsTxn,
+	// which rejects them; Go is rejected because the workflow state it would
+	// allocate a step ID from is the enclosing step's own, so nextStepID() would
+	// shift that step's function_id from N to N+1 -- away from the N its
+	// CheckOperationExecution looked up, and onto the ID its next sibling claims.
+	// Either way the operation records nothing and consumes no step ID.
+	t.Run("OpsRejectedWithinStep", func(t *testing.T) {
 		forkTarget, err := RunWorkflow(dbosCtx, getResultTargetWf, "fork-target")
 		require.NoError(t, err, "failed to start fork target workflow")
 		_, err = forkTarget.GetResult()
 		require.NoError(t, err, "failed to complete fork target workflow")
 
-		for _, tc := range []struct{ op, stepName string }{
+		// opName is the name the rejection message reports: the internal step name
+		// for the runAsTxn ops, the exported API name for Go.
+		for _, tc := range []struct{ op, opName string }{
 			{"setEvent", "DBOS.setEvent"},
 			{"closeStream", "DBOS.closeStream"},
 			{"cancelWorkflow", "DBOS.cancelWorkflow"},
@@ -1408,6 +1419,7 @@ func TestSteps(t *testing.T) {
 			{"pauseSchedule", "DBOS.pauseSchedule"},
 			{"resumeSchedule", "DBOS.resumeSchedule"},
 			{"deleteSchedule", "DBOS.deleteSchedule"},
+			{"go", "Go"},
 		} {
 			t.Run(tc.op, func(t *testing.T) {
 				handle, err := RunWorkflow(dbosCtx, opInStepWf, opInStepInput{
@@ -1417,11 +1429,13 @@ func TestSteps(t *testing.T) {
 				require.NoError(t, err, "failed to start workflow")
 				result, err := handle.GetResult()
 				require.NoError(t, err, "the enclosing step reports the error, so the workflow succeeds")
-				require.Contains(t, result, fmt.Sprintf("cannot call %s within a step", tc.stepName),
+				require.Contains(t, result, fmt.Sprintf("cannot call %s within a step", tc.opName),
 					"expected %s to be rejected inside a step", tc.op)
 
 				// The rejection is the enclosing step's only outcome: the operation
-				// itself never got a checkpoint, and consumed no step ID.
+				// itself never got a checkpoint, and consumed no step ID. For Go this
+				// is also what proves the enclosing step still checkpoints at its own
+				// function_id 0 rather than the 1 an allocation would have shifted it to.
 				steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
 				require.NoError(t, err, "failed to get workflow steps")
 				require.Len(t, steps, 1, "expected exactly 1 recorded step, got %+v", steps)

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -7861,42 +7861,64 @@ func TestWorkflowHandles(t *testing.T) {
 
 	workflowSleep := 1 * time.Second
 
-	t.Run("WorkflowHandleTimeout", func(t *testing.T) {
-		handle, err := RunWorkflow(dbosCtx, slowWorkflow, workflowSleep)
-		require.NoError(t, err, "failed to start workflow")
+	// A handle timeout must look the same to a caller whichever flavor of handle
+	// produced it: the two are meant to be interchangeable, and doc.go documents
+	// ErrTimeout for GetResult without qualifying which one you hold. Table-driven
+	// over both so the assertions cannot drift apart again.
+	timeoutHandleFlavors := []struct {
+		name       string
+		makeHandle func(t *testing.T) WorkflowHandle[string]
+	}{
+		{
+			name: "InMemoryHandle",
+			makeHandle: func(t *testing.T) WorkflowHandle[string] {
+				handle, err := RunWorkflow(dbosCtx, slowWorkflow, workflowSleep)
+				require.NoError(t, err, "failed to start workflow")
+				require.IsType(t, &workflowHandle[string]{}, handle, "expected an in-memory handle")
+				return handle
+			},
+		},
+		{
+			name: "PollingHandle",
+			makeHandle: func(t *testing.T) WorkflowHandle[string] {
+				originalHandle, err := RunWorkflow(dbosCtx, slowWorkflow, workflowSleep)
+				require.NoError(t, err, "failed to start workflow")
+				pollingHandle, err := RetrieveWorkflow[string](dbosCtx, originalHandle.GetWorkflowID())
+				require.NoError(t, err, "failed to retrieve workflow")
+				require.IsType(t, &workflowPollingHandle[string]{}, pollingHandle, "expected a polling handle")
+				return pollingHandle
+			},
+		},
+	}
 
-		start := time.Now()
-		_, err = handle.GetResult(WithHandleTimeout(10*time.Millisecond), WithHandlePollingInterval(1*time.Millisecond))
-		duration := time.Since(start)
+	for _, flavor := range timeoutHandleFlavors {
+		t.Run("WorkflowHandleTimeout/"+flavor.name, func(t *testing.T) {
+			handle := flavor.makeHandle(t)
 
-		require.Error(t, err, "expected timeout error")
-		assert.Contains(t, err.Error(), "workflow result timeout")
-		assert.True(t, duration < 100*time.Millisecond, "timeout should occur quickly")
-		assert.True(t, errors.Is(err, ErrTimeout), "expected a DBOS timeout error, got: %v", err)
-		assert.True(t, errors.Is(err, context.DeadlineExceeded),
-			"expected error to be detectable as context.DeadlineExceeded, got: %v", err)
-	})
+			start := time.Now()
+			_, err := handle.GetResult(WithHandleTimeout(10*time.Millisecond), WithHandlePollingInterval(1*time.Millisecond))
+			duration := time.Since(start)
 
-	t.Run("WorkflowPollingHandleTimeout", func(t *testing.T) {
-		// Start a workflow that will block on the first signal
-		originalHandle, err := RunWorkflow(dbosCtx, slowWorkflow, workflowSleep)
-		require.NoError(t, err, "failed to start workflow")
+			require.Error(t, err, "expected timeout error")
+			assert.True(t, duration < 100*time.Millisecond, "timeout should occur quickly")
+			// Only the shared prefix is asserted: the polling handle can exit
+			// through either the poll loop or the retrier's backoff depending on
+			// which notices the expiry first, and the two word it differently.
+			assert.Contains(t, err.Error(), "Operation timed out")
+			assert.True(t, errors.Is(err, ErrTimeout), "expected a DBOS timeout error, got: %v", err)
+			assert.True(t, errors.Is(err, context.DeadlineExceeded),
+				"expected error to be detectable as context.DeadlineExceeded, got: %v", err)
 
-		pollingHandle, err := RetrieveWorkflow[string](dbosCtx, originalHandle.GetWorkflowID())
-		require.NoError(t, err, "failed to retrieve workflow")
-
-		_, ok := pollingHandle.(*workflowPollingHandle[string])
-		require.True(t, ok, "expected polling handle, got %T", pollingHandle)
-
-		start := time.Now()
-		_, err = pollingHandle.GetResult(WithHandleTimeout(10*time.Millisecond), WithHandlePollingInterval(1*time.Millisecond))
-		duration := time.Since(start)
-
-		assert.True(t, duration < 100*time.Millisecond, "timeout should occur quickly")
-		require.Error(t, err, "expected timeout error")
-		assert.True(t, errors.Is(err, context.DeadlineExceeded),
-			"expected error to be detectable as context.DeadlineExceeded, got: %v", err)
-	})
+			// The coded error exists so it survives being checkpointed: a bare
+			// context sentinel degrades to a plain string and stops matching.
+			encoded := serializeWorkflowError(nil, err, NewGobSerializer().Name())
+			roundTripped := deserializeWorkflowError(&encoded)
+			assert.True(t, errors.Is(roundTripped, ErrTimeout),
+				"expected ErrTimeout to survive a DB round trip, got: %v", roundTripped)
+			assert.True(t, errors.Is(roundTripped, context.DeadlineExceeded),
+				"expected the cause to survive a DB round trip, got: %v", roundTripped)
+		})
+	}
 }
 
 func TestWorkflowHandleContextCancel(t *testing.T) {

--- a/docs/go-v1-migration-guide.md
+++ b/docs/go-v1-migration-guide.md
@@ -73,7 +73,7 @@ handle, err := dbos.Enqueue[string, int](client, "queue", "MyWorkflow", "input")
 handle, err := dbos.Enqueue[int](client, "queue", "MyWorkflow", "input")
 ```
 
-Same reorder applies to both debouncer types: `Debouncer[P, R]` / `NewDebouncer[P, R]` → `Debouncer[R, P]` / `NewDebouncer[R, P]`, and `DebouncerClient[P, R]` / `NewDebouncerClient[P, R]` → `DebouncerClient[R, P]` / `NewDebouncerClient[R, P]`. `NewDebouncer` call sites are unaffected (both parameters are inferred from the workflow function), but explicitly-typed variables must swap: `var d *dbos.Debouncer[string, int]` → `*dbos.Debouncer[int, string]`. `NewDebouncerClient` cannot infer its parameters — every call site must swap them by hand; watch for cases where input and result types are mutually assignable (e.g. both `string`), which compile unchanged with swapped meaning.
+Same reorder applies to both debouncer types: `Debouncer[P, R]` / `NewDebouncer[P, R]` → `Debouncer[R, P]` / `NewDebouncer[R, P]`, and `DebouncerClient[P, R]` / `NewDebouncerClient[P, R]` → `DebouncerClient[R, P]` / `NewDebouncerClient[R, P]`. `NewDebouncer`'s type parameters are still inferred from the workflow function, but it now also returns an error (see §7), and explicitly-typed variables must swap: `var d *dbos.Debouncer[string, int]` → `*dbos.Debouncer[int, string]`. `NewDebouncerClient` cannot infer its parameters — every call site must swap them by hand; watch for cases where input and result types are mutually assignable (e.g. both `string`), which compile unchanged with swapped meaning.
 
 ### Functions that widened from `Context` to `Client`
 
@@ -276,7 +276,9 @@ Slice-taking filters became variadic — call sites passing a literal slice need
 - New package-level accessors: `dbos.GetApplicationVersion(ctx)`, `dbos.GetExecutorID(ctx)`, `dbos.GetApplicationID(ctx)`.
 - `Config.DatabaseURL` accepts Postgres/CockroachDB URLs or key=value DSNs, and sqlite URLs (`sqlite:/path/to.db`, `sqlite:relative.db`, `sqlite::memory:`).
 - **SQLite now requires a driver import.** The SQLite driver moved out of the core package into `dbos/driver/sqlite`, registered database/sql-style. Apps using a sqlite URL or `Config.SQLiteSystemDB` must add `import _ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite"` (one blank import, anywhere in the binary); without it, startup fails with an error naming this import. Postgres-only apps need no change and no longer compile or link `modernc.org/sqlite`.
-- **One additive system-database schema change.** The first v1 `Launch()` runs migration 42, adding two defaulted columns to `workflow_status` (`is_debounced`, `debounce_deadline_epoch_ms`) for the debouncer redesign (§8). Existing workflows (including long-DELAYED ones), queues, and schedule rows carry over as-is, and v0.x and v1 executors can still share a system database during a rolling upgrade: old executors ignore the new columns and skip migration versions they don't know.
+- **One additive system-database schema change.** The first v1 `Launch()` runs migration 42, adding two defaulted columns to `workflow_status` (`is_debounced`, `debounce_deadline_epoch_ms`) for the debouncer. Existing workflows (including long-DELAYED ones), queues, and schedule rows carry over as-is, and v0.x and v1 executors can still share a system database during a rolling upgrade: old executors ignore the new columns and skip migration versions they don't know.
+- **Debouncer changes.** `NewDebouncer` now returns `(*Debouncer[R, P], error)` — call sites gain error handling (type parameters are still inferred); `NewDebouncerClient` still returns the client directly. Debouncers can be created at any time, including after `Launch()` (v0 required creation before launch). New options: `WithDebouncerQueue(name)` runs the debounced workflow on a named registered queue instead of the DBOS internal queue (fixed per debouncer, since debounce keys are scoped to it), and client-side `WithDebouncerClassName(name)` targets workflows another runtime registers under a class name. `Debounce` now rejects options a debounce owns or cannot support (`WithQueue`, `WithDeduplicationID`, `WithDelay`, `WithPriority`, `WithQueuePartitionKey`, `WithDeduplicationPolicy`) with an error matching `dbos.ErrInvalidOption`. Pending debounced workflows are now visible to workflow management: they appear as `DELAYED` on their queue with `IsDebounced` set and can be listed with `dbos.WithFilterIsDebounced(true)`. The debounce timeout is captured by the call that enqueues the workflow — later calls coalescing on the same pending workflow extend the delay up to that fixed deadline but never move it — and a deadline on the `Debounce` context is recorded as the debounced workflow's execution timeout (the clock starts at dequeue), never as an absolute deadline.
+- **Drain debouncers before upgrading.** A debounce still pending when you deploy v1 will not fire under the new version. Before upgrading, stop calling `Debounce` and let in-flight debounces fire (at most the debounce delay or timeout); cancel any stragglers left after the upgrade with `CancelWorkflow`.
 
 ### Custom serializers must handle non-user values
 
@@ -286,18 +288,26 @@ A `Serializer[any]` must therefore be total: it must encode and decode arbitrary
 
 One deliberate exception: `Recv` and `GetEvent` checkpoint the *sender's* encoded payload verbatim under the sender's recorded format — the receiver's serializer is never asked to re-encode a message or event it didn't produce.
 
-## 8. Debouncer redesign
+## 8. DBOS calls are rejected inside step bodies
 
-Debouncing no longer runs through an internal coordinator workflow. A debounced workflow is now enqueued directly in the `DELAYED` status, holding its debounce key as its deduplication ID; each `Debounce` call atomically pushes back its start time and replaces its input, and the key is released when the delay elapses and the workflow is released to its queue. The `Debouncer` / `DebouncerClient` API is unchanged apart from the §2 type-parameter reorder, with these differences:
+v0 let most DBOS operations run inside a step body and silently dropped their durability guarantees: `SetEvent`, `CloseStream`, workflow-management writes, and `RunAsTransaction` invoked from inside a step executed in a real database transaction but recorded **no checkpoint**, so recovery could repeat them. v1 rejects them instead with an `ErrorCodeStepExecution` error (`cannot call <X> within a step`). Newly rejected inside a step (v0 already rejected `Send`, `Recv`, `GetEvent`, `Sleep`, `Patch`, `DeprecatePatch`, and spawning a child workflow with `RunWorkflow`):
 
-- New `WithDebouncerQueue(name)` runs the debounced workflow on a named queue instead of the DBOS internal queue. The queue is fixed per debouncer (debounce keys are scoped to it); `Debounce` calls cannot override it.
-- A deadline on the `Debounce` context is recorded as the debounced workflow's execution timeout, never as an absolute deadline: like an enqueue timeout, the clock starts when the workflow is dequeued, so the debounce delay does not count against it. The timeout is captured by the call that enqueues the workflow; later calls coalescing on the same pending workflow do not change it.
-- `Debounce` rejects options a debounce owns or cannot support: `WithQueue`, `WithDeduplicationID`, `WithDelay`, `WithPriority`, `WithQueuePartitionKey`, `WithDeduplicationPolicy`.
-- Debouncers can be created at any time, including after `Launch()` (v0 required creation before launch).
-- The debounce timeout is captured when the first call for a key enqueues the workflow; later calls extend the delay up to that fixed deadline but never move it.
-- Pending debounced workflows are visible to workflow management: they appear as `DELAYED` on their queue with `IsDebounced` set, and can be listed with `dbos.WithFilterIsDebounced(true)`.
+- `RunAsTransaction`
+- `Enqueue`
+- `Go`
+- `handle.GetResult()` — awaiting another workflow's result from inside a step
+- `SetEvent`, `CloseStream`
+- Workflow-management writes: `CancelWorkflow(s)`, `ResumeWorkflow(s)`, `ForkWorkflow(s)`, `DeleteWorkflows`, `SetWorkflowAttributes`, `SetWorkflowDelay`
+- Schedule writes: `CreateSchedule`, `PauseSchedule`, `ResumeSchedule`, `DeleteSchedule`
+- `Debounce` (v0 already rejected this indirectly, via the child-workflow guard)
 
-**Upgrade note: drain debouncers before upgrading.** v0 debouncing ran through internal `internalDebouncerWF` workflow registrations that v1 removes, so a v0 debouncer workflow still `PENDING` at upgrade cannot be recovered by a v1 executor — recovery logs "Workflow not found in registry" and leaves it `PENDING`, and its target workflow never starts. Before upgrading, stop calling `Debounce` and let in-flight debounces fire (at most the debounce delay or timeout); cancel any stragglers left after the upgrade with `CancelWorkflow`.
+Still allowed inside a step:
+
+- `WriteStream` — at-least-once, attributed to the enclosing step (a retried step may write duplicates).
+- Read/list operations — `ListWorkflows`, `GetWorkflowSteps`, `RetrieveWorkflow`, `ReadStream`, `GetWorkflowAggregates`, `GetStepAggregates`, `GetSchedule`, `ListSchedules`, queue reads, app-version reads. Called from a step they run directly with no checkpoint; called from workflow code they are checkpointed as steps, as before.
+- Nested `RunAsStep` — the inner function runs inline as part of the enclosing step, without its own checkpoint (unchanged from v0).
+
+Migration: hoist rejected calls out of step bodies into the surrounding workflow code. If a step needs another workflow's result, return from the step and await the handle in the workflow.
 
 ## 9. Mocks / tests
 
@@ -308,5 +318,5 @@ Mocks of the old `DBOSContext` must be regenerated from `dbos.Context` (which no
 1. `go mod edit -replace` to the local `go/` checkout; `go build ./...` to enumerate breakage.
 2. Mechanical renames (safe to sed, word-boundary matched):
    `DBOSContext`→`Context`, `NewDBOSContext`→`NewContext`, `DBOSError`→`Error`, `DBOSErrorCode`→`ErrorCode`, `SqliteSystemDB`→`SQLiteSystemDB`, `UpdateWorkflowAttributes`→`SetWorkflowAttributes`, `CancelWorkflowOptions`→`CancelWorkflowOption`, step-retry `With*`→`WithStep*`, list-filter `With*`→`WithFilter*` (per §6 table — names collide with unrelated options, so match exact identifiers), error-code constants per §5, `Client<Fn>`→`<Fn>` per §2, `WorkflowFn:`→`Workflow:` (schedule-spec literals, per §4).
-3. Structural fixes by hand: queue registration (`NewWorkflowQueue`→`RegisterQueue` + error handling + `WithQueue(queue)`), scheduled workflows (`WithSchedule`→`CreateSchedule`+`ScheduleSpec`, input signature), `Enqueue` type-param reorder, `RetrieveQueue`/`GetSchedule`/`GetLatestApplicationVersion` return-shape changes, `Shutdown` error handling.
+3. Structural fixes by hand: queue registration (`NewWorkflowQueue`→`RegisterQueue` + error handling + `WithQueue(queue)`), scheduled workflows (`WithSchedule`→`CreateSchedule`+`ScheduleSpec`, input signature), `Enqueue` type-param reorder, `RetrieveQueue`/`GetSchedule`/`GetLatestApplicationVersion`/`NewDebouncer` return-shape changes, `Shutdown` error handling, hoisting DBOS calls out of step bodies (§8).
 4. `go vet ./...` && `go build ./...` && run tests.

--- a/docs/go-v1-migration-guide.md
+++ b/docs/go-v1-migration-guide.md
@@ -290,21 +290,21 @@ One deliberate exception: `Recv` and `GetEvent` checkpoint the *sender's* encode
 
 ## 8. DBOS calls are rejected inside step bodies
 
-v0 let most DBOS operations run inside a step body and silently dropped their durability guarantees: `SetEvent`, `CloseStream`, workflow-management writes, and `RunAsTransaction` invoked from inside a step executed in a real database transaction but recorded **no checkpoint**, so recovery could repeat them. v1 rejects them instead with an `ErrorCodeStepExecution` error (`cannot call <X> within a step`). Newly rejected inside a step (v0 already rejected `Send`, `Recv`, `GetEvent`, `Sleep`, `Patch`, `DeprecatePatch`, and spawning a child workflow with `RunWorkflow`):
+v0 let most DBOS operations run inside a step body and silently dropped their durability guarantees: `CloseStream`, workflow-management writes, and `RunAsTransaction` invoked from inside a step executed in a real database transaction but recorded **no checkpoint**, so recovery could repeat them. v1 rejects them instead with an `ErrorCodeStepExecution` error (`cannot call <X> within a step`). Newly rejected inside a step (v0 already rejected `Send`, `Recv`, `GetEvent`, `Sleep`, `Patch`, `DeprecatePatch`, and spawning a child workflow with `RunWorkflow`):
 
 - `RunAsTransaction`
 - `Enqueue`
 - `Go`
 - `handle.GetResult()` — awaiting another workflow's result from inside a step
-- `SetEvent`, `CloseStream`
+- `CloseStream`
 - Workflow-management writes: `CancelWorkflow(s)`, `ResumeWorkflow(s)`, `ForkWorkflow(s)`, `DeleteWorkflows`, `SetWorkflowAttributes`, `SetWorkflowDelay`
 - Schedule writes: `CreateSchedule`, `PauseSchedule`, `ResumeSchedule`, `DeleteSchedule`
 - `Debounce` (v0 already rejected this indirectly, via the child-workflow guard)
 
 Still allowed inside a step:
 
-- `WriteStream` — at-least-once, attributed to the enclosing step (a retried step may write duplicates).
-- Read/list operations — `ListWorkflows`, `GetWorkflowSteps`, `RetrieveWorkflow`, `ReadStream`, `GetWorkflowAggregates`, `GetStepAggregates`, `GetSchedule`, `ListSchedules`, queue reads, app-version reads. Called from a step they run directly with no checkpoint; called from workflow code they are checkpointed as steps, as before.
+- `SetEvent` and `WriteStream` — at-least-once, attributed to the enclosing step (a retried step may write again).
+- Read/list operations — `ListWorkflows`, `GetWorkflowSteps`, `RetrieveWorkflow`, `ReadStream`, `GetWorkflowAggregates`, `GetStepAggregates`, `GetSchedule`, `ListSchedules`, queue reads, app-version reads. Called from a step they run within the enclosing step's durability scope, without their own checkpoint; called from workflow code they are checkpointed as steps, as before.
 - Nested `RunAsStep` — the inner function runs inline as part of the enclosing step, without its own checkpoint (unchanged from v0).
 
 Migration: hoist rejected calls out of step bodies into the surrounding workflow code. If a step needs another workflow's result, return from the step and await the handle in the workflow.


### PR DESCRIPTION
Forbid running `RunAsTransaction`/`GetResult`/`SetEvent`/`CloseStream` inside a step (today falls back to the parent durability context), preferring clarity over difficult semantics. Read operations (e.g., `ListWorkflows`) and `WriteStream` are still allowed.

