### PR TITLE
batch pg_notify

### DIFF
--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -45,22 +45,23 @@ type Config struct {
 	// sqlite::memory:). Exactly one of DatabaseURL, SystemDBPool, or SQLiteSystemDB must be set.
 	// SQLite URLs additionally require importing the driver package:
 	// import _ "github.com/dbos-inc/dbos-transact-golang/dbos/driver/sqlite"
-	DatabaseURL               string
-	SystemDBPool              *pgxpool.Pool   // SystemDBPool is a custom pg/CRDB pool. Optional; takes precedence over DatabaseURL. Mutually exclusive with SQLiteSystemDB.
-	SQLiteSystemDB            *sql.DB         // SQLiteSystemDB is a custom sqlite handle. Optional; takes precedence over DatabaseURL. Mutually exclusive with SystemDBPool. Requires importing dbos/driver/sqlite.
-	DatabaseSchema            string          // Database schema name (defaults to "dbos")
-	Logger                    *slog.Logger    // Custom logger instance (defaults to a new slog logger)
-	AdminServer               bool            // Enable Transact admin HTTP server (disabled by default)
-	AdminServerPort           int             // Port for the admin HTTP server (default: 3001)
-	ConductorURL              string          // DBOS conductor service URL (optional)
-	ConductorAPIKey           string          // DBOS conductor API key (optional)
-	ConductorExecutorMetadata map[string]any  // Metadata associated with this executor that may be used to identify it on the Conductor dashboard. Must be JSON-serializable.
-	ApplicationVersion        string          // Application version (optional, overridden by DBOS__APPVERSION env var)
-	ExecutorID                string          // Executor ID (optional, overridden by DBOS__VMID env var)
-	EnablePatching            bool            // Enable the patching system for Patch and DeprecatePatch (default: false)
-	Serializer                Serializer[any] // Custom serializer for encoding/decoding workflow inputs, outputs, and events (defaults to JSON serializer)
-	SchedulerPollingInterval  time.Duration   // controls how often dynamic schedules are reconciled with the database (defaults to 30 seconds)
-	SystemDBStartupTimeout    time.Duration   // Maximum time for system-database connection and migrations (defaults to 2 minutes)
+	DatabaseURL                  string
+	SystemDBPool                 *pgxpool.Pool   // SystemDBPool is a custom pg/CRDB pool. Optional; takes precedence over DatabaseURL. Mutually exclusive with SQLiteSystemDB.
+	SQLiteSystemDB               *sql.DB         // SQLiteSystemDB is a custom sqlite handle. Optional; takes precedence over DatabaseURL. Mutually exclusive with SystemDBPool. Requires importing dbos/driver/sqlite.
+	DatabaseSchema               string          // Database schema name (defaults to "dbos")
+	Logger                       *slog.Logger    // Custom logger instance (defaults to a new slog logger)
+	AdminServer                  bool            // Enable Transact admin HTTP server (disabled by default)
+	AdminServerPort              int             // Port for the admin HTTP server (default: 3001)
+	ConductorURL                 string          // DBOS conductor service URL (optional)
+	ConductorAPIKey              string          // DBOS conductor API key (optional)
+	ConductorExecutorMetadata    map[string]any  // Metadata associated with this executor that may be used to identify it on the Conductor dashboard. Must be JSON-serializable.
+	ApplicationVersion           string          // Application version (optional, overridden by DBOS__APPVERSION env var)
+	ExecutorID                   string          // Executor ID (optional, overridden by DBOS__VMID env var)
+	EnablePatching               bool            // Enable the patching system for Patch and DeprecatePatch (default: false)
+	Serializer                   Serializer[any] // Custom serializer for encoding/decoding workflow inputs, outputs, and events (defaults to JSON serializer)
+	SchedulerPollingInterval     time.Duration   // controls how often dynamic schedules are reconciled with the database (defaults to 30 seconds)
+	SystemDBStartupTimeout       time.Duration   // Maximum time for system-database connection and migrations (defaults to 2 minutes)
+	NotificationCoalesceInterval time.Duration   // Controls how often stream-write and set-event notifications are batched
 }
 
 func processConfig(inputConfig *Config) (*Config, error) {
@@ -85,25 +86,29 @@ func processConfig(inputConfig *Config) (*Config, error) {
 	if inputConfig.SystemDBStartupTimeout < 0 {
 		return nil, fmt.Errorf("systemDBStartupTimeout cannot be negative")
 	}
+	if inputConfig.NotificationCoalesceInterval < 0 || (inputConfig.NotificationCoalesceInterval > 0 && inputConfig.NotificationCoalesceInterval < sysdb.MinNotificationCoalesceInterval) {
+		return nil, fmt.Errorf("notificationCoalesceInterval must be at least %s, got %s", sysdb.MinNotificationCoalesceInterval, inputConfig.NotificationCoalesceInterval)
+	}
 
 	dbosConfig := &Config{
-		DatabaseURL:               inputConfig.DatabaseURL,
-		AppName:                   inputConfig.AppName,
-		DatabaseSchema:            inputConfig.DatabaseSchema,
-		Logger:                    inputConfig.Logger,
-		AdminServer:               inputConfig.AdminServer,
-		AdminServerPort:           inputConfig.AdminServerPort,
-		ConductorURL:              inputConfig.ConductorURL,
-		ConductorAPIKey:           inputConfig.ConductorAPIKey,
-		ConductorExecutorMetadata: inputConfig.ConductorExecutorMetadata,
-		ApplicationVersion:        inputConfig.ApplicationVersion,
-		ExecutorID:                inputConfig.ExecutorID,
-		SystemDBPool:              inputConfig.SystemDBPool,
-		SQLiteSystemDB:            inputConfig.SQLiteSystemDB,
-		EnablePatching:            inputConfig.EnablePatching,
-		Serializer:                inputConfig.Serializer,
-		SchedulerPollingInterval:  inputConfig.SchedulerPollingInterval,
-		SystemDBStartupTimeout:    inputConfig.SystemDBStartupTimeout,
+		DatabaseURL:                  inputConfig.DatabaseURL,
+		AppName:                      inputConfig.AppName,
+		DatabaseSchema:               inputConfig.DatabaseSchema,
+		Logger:                       inputConfig.Logger,
+		AdminServer:                  inputConfig.AdminServer,
+		AdminServerPort:              inputConfig.AdminServerPort,
+		ConductorURL:                 inputConfig.ConductorURL,
+		ConductorAPIKey:              inputConfig.ConductorAPIKey,
+		ConductorExecutorMetadata:    inputConfig.ConductorExecutorMetadata,
+		ApplicationVersion:           inputConfig.ApplicationVersion,
+		ExecutorID:                   inputConfig.ExecutorID,
+		SystemDBPool:                 inputConfig.SystemDBPool,
+		SQLiteSystemDB:               inputConfig.SQLiteSystemDB,
+		EnablePatching:               inputConfig.EnablePatching,
+		Serializer:                   inputConfig.Serializer,
+		SchedulerPollingInterval:     inputConfig.SchedulerPollingInterval,
+		SystemDBStartupTimeout:       inputConfig.SystemDBStartupTimeout,
+		NotificationCoalesceInterval: inputConfig.NotificationCoalesceInterval,
 	}
 
 	if dbosConfig.ConductorExecutorMetadata != nil {
@@ -121,6 +126,9 @@ func processConfig(inputConfig *Config) (*Config, error) {
 	}
 	if dbosConfig.SystemDBStartupTimeout == 0 {
 		dbosConfig.SystemDBStartupTimeout = _DEFAULT_SYSTEM_DB_STARTUP_TIMEOUT
+	}
+	if dbosConfig.NotificationCoalesceInterval == 0 {
+		dbosConfig.NotificationCoalesceInterval = sysdb.DefaultNotificationCoalesceInterval
 	}
 
 	// If patching is enabled and application version is not set, fix the application version
@@ -593,12 +601,13 @@ func NewContext(ctx context.Context, inputConfig Config) (Context, error) {
 	initExecutor.serializer = config.Serializer
 
 	newSystemDatabaseInputs := sysdb.NewSystemDatabaseInput{
-		DatabaseURL:     config.DatabaseURL,
-		DatabaseSchema:  config.DatabaseSchema,
-		CustomPool:      config.SystemDBPool,
-		CustomSqliteDB:  config.SQLiteSystemDB,
-		Logger:          initExecutor.logger,
-		ApplicationName: config.AppName,
+		DatabaseURL:                  config.DatabaseURL,
+		DatabaseSchema:               config.DatabaseSchema,
+		CustomPool:                   config.SystemDBPool,
+		CustomSqliteDB:               config.SQLiteSystemDB,
+		Logger:                       initExecutor.logger,
+		ApplicationName:              config.AppName,
+		NotificationCoalesceInterval: config.NotificationCoalesceInterval,
 		EncodeScheduledInput: func(ctx context.Context, scheduledTime time.Time, scheduleContext json.RawMessage) (*string, string, error) {
 			ser := resolveEncoder(ctx)
 			encoded, err := ser.Encode(ScheduledWorkflowInput{

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -311,7 +311,7 @@ func TestConfig(t *testing.T) {
 
 		err = sysDB.Pool().QueryRow(dbCtx, "SELECT version FROM dbos.dbos_migrations").Scan(&version)
 		require.NoError(t, err)
-		assert.Equal(t, int64(42), version, "migration version should be 42 (after all migrations including the debounce columns)")
+		assert.Equal(t, int64(44), version, "migration version should be 44 (after all migrations including dropping the streams and workflow_events triggers)")
 
 		// Test manual shutdown and recreate
 		Shutdown(ctx, 1*time.Minute)
@@ -916,7 +916,7 @@ func TestCustomSystemDBSchema(t *testing.T) {
 
 		err = sysDB.Pool().QueryRow(dbCtx, fmt.Sprintf("SELECT version FROM %s.dbos_migrations", customSchema)).Scan(&version)
 		require.NoError(t, err)
-		assert.Equal(t, int64(42), version, "migration version should be 42 (after all migrations including the debounce columns)")
+		assert.Equal(t, int64(44), version, "migration version should be 44 (after all migrations including dropping the streams and workflow_events triggers)")
 	})
 
 	// Test workflows for exercising Send/Recv and SetEvent/GetEvent

--- a/dbos/internal/sysdb/migrations/43_drop_streams_trigger.sql
+++ b/dbos/internal/sysdb/migrations/43_drop_streams_trigger.sql
@@ -1,0 +1,8 @@
+-- Migration 43: Drop the per-row streams NOTIFY trigger installed by migration
+-- 39. A notifying commit takes a global lock on the async notification queue,
+-- so notifying from inside the write transaction serializes stream writes.
+-- Notifications are now coalesced in memory and pushed off the write path by
+-- the notifier loop. Postgres-only, matching migration 39.
+
+DROP TRIGGER IF EXISTS dbos_streams_trigger ON %s.streams;
+DROP FUNCTION IF EXISTS %s.streams_function();

--- a/dbos/internal/sysdb/migrations/44_drop_workflow_events_trigger.sql
+++ b/dbos/internal/sysdb/migrations/44_drop_workflow_events_trigger.sql
@@ -1,0 +1,9 @@
+-- Migration 44: Drop the per-row workflow_events NOTIFY trigger installed by
+-- migration 1, for the same reason as migration 43: SetEvent notifications are
+-- now coalesced and pushed off the write path by the notifier loop.
+--
+-- The notifications trigger (DBOS.Send) is deliberately kept: messages can be
+-- sent from anywhere, including processes with no notifier loop to flush them.
+
+DROP TRIGGER IF EXISTS dbos_workflow_events_trigger ON %s.workflow_events;
+DROP FUNCTION IF EXISTS %s.workflow_events_function();

--- a/dbos/internal/sysdb/notifier.go
+++ b/dbos/internal/sysdb/notifier.go
@@ -131,7 +131,12 @@ func (n *notifyRegistry) signal(payload string) {
 
 // pushes reports whether payloads signaled here are pushed to other processes.
 func (n *notifyRegistry) pushes() bool {
-	return n != nil && n.pending != nil
+	if n == nil {
+		return false
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.pending != nil
 }
 
 // drainPending removes and returns the payloads queued for the next push.
@@ -146,7 +151,7 @@ func (n *notifyRegistry) drainPending() []string {
 	for payload := range n.pending {
 		payloads = append(payloads, payload)
 	}
-	n.pending = make(map[string]struct{})
+	clear(n.pending)
 	return payloads
 }
 

--- a/dbos/internal/sysdb/notifier.go
+++ b/dbos/internal/sysdb/notifier.go
@@ -1,0 +1,279 @@
+package sysdb
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// notifier.go: how a payload written here reaches every waiter for it.
+//
+// Waiters (recv, getEvent, stream readers) subscribe to a notifyRegistry, one
+// per LISTEN/NOTIFY channel. A payload reaches a registry either from the wire
+// -- the listener loop or the polling fallback in system_database.go calls
+// notify() -- or from this process writing it, which calls signal(): that wakes
+// the local waiters immediately and queues the payload for the notifier loop to
+// push to the other processes listening on the channel.
+
+// DefaultNotificationCoalesceInterval is how often payloads queued by
+// notifyRegistry.signal are pushed to the other processes listening on their
+// channel. It bounds the wakeup latency this adds and caps the rate of
+// notifying commits regardless of write throughput.
+const DefaultNotificationCoalesceInterval = 10 * time.Millisecond
+
+// MinNotificationCoalesceInterval is the smallest configurable flush interval.
+const MinNotificationCoalesceInterval = time.Millisecond
+
+// _NOTIFIER_FINAL_FLUSH_TIMEOUT bounds the flush issued after the notifier's
+// context is canceled, so a hung database cannot delay shutdown.
+const _NOTIFIER_FINAL_FLUSH_TIMEOUT = 5 * time.Second
+
+// notifyRegistry is one notification channel's local half: it delivers
+// per-payload wake-ups to the waiters in this process (recv, getEvent, stream
+// readers). Payloads reach it from two directions -- notify() for one observed
+// on the wire, signal() for one this process just wrote -- and signal() also
+// queues the payload for the notifier loop to push to the other processes
+// listening on the channel.
+type notifyRegistry struct {
+	channel string // the LISTEN/NOTIFY channel this registry mirrors
+	mu      sync.Mutex
+	subs    map[string]map[chan struct{}]struct{} // payload -> set of waiter channels
+	pending map[string]struct{}                   // payloads awaiting a push; nil when this process does not push on this channel
+}
+
+// newNotifyRegistry builds the registry for a channel. push enables the
+// outbound half: it is off where notifications are not pushed from the
+// application, either because the backend has no listen/notify or because a
+// database trigger already emits them (the notifications channel).
+func newNotifyRegistry(channel string, push bool) *notifyRegistry {
+	n := &notifyRegistry{
+		channel: channel,
+		subs:    make(map[string]map[chan struct{}]struct{}),
+	}
+	if push {
+		n.pending = make(map[string]struct{})
+	}
+	return n
+}
+
+func (n *notifyRegistry) addLocked(payload string, ch chan struct{}) {
+	set := n.subs[payload]
+	if set == nil {
+		set = make(map[chan struct{}]struct{})
+		n.subs[payload] = set
+	}
+	set[ch] = struct{}{}
+}
+
+// subscribe registers a new waiter for payload and returns its wake channel.
+func (n *notifyRegistry) subscribe(payload string) chan struct{} {
+	ch := make(chan struct{}, 1)
+	n.mu.Lock()
+	n.addLocked(payload, ch)
+	n.mu.Unlock()
+	return ch
+}
+
+// subscribeExclusive registers the sole waiter for payload, returning false if one
+// already exists.
+func (n *notifyRegistry) subscribeExclusive(payload string) (chan struct{}, bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.subs[payload]) > 0 {
+		return nil, false
+	}
+	ch := make(chan struct{}, 1)
+	n.addLocked(payload, ch)
+	return ch, true
+}
+
+// unsubscribe removes a waiter; the payload entry is dropped once its last waiter leaves.
+func (n *notifyRegistry) unsubscribe(payload string, ch chan struct{}) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	set := n.subs[payload]
+	delete(set, ch)
+	if len(set) == 0 {
+		delete(n.subs, payload)
+	}
+}
+
+// notify wakes every waiter for payload.
+func (n *notifyRegistry) notify(payload string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.notifyLocked(payload)
+}
+
+func (n *notifyRegistry) notifyLocked(payload string) {
+	for ch := range n.subs[payload] {
+		select {
+		case ch <- struct{}{}:
+		default: // Do not block (coalesce multiple notifications into one)
+		}
+	}
+}
+
+// signal reports a payload this process just wrote: waiters here are woken
+// immediately, with no round trip, and the payload is queued for the notifier
+// loop to push to waiters in other processes.
+//
+// Call it only after the write has committed, or a woken waiter may re-read
+// before the row is visible and go back to sleep until its fallback poll.
+func (n *notifyRegistry) signal(payload string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.notifyLocked(payload)
+	if n.pending != nil {
+		n.pending[payload] = struct{}{}
+	}
+}
+
+// pushes reports whether payloads signaled here are pushed to other processes.
+func (n *notifyRegistry) pushes() bool {
+	return n != nil && n.pending != nil
+}
+
+// drainPending removes and returns the payloads queued for the next push.
+// Duplicates have already collapsed: one wakeup per payload per flush.
+func (n *notifyRegistry) drainPending() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.pending) == 0 {
+		return nil
+	}
+	payloads := make([]string, 0, len(n.pending))
+	for payload := range n.pending {
+		payloads = append(payloads, payload)
+	}
+	n.pending = make(map[string]struct{})
+	return payloads
+}
+
+// notifyAll wakes every waiter regardless of payload; used after a listener
+// reconnect so waiters re-poll for a value whose notification may have been missed.
+func (n *notifyRegistry) notifyAll() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for _, set := range n.subs {
+		for ch := range set {
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+// payloads returns a snapshot of the currently registered payloads (used by the
+// polling fallback to know which rows to check).
+func (n *notifyRegistry) payloads() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	out := make([]string, 0, len(n.subs))
+	for payload := range n.subs {
+		out = append(out, payload)
+	}
+	return out
+}
+
+// has reports whether any waiter is registered for payload.
+func (n *notifyRegistry) Has(payload string) bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.subs[payload]) > 0
+}
+
+// waiterCount reports the number of waiters registered for payload.
+func (n *notifyRegistry) WaiterCount(payload string) int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return len(n.subs[payload])
+}
+
+// clear drops all registrations (used on shutdown).
+func (n *notifyRegistry) clear() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.subs = make(map[string]map[chan struct{}]struct{})
+}
+
+// pushRegistries returns the notification registries where notification pushes are enabled, among eligible candidates.
+func (s *SysDB) pushRegistries() []*notifyRegistry {
+	registries := make([]*notifyRegistry, 0, 2)
+	for _, registry := range []*notifyRegistry{s.EventNotifier, s.streamNotifier} {
+		if registry.pushes() {
+			registries = append(registries, registry)
+		}
+	}
+	return registries
+}
+
+// pushesNotifications reports whether this process pushes any notification at
+// all, and so needs a notifier loop.
+func (s *SysDB) pushesNotifications() bool {
+	return len(s.pushRegistries()) > 0
+}
+
+// SignalStreamWrite wakes readers of the given stream, here and elsewhere. Call
+// it after the write commits.
+func (s *SysDB) SignalStreamWrite(workflowID, key string) {
+	s.streamNotifier.signal(workflowID + "::" + key)
+}
+
+// SignalEventSet wakes GetEvent waiters on the given key, here and elsewhere.
+// Call it after the write commits.
+func (s *SysDB) SignalEventSet(workflowID, key string) {
+	s.EventNotifier.signal(workflowID + "::" + key)
+}
+
+// notifierLoop pushes queued notifications until the context is canceled, then
+// pushes once more so writes made just before shutdown still wake waiters in
+// other processes promptly.
+func (s *SysDB) notifierLoop(ctx context.Context) {
+	defer s.logger.Debug("Notifier loop exiting")
+	s.logger.Debug("DBOS: Starting notifier loop")
+
+	interval := s.notificationCoalesceInterval
+	if interval <= 0 {
+		interval = DefaultNotificationCoalesceInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// The loop's context is already canceled by the time shutdown runs,
+			// so the final flush needs its own bounded context.
+			flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), _NOTIFIER_FINAL_FLUSH_TIMEOUT)
+			s.flushNotifications(flushCtx)
+			cancel()
+			return
+		case <-ticker.C:
+			s.flushNotifications(ctx)
+		}
+	}
+}
+
+// flushNotifications emits one notifying transaction per channel for everything
+// queued since the last flush.
+func (s *SysDB) flushNotifications(ctx context.Context) {
+	for _, registry := range s.pushRegistries() { // streams, events, etc
+		payloads := registry.drainPending()
+		if len(payloads) == 0 {
+			continue
+		}
+		// Batch pg_notify calls for all payloads.
+		if err := Retry(ctx, func() error {
+			_, err := s.pool.Exec(ctx, `SELECT pg_notify($1, p) FROM unnest($2::text[]) AS p`, registry.channel, payloads)
+			return err
+		}, WithRetrierLogger(s.logger)); err != nil {
+			// For non transient DB connection errors, drop the batch rather than requeue it.
+			// Waiters make progress on their fallback poll.
+			if ctx.Err() == nil {
+				s.logger.Warn("Failed to push notifications", "channel", registry.channel, "count", len(payloads), "error", err)
+			}
+		}
+	}
+}

--- a/dbos/internal/sysdb/notifier_test.go
+++ b/dbos/internal/sysdb/notifier_test.go
@@ -1,0 +1,191 @@
+package sysdb
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// flushRecorderPool counts the pg_notify statements the notifier issues, and
+// can fail the first few of them.
+type flushRecorderPool struct {
+	mu     sync.Mutex
+	n      int
+	errs   []error // returned to the first len(errs) calls, one each
+	sentTo []string
+}
+
+func (p *flushRecorderPool) calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.n
+}
+
+func (p *flushRecorderPool) Exec(ctx context.Context, q string, args ...any) (Result, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.n++
+	if p.n <= len(p.errs) {
+		return nil, p.errs[p.n-1]
+	}
+	if len(args) > 0 {
+		if channel, ok := args[0].(string); ok {
+			p.sentTo = append(p.sentTo, channel)
+		}
+	}
+	return nil, nil
+}
+
+func (p *flushRecorderPool) delivered() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.sentTo...)
+}
+
+func (p *flushRecorderPool) Query(ctx context.Context, q string, args ...any) (Rows, error) {
+	return nil, errors.New("not implemented")
+}
+func (p *flushRecorderPool) QueryRow(ctx context.Context, q string, args ...any) Row {
+	panic("not implemented")
+}
+func (p *flushRecorderPool) BeginTx(ctx context.Context, opts TxOptions) (Tx, error) {
+	return nil, errors.New("not implemented")
+}
+func (p *flushRecorderPool) Ping(ctx context.Context) error { return nil }
+func (p *flushRecorderPool) Close()                         {}
+
+// pushingSysDB is a SysDB whose registries push, wired to a pool that only
+// records flushes.
+func pushingSysDB(interval time.Duration) *SysDB {
+	return &SysDB{
+		dialect:                      SqliteDialect{},
+		logger:                       slog.New(slog.DiscardHandler),
+		pool:                         &flushRecorderPool{},
+		RecvNotifier:                 newNotifyRegistry(_DBOS_NOTIFICATIONS_CHANNEL, false),
+		EventNotifier:                newNotifyRegistry(_DBOS_WORKFLOW_EVENTS_CHANNEL, true),
+		streamNotifier:               newNotifyRegistry(_DBOS_STREAMS_CHANNEL, true),
+		notificationCoalesceInterval: interval,
+	}
+}
+
+func TestSignalWakesLocalWaiterAndQueuesOnePush(t *testing.T) {
+	s := pushingSysDB(time.Hour) // never ticks: the queue is inspected by hand
+	ch, release := s.StreamWakeChannel("wf", "key")
+	defer release()
+
+	// Repeated writes to the same stream wake the reader now and collapse into a
+	// single wakeup for other processes: that collapsing is the point of
+	// coalescing.
+	for range 100 {
+		s.SignalStreamWrite("wf", "key")
+	}
+	select {
+	case <-ch:
+	default:
+		t.Fatal("local stream reader was not woken")
+	}
+	s.SignalStreamWrite("wf", "other")
+	s.SignalEventSet("wf", "event")
+
+	if got := len(s.streamNotifier.drainPending()); got != 2 {
+		t.Errorf("expected 2 deduplicated stream payloads, got %d", got)
+	}
+	if got := len(s.EventNotifier.drainPending()); got != 1 {
+		t.Errorf("expected 1 event payload, got %d", got)
+	}
+	// A drain empties the queue, so an idle notifier issues no statements.
+	if got := s.streamNotifier.drainPending(); got != nil {
+		t.Errorf("expected nothing pending after drain, got %v", got)
+	}
+}
+
+func TestRegistriesThatDoNotPushOnlyWakeLocalWaiters(t *testing.T) {
+	// Messages keep their database trigger, and no channel is pushed at all on a
+	// backend without listen/notify: signaling must still wake local waiters
+	// without queueing anything.
+	s := pushingSysDB(time.Hour)
+	s.RecvNotifier = newNotifyRegistry(_DBOS_NOTIFICATIONS_CHANNEL, false)
+	s.EventNotifier = newNotifyRegistry(_DBOS_WORKFLOW_EVENTS_CHANNEL, false)
+	s.streamNotifier = newNotifyRegistry(_DBOS_STREAMS_CHANNEL, false)
+
+	if s.pushesNotifications() {
+		t.Fatal("a backend that pushes nothing should not need a notifier loop")
+	}
+	ch, release := s.StreamWakeChannel("wf", "key")
+	defer release()
+
+	s.SignalStreamWrite("wf", "key")
+	select {
+	case <-ch:
+	default:
+		t.Fatal("local stream reader was not woken")
+	}
+	if got := s.streamNotifier.drainPending(); got != nil {
+		t.Errorf("expected nothing queued for push, got %v", got)
+	}
+}
+
+func TestFlushRetriesTransientErrorsAndDropsTheRest(t *testing.T) {
+	// A database blip must not cost waiters in other processes their wakeup: the
+	// push is retried until it lands.
+	s := pushingSysDB(time.Hour)
+	pool := s.pool.(*flushRecorderPool)
+	pool.errs = []error{&pgconn.PgError{Code: pgerrcode.ConnectionFailure}}
+	s.SignalStreamWrite("wf", "key")
+
+	s.flushNotifications(context.Background())
+	if got := pool.calls(); got != 2 {
+		t.Fatalf("expected the transient failure to be retried (2 calls), got %d", got)
+	}
+	if got := pool.delivered(); len(got) != 1 || got[0] != _DBOS_STREAMS_CHANNEL {
+		t.Fatalf("expected the retry to deliver the stream batch, got %v", got)
+	}
+
+	// An error retrying cannot fix ends the flush instead of looping forever. The
+	// batch is dropped, not requeued: waiters fall back to polling.
+	s = pushingSysDB(time.Hour)
+	pool = s.pool.(*flushRecorderPool)
+	pool.errs = []error{errors.New("malformed payload")}
+	s.SignalStreamWrite("wf", "key")
+
+	s.flushNotifications(context.Background())
+	if got := pool.calls(); got != 1 {
+		t.Fatalf("expected no retry of a non-retryable error, got %d calls", got)
+	}
+	if got := s.streamNotifier.drainPending(); got != nil {
+		t.Errorf("expected the dropped batch not to be requeued, got %v", got)
+	}
+}
+
+func TestNotifierLoopFlushesAfterCancel(t *testing.T) {
+	// The final push lets values written just before shutdown wake waiters in
+	// other processes instead of waiting out their fallback poll.
+	s := pushingSysDB(time.Hour) // never ticks; only the final flush can fire
+	s.SignalStreamWrite("wf", "key")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.notifierLoop(ctx)
+		close(done)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("notifier loop did not exit after cancel")
+	}
+	if got := s.pool.(*flushRecorderPool).calls(); got != 1 {
+		t.Fatalf("expected one final push, got %d", got)
+	}
+	if got := s.streamNotifier.drainPending(); got != nil {
+		t.Errorf("expected the final push to drain the queue, got %v", got)
+	}
+}

--- a/dbos/internal/sysdb/sqlite_migrations.go
+++ b/dbos/internal/sysdb/sqlite_migrations.go
@@ -130,7 +130,7 @@ var sqliteMigration42SQL string
 
 // BuildSqliteMigrations returns the SQLite migration list. Versions mirror pg
 // numbering (matching Python's sqlite_migrations); pg migrations 10, 14, 20,
-// 38, and 39 have no SQLite counterpart and are omitted.
+// 38, 39, 43, and 44 have no SQLite counterpart and are omitted.
 func BuildSqliteMigrations() []MigrationFile {
 	return []MigrationFile{
 		{Version: 1, SQL: sqliteMigration1SQL},

--- a/dbos/internal/sysdb/sqlite_pool.go
+++ b/dbos/internal/sysdb/sqlite_pool.go
@@ -177,9 +177,9 @@ func newSqliteSystemDatabase(encodeScheduledInput func(context.Context, time.Tim
 	return &SysDB{
 		pool:                 NewSQLPool(db),
 		dialect:              SqliteDialect{},
-		RecvNotifier:         newNotifyRegistry(),
-		EventNotifier:        newNotifyRegistry(),
-		streamNotifier:       newNotifyRegistry(),
+		RecvNotifier:         newNotifyRegistry(_DBOS_NOTIFICATIONS_CHANNEL, false),
+		EventNotifier:        newNotifyRegistry(_DBOS_WORKFLOW_EVENTS_CHANNEL, false),
+		streamNotifier:       newNotifyRegistry(_DBOS_STREAMS_CHANNEL, false),
 		notificationLoopDone: make(chan struct{}),
 		logger:               logger.With("service", "system_database"),
 		schema:               databaseSchema,

--- a/dbos/internal/sysdb/sysdb_test.go
+++ b/dbos/internal/sysdb/sysdb_test.go
@@ -42,7 +42,7 @@ func TestNotificationLoopCompletionDoesNotRequireShutdownWaiter(t *testing.T) {
 }
 
 func TestStreamWakeChannelCleanupPreservesConcurrentReaders(t *testing.T) {
-	s := &SysDB{streamNotifier: newNotifyRegistry()}
+	s := &SysDB{streamNotifier: newNotifyRegistry(_DBOS_STREAMS_CHANNEL, true)}
 	const readers = 32
 
 	type subscription struct {

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -88,6 +88,11 @@ type SystemDatabase interface {
 	// the given workflow's stream, plus a cleanup func to drop the registration.
 	StreamWakeChannel(workflowID, key string) (chan struct{}, func())
 
+	// Wakeups for readers in other goroutines. Also queue a coalesced NOTIFY
+	// periodically flushed into a pg_notify call.
+	SignalStreamWrite(workflowID, key string)
+	SignalEventSet(workflowID, key string)
+
 	// Patches
 	Patch(ctx context.Context, input PatchDBInput) (bool, error)
 	DoesPatchExists(ctx context.Context, input PatchDBInput) (string, error)
@@ -152,6 +157,10 @@ type SysDB struct {
 	RecvNotifier         *notifyRegistry // recv waiters, keyed by "destinationID::topic"
 	EventNotifier        *notifyRegistry // getEvent waiters, keyed by "targetWorkflowID::key"
 	streamNotifier       *notifyRegistry // stream readers, keyed by "workflowID::key"
+	notifierDone         chan struct{}   // closed when the notifier loop has made its final push
+
+	notificationCoalesceInterval time.Duration
+
 	logger               *slog.Logger
 	encodeScheduledInput func(ctx context.Context, scheduledTime time.Time, scheduleContext json.RawMessage) (*string, string, error)
 	schema               string
@@ -341,6 +350,12 @@ var migration41SQL string
 //go:embed migrations/42_add_debounce_columns.sql
 var migration42SQL string
 
+//go:embed migrations/43_drop_streams_trigger.sql
+var migration43SQL string
+
+//go:embed migrations/44_drop_workflow_events_trigger.sql
+var migration44SQL string
+
 type MigrationFile struct {
 	Version int64
 	SQL     string
@@ -357,6 +372,10 @@ const (
 
 	// Stream sentinel value for closure
 	StreamClosedSentinel = "__DBOS_STREAM_CLOSED__"
+
+	// How often a blocked recv/getEvent waiter re-checks the database for a row
+	// whose notification it may have missed.
+	_NOTIFICATION_FALLBACK_RECHECK_INTERVAL = 60 * time.Second
 
 	// Database retry timeouts
 	_DB_CONNECTION_RETRY_BASE_DELAY = 1 * time.Second
@@ -424,6 +443,16 @@ func BuildMigrations(schema string, isCockroach bool) []MigrationFile {
 			sanitizedSchema, sanitizedSchema, sanitizedSchema, sanitizedSchema, sanitizedSchema)
 	}
 
+	// Migrations 43 and 44 drop the streams and workflow_events triggers
+	// installed by migrations 39 and 1. Both are gated like the triggers they
+	// remove: on CockroachDB they were never created, so this is a no-op (the
+	// version row still advances).
+	migration43SQLProcessed, migration44SQLProcessed := "", ""
+	if !isCockroach {
+		migration43SQLProcessed = fmt.Sprintf(migration43SQL, sanitizedSchema, sanitizedSchema)
+		migration44SQLProcessed = fmt.Sprintf(migration44SQL, sanitizedSchema, sanitizedSchema)
+	}
+
 	return []MigrationFile{
 		{Version: 1, SQL: migration1SQLProcessed},
 		{Version: 2, SQL: fmt.Sprintf(migration2SQL, sanitizedSchema)},
@@ -467,6 +496,8 @@ func BuildMigrations(schema string, isCockroach bool) []MigrationFile {
 		{Version: 40, SQL: fmt.Sprintf(migration40SQL, sanitizedSchema, sanitizedSchema)},
 		{Version: 41, SQL: fmt.Sprintf(migration41SQL, sanitizedSchema, sanitizedSchema)},
 		{Version: 42, SQL: fmt.Sprintf(migration42SQL, sanitizedSchema, sanitizedSchema)},
+		{Version: 43, SQL: migration43SQLProcessed},
+		{Version: 44, SQL: migration44SQLProcessed},
 	}
 }
 
@@ -707,13 +738,14 @@ func applyCockroachMigration10(ctx context.Context, tx pgx.Tx, schema, sanitized
 }
 
 type NewSystemDatabaseInput struct {
-	DatabaseURL     string
-	DatabaseSchema  string
-	CustomPool      *pgxpool.Pool
-	CustomSqliteDB  *sql.DB
-	Logger          *slog.Logger
-	ApplicationName string
-	StartupTimeout  time.Duration
+	DatabaseURL                  string
+	DatabaseSchema               string
+	CustomPool                   *pgxpool.Pool
+	CustomSqliteDB               *sql.DB
+	Logger                       *slog.Logger
+	ApplicationName              string
+	StartupTimeout               time.Duration
+	NotificationCoalesceInterval time.Duration
 	// EncodeScheduledInput serializes the input of a schedule-created workflow
 	// (backfill/trigger). Injected by the caller to keep serialization concerns
 	// out of the system database.
@@ -897,17 +929,24 @@ func NewSystemDatabase(ctx context.Context, inputs NewSystemDatabaseInput) (Syst
 		dialect = CockroachDialect{}
 	}
 
+	push := dialect.SupportsListenNotify()
+	coalesceInterval := inputs.NotificationCoalesceInterval
+	if coalesceInterval <= 0 {
+		coalesceInterval = DefaultNotificationCoalesceInterval
+	}
+
 	return &SysDB{
-		pool:                 NewPgxPool(pool),
-		dialect:              dialect,
-		RecvNotifier:         newNotifyRegistry(),
-		EventNotifier:        newNotifyRegistry(),
-		streamNotifier:       newNotifyRegistry(),
-		encodeScheduledInput: inputs.EncodeScheduledInput,
-		notificationLoopDone: make(chan struct{}),
-		logger:               logger.With("service", "system_database"),
-		schema:               databaseSchema,
-		isCockroachDB:        isCockroach,
+		pool:                         NewPgxPool(pool),
+		dialect:                      dialect,
+		RecvNotifier:                 newNotifyRegistry(_DBOS_NOTIFICATIONS_CHANNEL, false),
+		EventNotifier:                newNotifyRegistry(_DBOS_WORKFLOW_EVENTS_CHANNEL, push),
+		streamNotifier:               newNotifyRegistry(_DBOS_STREAMS_CHANNEL, push),
+		notificationCoalesceInterval: coalesceInterval,
+		encodeScheduledInput:         inputs.EncodeScheduledInput,
+		notificationLoopDone:         make(chan struct{}),
+		logger:                       logger.With("service", "system_database"),
+		schema:                       databaseSchema,
+		isCockroachDB:                isCockroach,
 	}, nil
 }
 
@@ -954,10 +993,22 @@ func (s *SysDB) StreamWakeChannel(workflowID, key string) (chan struct{}, func()
 
 func (s *SysDB) Launch(ctx context.Context) {
 	done := make(chan struct{})
+	var notifierDone chan struct{}
+	if s.pushesNotifications() {
+		notifierDone = make(chan struct{})
+	}
 	s.notificationLoopMu.Lock()
 	s.notificationLoopDone = done
+	s.notifierDone = notifierDone
 	s.launched = true
 	s.notificationLoopMu.Unlock()
+
+	if notifierDone != nil {
+		go func() {
+			s.notifierLoop(ctx)
+			close(notifierDone)
+		}()
+	}
 
 	if s.ListenNotifyPool() == nil {
 		go func() {
@@ -979,8 +1030,9 @@ func (s *SysDB) Shutdown(ctx context.Context, timeout time.Duration) []string {
 	s.notificationLoopMu.Lock()
 	launched := s.launched
 	done := s.notificationLoopDone
+	notifierDone := s.notifierDone
 	s.notificationLoopMu.Unlock()
-	listenerStopped := true
+	loopsStopped := true
 	if launched {
 		// Wait for the notification loop to exit
 		// The context should be cancelled prior to calling shutdown
@@ -989,7 +1041,18 @@ func (s *SysDB) Shutdown(ctx context.Context, timeout time.Duration) []string {
 		case <-time.After(timeout):
 			s.logger.Warn("Notification listener loop did not finish in time", "timeout", timeout)
 			pending = append(pending, "notification listener")
-			listenerStopped = false
+			loopsStopped = false
+		}
+		// Wait for the notifier's final flush before closing the pool, so
+		// writes made just before shutdown still wake their waiters.
+		if notifierDone != nil {
+			select {
+			case <-notifierDone:
+			case <-time.After(timeout):
+				s.logger.Warn("Notifier loop did not finish in time", "timeout", timeout)
+				pending = append(pending, "notifier")
+				loopsStopped = false
+			}
 		}
 	}
 
@@ -1013,9 +1076,9 @@ func (s *SysDB) Shutdown(ctx context.Context, timeout time.Duration) []string {
 	s.streamNotifier.clear()
 
 	s.notificationLoopMu.Lock()
-	// Stay launched while the notification loop is still running so a later
+	// Stay launched while a background loop is still running so a later
 	// Shutdown call waits for it again instead of skipping the check.
-	if listenerStopped {
+	if loopsStopped {
 		s.launched = false
 	}
 	s.notificationLoopMu.Unlock()
@@ -3804,119 +3867,6 @@ func (s *SysDB) Send(ctx context.Context, input WorkflowSendInput) error {
 	return nil
 }
 
-// notifyRegistry delivers per-payload wake-ups to notification waiters (recv and
-// getEvent).
-type notifyRegistry struct {
-	mu   sync.Mutex
-	subs map[string]map[chan struct{}]struct{} // payload -> set of waiter channels
-}
-
-func newNotifyRegistry() *notifyRegistry {
-	return &notifyRegistry{subs: make(map[string]map[chan struct{}]struct{})}
-}
-
-func (n *notifyRegistry) addLocked(payload string, ch chan struct{}) {
-	set := n.subs[payload]
-	if set == nil {
-		set = make(map[chan struct{}]struct{})
-		n.subs[payload] = set
-	}
-	set[ch] = struct{}{}
-}
-
-// subscribe registers a new waiter for payload and returns its wake channel.
-func (n *notifyRegistry) subscribe(payload string) chan struct{} {
-	ch := make(chan struct{}, 1)
-	n.mu.Lock()
-	n.addLocked(payload, ch)
-	n.mu.Unlock()
-	return ch
-}
-
-// subscribeExclusive registers the sole waiter for payload, returning false if one
-// already exists.
-func (n *notifyRegistry) subscribeExclusive(payload string) (chan struct{}, bool) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	if len(n.subs[payload]) > 0 {
-		return nil, false
-	}
-	ch := make(chan struct{}, 1)
-	n.addLocked(payload, ch)
-	return ch, true
-}
-
-// unsubscribe removes a waiter; the payload entry is dropped once its last waiter leaves.
-func (n *notifyRegistry) unsubscribe(payload string, ch chan struct{}) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	set := n.subs[payload]
-	delete(set, ch)
-	if len(set) == 0 {
-		delete(n.subs, payload)
-	}
-}
-
-// notify wakes every waiter for payload.
-func (n *notifyRegistry) notify(payload string) {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	for ch := range n.subs[payload] {
-		select {
-		case ch <- struct{}{}:
-		default: // Do not block (coalesce multiple notifications into one)
-		}
-	}
-}
-
-// notifyAll wakes every waiter regardless of payload; used after a listener
-// reconnect so waiters re-poll for a value whose notification may have been missed.
-func (n *notifyRegistry) notifyAll() {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	for _, set := range n.subs {
-		for ch := range set {
-			select {
-			case ch <- struct{}{}:
-			default:
-			}
-		}
-	}
-}
-
-// payloads returns a snapshot of the currently registered payloads (used by the
-// polling fallback to know which rows to check).
-func (n *notifyRegistry) payloads() []string {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	out := make([]string, 0, len(n.subs))
-	for payload := range n.subs {
-		out = append(out, payload)
-	}
-	return out
-}
-
-// has reports whether any waiter is registered for payload.
-func (n *notifyRegistry) Has(payload string) bool {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	return len(n.subs[payload]) > 0
-}
-
-// waiterCount reports the number of waiters registered for payload.
-func (n *notifyRegistry) WaiterCount(payload string) int {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	return len(n.subs[payload])
-}
-
-// clear drops all registrations (used on shutdown).
-func (n *notifyRegistry) clear() {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	n.subs = make(map[string]map[chan struct{}]struct{})
-}
-
 // NotificationWaiter tracks a waiter registered for a notification (recv message or workflow event).
 type NotificationWaiter struct {
 	Pending bool                                   // the awaited row already existed at registration time
@@ -3924,17 +3874,27 @@ type NotificationWaiter struct {
 	Release func()                                 // unregister the waiter; must be called after the result is read (or on abandonment)
 }
 
-func (s *SysDB) notificationWait(ctx context.Context, opName, payload string, ch <-chan struct{}, recheck func(context.Context) (bool, error)) func(deadline time.Time) (bool, error) {
+func (s *SysDB) notificationWait(ctx context.Context, opName, payload string, registry *notifyRegistry, ch <-chan struct{}, recheck func(context.Context) (bool, error)) func(deadline time.Time) (bool, error) {
 	return func(deadline time.Time) (bool, error) {
 		// The caller has already probed and found nothing; any notify since then is
 		// buffered in ch, so wait for a wake before rechecking. The deadline bounds
 		// recheck's retries so a DB outage cannot block past the timeout.
 		waitCtx, cancel := context.WithDeadline(ctx, deadline)
 		defer cancel()
+		// Safety net for a wakeup that never arrives (needed only on a channel with batch pg_notify)
+		// The NOTIFY is emitted by the notifier loop after the write commits, so a writer dying in between leaves none behind.
+		var fallback <-chan time.Time
+		if registry.pushes() {
+			ticker := time.NewTicker(_NOTIFICATION_FALLBACK_RECHECK_INTERVAL)
+			defer ticker.Stop()
+			fallback = ticker.C
+		}
 		for {
 			select {
 			case <-ch:
 				// A notification or reconnect repoll fired; re-check.
+			case <-fallback:
+				// Fallback re-check; see above.
 			case <-waitCtx.Done():
 				if err := ctx.Err(); err != nil {
 					s.logger.Warn(opName+" context cancelled", "payload", payload, "cause", context.Cause(ctx))
@@ -3991,7 +3951,7 @@ func (s *SysDB) StartRecvListener(ctx context.Context, destinationID, topic stri
 		release()
 		return nil, err
 	}
-	wait := s.notificationWait(ctx, "Recv()", payload, ch, recheck)
+	wait := s.notificationWait(ctx, "Recv()", payload, s.RecvNotifier, ch, recheck)
 
 	return &NotificationWaiter{Pending: exists, Wait: wait, Release: release}, nil
 }
@@ -4092,7 +4052,7 @@ func (s *SysDB) StartEventListener(ctx context.Context, targetWorkflowID, key st
 		release()
 		return nil, err
 	}
-	wait := s.notificationWait(ctx, "GetEvent()", payload, ch, recheck)
+	wait := s.notificationWait(ctx, "GetEvent()", payload, s.EventNotifier, ch, recheck)
 
 	return &NotificationWaiter{Pending: exists, Wait: wait, Release: release}, nil
 }

--- a/dbos/migration_test.go
+++ b/dbos/migration_test.go
@@ -14,6 +14,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// triggerExists reports whether a trigger of the given name is installed on a
+// table in the dbos schema.
+func triggerExists(t *testing.T, pool *pgxpool.Pool, table, trigger string) bool {
+	t.Helper()
+	var found bool
+	err := pool.QueryRow(context.Background(), `
+		SELECT EXISTS (
+			SELECT 1 FROM pg_trigger tg
+			JOIN pg_class cl ON tg.tgrelid = cl.oid
+			JOIN pg_namespace ns ON cl.relnamespace = ns.oid
+			WHERE ns.nspname = 'dbos' AND cl.relname = $1 AND tg.tgname = $2)`,
+		table, trigger).Scan(&found)
+	require.NoError(t, err)
+	return found
+}
+
 // poolFromContext extracts the underlying pgxpool from a Context that was
 // set up via setupDBOS.
 func poolFromContext(t *testing.T, ctx Context) *pgxpool.Pool {
@@ -301,6 +317,15 @@ func TestMigrationStatements(t *testing.T) {
 	var version int64
 	require.NoError(t, pool.QueryRow(bg, "SELECT version FROM dbos.dbos_migrations").Scan(&version))
 	assert.Equal(t, latest, version)
+
+	// A notifying transaction takes a global lock, so the streams and
+	// workflow_events triggers were replaced by coalesced notifications pushed off
+	// the write path. The notifications trigger stays: DBOS.Send may run in a
+	// process with no notifier loop to flush a notification for it.
+	assert.False(t, triggerExists(t, pool, "streams", "dbos_streams_trigger"))
+	assert.False(t, triggerExists(t, pool, "workflow_events", "dbos_workflow_events_trigger"))
+	assert.True(t, triggerExists(t, pool, "notifications", "dbos_notifications_trigger"),
+		"the notifications trigger must be kept for senders with no notifier loop")
 
 	// A funny schema name is quoted throughout and applies cleanly.
 	funny := "F8nny_sCHem@-n@m3"

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -3593,8 +3593,6 @@ func (c *dbosContext) WriteStream(_ Context, key string, value any, opts ...Writ
 			StepID:        wfState.stepID,
 		})
 	}, WithStepName("DBOS.writeStream"))
-	// Signal only once the transaction has committed, so a woken reader finds
-	// the value instead of going back to sleep.
 	if err == nil && writtenWorkflowID != "" {
 		c.systemDB.SignalStreamWrite(writtenWorkflowID, key)
 	}
@@ -3615,6 +3613,8 @@ func WriteStream[P any](ctx Context, key string, value P, opts ...WriteStreamOpt
 	}
 	return ctx.WriteStream(ctx, key, value, opts...)
 }
+
+const _READ_STREAM_POLL_INTERVAL = 1 * time.Second
 
 // ReadStreamOption is a functional option for ReadStream.
 type ReadStreamOption func(*readStreamOptions)
@@ -3777,7 +3777,7 @@ func (c *dbosContext) readStream(workflowID string, key string, snapshot bool, f
 				return
 			case <-wakeCh:
 				// A value was written; read again immediately
-			case <-time.After(sysdb.DBRetryInterval):
+			case <-time.After(_READ_STREAM_POLL_INTERVAL):
 				// Continue loop to read again
 			}
 		}

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -3272,9 +3272,10 @@ func (c *dbosContext) SetEvent(_ Context, key string, message any, opts ...SetEv
 		return fmt.Errorf("failed to serialize event value: %w", err)
 	}
 
+	// Raw call within a step
 	if wfState, ok := c.Value(workflowStateKey).(*workflowState); ok && wfState != nil && wfState.isWithinStep {
 		uncancellableCtx := WithoutCancel(c)
-		return sysdb.Retry(c, func() error {
+		err = sysdb.Retry(c, func() error {
 			return c.systemDB.SetEvent(uncancellableCtx, sysdb.WorkflowSetEventInput{
 				Key:           key,
 				Message:       encodedMessage,
@@ -3283,13 +3284,19 @@ func (c *dbosContext) SetEvent(_ Context, key string, message any, opts ...SetEv
 				StepID:        wfState.stepID,
 			})
 		}, sysdb.WithRetrierLogger(c.logger))
+		if err == nil {
+			c.systemDB.SignalEventSet(wfState.workflowID, key)
+		}
+		return err
 	}
 
+	var setWorkflowID string
 	_, err = runAsTxn(c, func(ctx context.Context, tx Tx) (any, error) {
 		wfState, ok := ctx.Value(workflowStateKey).(*workflowState)
 		if !ok || wfState == nil {
 			return nil, models.NewStepExecutionError("", "DBOS.setEvent", fmt.Errorf("workflow state not found in context: are you running this step within a workflow?"))
 		}
+		setWorkflowID = wfState.workflowID
 		return nil, c.systemDB.SetEvent(ctx, sysdb.WorkflowSetEventInput{
 			Key:           key,
 			Message:       encodedMessage,
@@ -3299,6 +3306,10 @@ func (c *dbosContext) SetEvent(_ Context, key string, message any, opts ...SetEv
 			StepID:        wfState.stepID,
 		})
 	}, WithStepName("DBOS.setEvent"))
+	// Signal only once the transaction has committed.
+	if err == nil && setWorkflowID != "" {
+		c.systemDB.SignalEventSet(setWorkflowID, key)
+	}
 	return err
 }
 
@@ -3551,7 +3562,7 @@ func (c *dbosContext) WriteStream(_ Context, key string, value any, opts ...Writ
 
 	if wfState, ok := c.Value(workflowStateKey).(*workflowState); ok && wfState != nil && wfState.isWithinStep {
 		uncancellableCtx := WithoutCancel(c)
-		return sysdb.Retry(c, func() error {
+		err = sysdb.Retry(c, func() error {
 			return c.systemDB.WriteStream(uncancellableCtx, sysdb.WriteStreamDBInput{
 				Key:           key,
 				Value:         encodedValue,
@@ -3560,13 +3571,19 @@ func (c *dbosContext) WriteStream(_ Context, key string, value any, opts ...Writ
 				StepID:        wfState.stepID,
 			})
 		}, sysdb.WithRetrierLogger(c.logger))
+		if err == nil {
+			c.systemDB.SignalStreamWrite(wfState.workflowID, key)
+		}
+		return err
 	}
 
+	var writtenWorkflowID string
 	_, err = runAsTxn(c, func(ctx context.Context, tx Tx) (any, error) {
 		wfState, ok := ctx.Value(workflowStateKey).(*workflowState)
 		if !ok || wfState == nil {
 			return "", fmt.Errorf("workflow state not found in context: are you running this within a workflow?")
 		}
+		writtenWorkflowID = wfState.workflowID
 		return "", c.systemDB.WriteStream(ctx, sysdb.WriteStreamDBInput{
 			Key:           key,
 			Value:         encodedValue,
@@ -3576,6 +3593,11 @@ func (c *dbosContext) WriteStream(_ Context, key string, value any, opts ...Writ
 			StepID:        wfState.stepID,
 		})
 	}, WithStepName("DBOS.writeStream"))
+	// Signal only once the transaction has committed, so a woken reader finds
+	// the value instead of going back to sleep.
+	if err == nil && writtenWorkflowID != "" {
+		c.systemDB.SignalStreamWrite(writtenWorkflowID, key)
+	}
 	return err
 }
 
@@ -3710,6 +3732,11 @@ func (c *dbosContext) readStream(workflowID string, key string, snapshot bool, f
 				return
 			}
 
+			// We got data so expect more instead of checking stream liveliness now.
+			if len(entries) > 0 {
+				continue
+			}
+
 			// Check if workflow is still active (PENDING or ENQUEUED)
 			status, err := sysdb.RetryWithResult(c, func() (WorkflowStatusType, error) {
 				workflows, err := c.systemDB.ListWorkflows(c, sysdb.ListWorkflowsDBInput{
@@ -3741,18 +3768,17 @@ func (c *dbosContext) readStream(workflowID string, key string, snapshot bool, f
 				continue
 			}
 
-			// If no new entries, wait for a write notification, with a bounded
-			// fallback to poll for workflow termination and missed notifications
-			if len(entries) == 0 {
-				select {
-				case <-c.Done():
-					send(StreamValue[any]{Err: c.Err()})
-					return
-				case <-wakeCh:
-					// A value was written; read again immediately
-				case <-time.After(sysdb.DBRetryInterval):
-					// Continue loop to read again
-				}
+			// Nothing to read and the producer is still running: wait for a write
+			// notification, with a bounded fallback to poll for workflow
+			// termination and missed notifications
+			select {
+			case <-c.Done():
+				send(StreamValue[any]{Err: c.Err()})
+				return
+			case <-wakeCh:
+				// A value was written; read again immediately
+			case <-time.After(sysdb.DBRetryInterval):
+				// Continue loop to read again
 			}
 		}
 	}()
@@ -3960,12 +3986,14 @@ func ReadStreamAsync[R any](ctx Client, workflowID string, key string) (<-chan S
 }
 
 func (c *dbosContext) CloseStream(_ Context, key string) error {
+	var closedWorkflowID string
 	_, err := runAsTxn(c, func(ctx context.Context, tx Tx) (any, error) {
 		sentinel := sysdb.StreamClosedSentinel
 		wfState, ok := ctx.Value(workflowStateKey).(*workflowState)
 		if !ok || wfState == nil {
 			return "", fmt.Errorf("workflow state not found in context: are you running this within a workflow?")
 		}
+		closedWorkflowID = wfState.workflowID
 		return "", c.systemDB.WriteStream(ctx, sysdb.WriteStreamDBInput{
 			Key:        key,
 			Value:      &sentinel,
@@ -3974,6 +4002,9 @@ func (c *dbosContext) CloseStream(_ Context, key string) error {
 			StepID:     wfState.stepID,
 		})
 	}, WithStepName("DBOS.closeStream"))
+	if err == nil && closedWorkflowID != "" {
+		c.systemDB.SignalStreamWrite(closedWorkflowID, key)
+	}
 	return err
 }
 

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -8917,7 +8917,7 @@ func TestStreams(t *testing.T) {
 
 	t.Run("NotificationLatency", func(t *testing.T) {
 		// A blocked reader must be woken by the streams LISTEN/NOTIFY trigger,
-		// not the bounded-wait fallback that fires every sysdb.DBRetryInterval (1s).
+		// not the bounded-wait fallback that fires every _READ_STREAM_POLL_INTERVAL (1s).
 		if dbosCtx.(*dbosContext).systemDB.(*sysdb.SysDB).ListenNotifyPool() == nil {
 			t.Skip("backend does not support LISTEN/NOTIFY")
 		}

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -8986,6 +8986,166 @@ func collectStreamValues[R any](ch <-chan StreamValue[R]) ([]R, bool, error) {
 	return values, closed, err
 }
 
+const (
+	notifyTestStreamKey = "notify-test-stream"
+	notifyTestEventKey  = "notify-test-event"
+	// Each round is measured from a waiter that is already blocked. A waiter
+	// woken by its own fallback instead of a notification takes most of that
+	// interval, so several rounds separate the two cases by seconds.
+	notifyTestRounds = 5
+	// The budget every round must fit in when the wakeup is pushed. Falling back
+	// costs ~(fallback interval - notifyTestSettle) per round, an order of
+	// magnitude more.
+	notifyTestBudget = time.Second
+	// Time for a waiter to drain what is already written and block.
+	notifyTestSettle = 100 * time.Millisecond
+)
+
+// gatedNotifyWorkflow parks before each write, so every measurement below
+// starts with the waiter already blocked and nothing yet written.
+func gatedNotifyWorkflow(gate chan struct{}) func(Context, string) (string, error) {
+	return func(ctx Context, _ string) (string, error) {
+		for i := range notifyTestRounds {
+			<-gate
+			if err := WriteStream(ctx, notifyTestStreamKey, fmt.Sprintf("streamed-%d", i)); err != nil {
+				return "", err
+			}
+		}
+		for i := range notifyTestRounds {
+			<-gate
+			if err := SetEvent(ctx, fmt.Sprintf("%s-%d", notifyTestEventKey, i), "evented"); err != nil {
+				return "", err
+			}
+		}
+		return "done", nil
+	}
+}
+
+// awaitStreamValues returns how long a blocked reader took, in total, to
+// receive notifyTestRounds values written one gate opening at a time.
+func awaitStreamValues(t *testing.T, reader Client, workflowID string, gate chan struct{}) time.Duration {
+	t.Helper()
+	ch, err := ReadStreamAsync[string](reader, workflowID, notifyTestStreamKey)
+	require.NoError(t, err)
+
+	var total time.Duration
+	for i := range notifyTestRounds {
+		// Let the reader drain what it has and block, so the value written below
+		// reaches it as a wakeup rather than as part of a read already in flight.
+		time.Sleep(notifyTestSettle)
+		start := time.Now()
+		gate <- struct{}{}
+
+		select {
+		case value := <-ch:
+			require.NoError(t, value.Err)
+			require.Equal(t, fmt.Sprintf("streamed-%d", i), value.Value)
+		case <-time.After(30 * time.Second):
+			t.Fatal("reader never received the stream value")
+		}
+		total += time.Since(start)
+	}
+	return total
+}
+
+// awaitEvents returns how long blocked GetEvent calls took, in total, to see
+// notifyTestRounds values set one gate opening at a time.
+func awaitEvents(t *testing.T, reader Client, workflowID string, gate chan struct{}) time.Duration {
+	t.Helper()
+	type eventResult struct {
+		value string
+		err   error
+	}
+
+	var total time.Duration
+	for i := range notifyTestRounds {
+		results := make(chan eventResult, 1)
+		go func() {
+			value, err := GetEvent[string](reader, workflowID, fmt.Sprintf("%s-%d", notifyTestEventKey, i), 30*time.Second)
+			results <- eventResult{value, err}
+		}()
+
+		// Let GetEvent register its listener and block.
+		time.Sleep(notifyTestSettle)
+		start := time.Now()
+		gate <- struct{}{}
+
+		select {
+		case result := <-results:
+			require.NoError(t, result.err)
+			require.Equal(t, "evented", result.value)
+		case <-time.After(30 * time.Second):
+			t.Fatal("waiter never received the event")
+		}
+		total += time.Since(start)
+	}
+	return total
+}
+
+// With the triggers gone, a write only reaches waiters in other processes if
+// the writing process pushes the notification itself. A second DBOS context,
+// with its own pool, listener, and notifier, stands in for that process.
+func TestNotificationsReachOtherProcesses(t *testing.T) {
+	skipIfSqlite(t, "coalesced notifications require LISTEN/NOTIFY; sqlite waiters poll")
+	skipIfCockroach(t, "coalesced notifications require LISTEN/NOTIFY; CockroachDB waiters poll")
+
+	writerCtx := setupDBOS(t, setupDBOSOptions{dropDB: true})
+
+	gate := make(chan struct{})
+	writerWorkflow := gatedNotifyWorkflow(gate)
+	RegisterWorkflow(writerCtx, writerWorkflow, WithWorkflowName("CrossProcessNotifyWorkflow"))
+	require.NoError(t, Launch(writerCtx))
+
+	reader, err := NewClient(context.Background(), ClientConfig{DatabaseURL: backendDatabaseURL(t)})
+	require.NoError(t, err)
+	t.Cleanup(func() { reader.Shutdown(reader, 30*time.Second) })
+
+	handle, err := RunWorkflow(writerCtx, writerWorkflow, "")
+	require.NoError(t, err)
+
+	// A reader that missed the notification would only re-read on its fallback
+	// poll, one sysdb.DBRetryInterval later; a GetEvent waiter that missed it
+	// would only re-check on its own fallback tick a minute later.
+	require.Less(t, awaitStreamValues(t, reader, handle.GetWorkflowID(), gate), notifyTestBudget,
+		"stream writes should have been pushed to the other process, not found by its fallback poll")
+	require.Less(t, awaitEvents(t, reader, handle.GetWorkflowID(), gate), notifyTestBudget,
+		"events should have been pushed to the other process, not found by its fallback re-check")
+
+	_, err = handle.GetResult()
+	require.NoError(t, err)
+}
+
+// Waiters in the writing process are woken directly, without waiting for the
+// coalescing flush or a round trip through the database. The interval below is
+// set far out so that any wakeup arriving in time can only be the local one.
+func TestLocalWaitersAreWokenWithoutTheDatabase(t *testing.T) {
+	databaseURL := backendDatabaseURL(t)
+	resetTestDatabase(t, databaseURL)
+	dbosCtx, err := NewContext(context.Background(), Config{
+		DatabaseURL:                  databaseURL,
+		AppName:                      "test-app",
+		NotificationCoalesceInterval: time.Hour,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { Shutdown(dbosCtx, 30*time.Second) })
+
+	gate := make(chan struct{})
+	writerWorkflow := gatedNotifyWorkflow(gate)
+	RegisterWorkflow(dbosCtx, writerWorkflow, WithWorkflowName("LocalNotifyWorkflow"))
+	require.NoError(t, Launch(dbosCtx))
+
+	handle, err := RunWorkflow(dbosCtx, writerWorkflow, "")
+	require.NoError(t, err)
+
+	require.Less(t, awaitStreamValues(t, dbosCtx, handle.GetWorkflowID(), gate), notifyTestBudget,
+		"a local reader should be woken directly, not by its fallback poll")
+	require.Less(t, awaitEvents(t, dbosCtx, handle.GetWorkflowID(), gate), notifyTestBudget,
+		"a local waiter should be woken directly, not by its fallback re-check")
+
+	_, err = handle.GetResult()
+	require.NoError(t, err)
+}
+
 // Complex nested struct for testing rich input/output serialization in export/import
 type exportTestAddress struct {
 	Street  string `json:"street"`


### PR DESCRIPTION
This PR remove the per-stream-entry/per-event trigger/notify call in favor of batching pg_notify calls outside of the durable message transaction.

Specifically, we reuse the existing "notification hub" object, that was only used on the receiver side, to also expose producer-facing methods to signal an event/stream write, and periodically call pg_notify for these messages.

As an optimization, same-process consumers are immediately awoken (note this can only happen _after_ the write transaction has committed)


Closes #415 and #394 