### PR TITLE
Always enqueue recovered workflows

### DIFF
--- a/.github/workflows/cancellation-chaos-tests.yml
+++ b/.github/workflows/cancellation-chaos-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/chaos-tests.yml
+++ b/.github/workflows/chaos-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/tests-crdb.yml
+++ b/.github/workflows/tests-crdb.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - name: Start CockroachDB container
         run: |

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
 
       - name: Download dependencies
         run: go mod download

--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -432,7 +432,9 @@ func TestAdminServer(t *testing.T) {
 		require.NoError(t, err, "Failed to get first workflow result")
 		assert.Equal(t, "result-workflow1", result1)
 
-		// Record time between workflows
+		// Record time between workflows. Sleep on both sides so neither workflow's
+		// created_at can tie timeBetween at millisecond granularity.
+		time.Sleep(2 * time.Millisecond)
 		timeBetween := time.Now()
 		time.Sleep(500 * time.Millisecond)
 

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -513,7 +513,7 @@ type launchRecoveryFaultPool struct {
 }
 
 func (p *launchRecoveryFaultPool) Query(ctx context.Context, query string, args ...any) (sysdb.Rows, error) {
-	if strings.Contains(query, "SELECT workflow_uuid, status, name") {
+	if strings.Contains(query, "NULLIF(queue_name, '')") {
 		return nil, errors.New("injected recovery failure")
 	}
 	return p.Pool.Query(ctx, query, args...)

--- a/dbos/debouncer_test.go
+++ b/dbos/debouncer_test.go
@@ -379,9 +379,9 @@ func TestDebouncer(t *testing.T) {
 		// recovers to completion like any queued workflow.
 		setWorkflowStatusPending(t, dbosCtx, handle1.GetWorkflowID())
 
-		cleared, err := dbosCtxInstance.systemDB.ClearQueueAssignment(context.Background(), handle1.GetWorkflowID())
-		require.NoError(t, err, "failed to clear queue assignment")
-		require.True(t, cleared, "should have cleared queue assignment")
+		reenqueuedIDs, err := dbosCtxInstance.systemDB.ReenqueueForRecovery(context.Background(), []string{dbosCtxInstance.executorID}, dbosCtxInstance.applicationVersion, models.InternalQueueName)
+		require.NoError(t, err, "failed to re-enqueue workflow for recovery")
+		require.Contains(t, reenqueuedIDs, handle1.GetWorkflowID(), "should have re-enqueued workflow")
 
 		recoveredHandle := newWorkflowPollingHandle[any](dbosCtx, handle1.GetWorkflowID())
 		_, err = recoveredHandle.GetResult()

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -102,7 +102,7 @@ type SystemDatabase interface {
 	TransitionDelayedWorkflows(ctx context.Context) error
 	DebounceDelayedWorkflow(ctx context.Context, input DebounceDelayedWorkflowDBInput) (*DebounceResult, error)
 	DequeueWorkflows(ctx context.Context, input DequeueWorkflowsInput) ([]DequeuedWorkflow, error)
-	ClearQueueAssignment(ctx context.Context, workflowID string) (bool, error)
+	ReenqueueForRecovery(ctx context.Context, executorIDs []string, appVersion string, recoveryQueueName string) ([]string, error)
 	GetQueuePartitions(ctx context.Context, queueName string) ([]string, error)
 
 	// Database-backed queue registry (the queues table)
@@ -4709,28 +4709,55 @@ func (s *SysDB) DequeueWorkflows(ctx context.Context, input DequeueWorkflowsInpu
 	return retWorkflows, nil
 }
 
-func (s *SysDB) ClearQueueAssignment(ctx context.Context, workflowID string) (bool, error) {
-	query := s.RenderSQL(`UPDATE %sworkflow_status
-			  SET status = $1, started_at_epoch_ms = NULL
-			  WHERE workflow_uuid = $2
-			    AND queue_name IS NOT NULL
-			    AND status = $3`, s.dialect.SchemaPrefix(s.schema))
-
-	commandTag, err := s.pool.Exec(ctx, query,
+// ReenqueueForRecovery returns the PENDING workflows of the given executors
+// to a queue so they are re-dispatched, and returns the re-enqueued workflow IDs.
+// Non-queued workflows are placed on recoveryQueueName.
+func (s *SysDB) ReenqueueForRecovery(ctx context.Context, executorIDs []string, appVersion string, recoveryQueueName string) ([]string, error) {
+	if len(executorIDs) == 0 {
+		return nil, nil
+	}
+	encodedExecutorIDs, err := encodeArrayParam(s.dialect, executorIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode executor IDs for recovery: %w", err)
+	}
+	executorClause := dialectAnyClause(s.dialect, "executor_id", 5)
+	args := []any{
 		models.WorkflowStatusEnqueued,
-		workflowID,
-		models.WorkflowStatusPending)
-
-	if err != nil {
-		return false, fmt.Errorf("failed to clear queue assignment for workflow %s: %w", workflowID, err)
+		time.Now().UnixMilli(),
+		recoveryQueueName,
+		models.WorkflowStatusPending,
+		encodedExecutorIDs,
 	}
-
-	// If no rows were affected, the workflow is not anymore in the queue or was already completed
-	n, err := commandTag.RowsAffected()
-	if err != nil {
-		return false, fmt.Errorf("failed to read rows affected after clearing queue assignment for workflow %s: %w", workflowID, err)
+	versionClause := ""
+	if appVersion != "" { // appVersion should never be an empty string, but be defensive.
+		versionClause = " AND application_version = $6"
+		args = append(args, appVersion)
 	}
-	return n > 0, nil
+	query := s.RenderSQL(`UPDATE %sworkflow_status
+			  SET status = $1, started_at_epoch_ms = NULL, updated_at = $2,
+			      queue_name = COALESCE(NULLIF(queue_name, ''), $3)
+			  WHERE status = $4
+			    AND %s%s
+			  RETURNING workflow_uuid`, s.dialect.SchemaPrefix(s.schema), executorClause, versionClause)
+
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to re-enqueue workflows for recovery: %w", err)
+	}
+	defer rows.Close()
+
+	var workflowIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("failed to scan re-enqueued workflow id: %w", err)
+		}
+		workflowIDs = append(workflowIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read re-enqueued workflow ids: %w", err)
+	}
+	return workflowIDs, nil
 }
 
 // GetQueuePartitions returns all unique partition keys for enqueued workflows in a queue.

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -4474,11 +4474,14 @@ func (s *SysDB) debounceDelayedWorkflowInternal(ctx context.Context, tx Tx, inpu
 }
 
 type DequeuedWorkflow struct {
-	Id            string
-	Name          string
-	Input         *string
-	Serialization string
-	ConfigName    *string
+	Id                 string
+	Name               string
+	Input              *string
+	Serialization      string
+	ConfigName         *string
+	AuthenticatedUser  string
+	AssumedRole        string
+	AuthenticatedRoles []string
 }
 
 type DequeueWorkflowsInput struct {
@@ -4670,7 +4673,7 @@ func (s *SysDB) DequeueWorkflows(ctx context.Context, input DequeueWorkflowsInpu
 		        ELSE workflow_deadline_epoch_ms
 		    END
 		WHERE workflow_uuid = $6 AND status = $7
-		RETURNING name, inputs, serialization, config_name`, schemaPrefix)
+		RETURNING name, inputs, serialization, config_name, authenticated_user, assumed_role, authenticated_roles`, schemaPrefix)
 
 	var retWorkflows []DequeuedWorkflow
 	for _, id := range dequeuedIDs {
@@ -4681,7 +4684,7 @@ func (s *SysDB) DequeueWorkflows(ctx context.Context, input DequeueWorkflowsInpu
 		}
 		retWorkflow := DequeuedWorkflow{Id: id}
 
-		var serialization *string
+		var serialization, authenticatedUser, assumedRole, authenticatedRoles *string
 		err := tx.QueryRow(ctx, updateQuery,
 			models.WorkflowStatusPending,
 			input.ApplicationVersion,
@@ -4689,7 +4692,7 @@ func (s *SysDB) DequeueWorkflows(ctx context.Context, input DequeueWorkflowsInpu
 			time.Now().UnixMilli(),
 			input.Queue.RateLimit != nil,
 			id,
-			models.WorkflowStatusEnqueued).Scan(&retWorkflow.Name, &retWorkflow.Input, &serialization, &retWorkflow.ConfigName)
+			models.WorkflowStatusEnqueued).Scan(&retWorkflow.Name, &retWorkflow.Input, &serialization, &retWorkflow.ConfigName, &authenticatedUser, &assumedRole, &authenticatedRoles)
 		if err != nil {
 			if err == pgx.ErrNoRows {
 				continue
@@ -4698,6 +4701,17 @@ func (s *SysDB) DequeueWorkflows(ctx context.Context, input DequeueWorkflowsInpu
 		}
 		if serialization != nil {
 			retWorkflow.Serialization = *serialization
+		}
+		if authenticatedUser != nil {
+			retWorkflow.AuthenticatedUser = *authenticatedUser
+		}
+		if assumedRole != nil {
+			retWorkflow.AssumedRole = *assumedRole
+		}
+		if authenticatedRoles != nil {
+			if err := json.Unmarshal([]byte(*authenticatedRoles), &retWorkflow.AuthenticatedRoles); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal authenticated roles for workflow %s: %w", id, err)
+			}
 		}
 
 		retWorkflows = append(retWorkflows, retWorkflow)

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -1142,7 +1142,6 @@ func (s *SysDB) InsertWorkflowStatus(ctx context.Context, input InsertWorkflowSt
 		timeoutMs = &millis
 	}
 
-	// Our DB works with NULL values
 	var applicationVersion *string
 	if len(input.Status.ApplicationVersion) > 0 {
 		applicationVersion = &input.Status.ApplicationVersion
@@ -1187,6 +1186,11 @@ func (s *SysDB) InsertWorkflowStatus(ctx context.Context, input InsertWorkflowSt
 	if !input.Status.DebounceDeadline.IsZero() {
 		millis := input.Status.DebounceDeadline.UnixMilli()
 		debounceDeadlineEpochMs = &millis
+	}
+
+	var queueName *string
+	if input.Status.QueueName != "" {
+		queueName = &input.Status.QueueName
 	}
 
 	query := s.RenderSQL(`INSERT INTO %sworkflow_status (
@@ -1253,7 +1257,7 @@ func (s *SysDB) InsertWorkflowStatus(ctx context.Context, input InsertWorkflowSt
 		input.Status.ID,
 		input.Status.Status,
 		input.Status.Name,
-		input.Status.QueueName,
+		queueName,
 		input.Status.AuthenticatedUser,
 		input.Status.AssumedRole,
 		authenticatedRoles,
@@ -4733,6 +4737,7 @@ func (s *SysDB) ReenqueueForRecovery(ctx context.Context, executorIDs []string, 
 		versionClause = " AND application_version = $6"
 		args = append(args, appVersion)
 	}
+	// NULLIF: legacy rows stored not-enqueued as '' rather than NULL
 	query := s.RenderSQL(`UPDATE %sworkflow_status
 			  SET status = $1, started_at_epoch_ms = NULL, updated_at = $2,
 			      queue_name = COALESCE(NULLIF(queue_name, ''), $3)

--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -693,7 +693,15 @@ func (qr *queueRunner) runQueue(ctx *dbosContext, queue workflowQueue) {
 				}
 
 				// Pass encoded input directly - decoding will happen in workflow wrapper when we know the target type
-				_, err := registeredWorkflow.wrappedFunction(ctx, workflow.Input, workflow.Serialization, WithWorkflowID(workflow.Id), withIsDequeue())
+				// Auth identity is re-attached so child workflows spawned during
+				// the dequeued execution inherit the same identity as the original run.
+				_, err := registeredWorkflow.wrappedFunction(ctx, workflow.Input, workflow.Serialization,
+					WithWorkflowID(workflow.Id),
+					withIsDequeue(),
+					WithAuthenticatedUser(workflow.AuthenticatedUser),
+					WithAssumedRole(workflow.AssumedRole),
+					WithAuthenticatedRoles(workflow.AuthenticatedRoles...),
+				)
 				if err != nil {
 					queueLogger.Error("Error running queued workflow", "error", err)
 				}

--- a/dbos/queues_test.go
+++ b/dbos/queues_test.go
@@ -704,10 +704,15 @@ func TestWorkflowQueues(t *testing.T) {
 	})
 
 	t.Run("ReturnExistingValidation", func(t *testing.T) {
-		// Missing queue name
+		// Missing queue name (the deduplication ID check fires first)
 		_, err := RunWorkflow(dbosCtx, testWorkflow, "x", WithDeduplicationID("id"), WithDeduplicationPolicy(DeduplicationPolicyReturnExisting))
 		require.Error(t, err, "expected error when queue name is missing")
-		assert.Contains(t, err.Error(), "requires a queue name")
+		assert.Contains(t, err.Error(), "deduplication ID provided but queue name is missing")
+
+		// A policy alone (no dedup ID, no queue) still hits the policy check
+		_, err = RunWorkflow(dbosCtx, testWorkflow, "x", WithDeduplicationPolicy(DeduplicationPolicyReturnExisting))
+		require.Error(t, err, "expected error when deduplication ID and queue are missing")
+		assert.Contains(t, err.Error(), "requires a deduplication ID")
 
 		// Missing deduplication ID
 		_, err = RunWorkflow(dbosCtx, testWorkflow, "x", WithQueue(dedupQueue), WithDeduplicationPolicy(DeduplicationPolicyReturnExisting))

--- a/dbos/queues_test.go
+++ b/dbos/queues_test.go
@@ -1703,6 +1703,33 @@ func TestPartitionedQueues(t *testing.T) {
 		assert.Contains(t, dbosErr.Message, "partition key provided but queue name is missing")
 	})
 
+	t.Run("DeduplicationIDWithoutQueue", func(t *testing.T) {
+		dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
+
+		simpleWorkflow := func(ctx Context, input string) (string, error) {
+			return input, nil
+		}
+		RegisterWorkflow(dbosCtx, simpleWorkflow)
+
+		err := Launch(dbosCtx)
+		require.NoError(t, err, "failed to launch DBOS instance")
+
+		// A dedup ID on a non-queued workflow would be silently persisted and
+		// collide on the internal queue once recovery re-enqueues the workflow.
+		_, err = RunWorkflow(dbosCtx, simpleWorkflow, "test-input", WithDeduplicationID("dedup-without-queue"))
+		require.Error(t, err, "expected error when running with deduplication ID but no queue name")
+		var dbosErr *Error
+		require.ErrorAs(t, err, &dbosErr, "expected error to be of type *Error, got %T", err)
+		assert.True(t, errors.Is(err, ErrInvalidOption), "expected error to be ErrorCodeInvalidOption")
+		assert.Contains(t, dbosErr.Message, "deduplication ID provided but queue name is missing")
+
+		_, err = RunWorkflow(dbosCtx, simpleWorkflow, "test-input", WithPriority(5))
+		require.Error(t, err, "expected error when running with priority but no queue name")
+		require.ErrorAs(t, err, &dbosErr, "expected error to be of type *Error, got %T", err)
+		assert.True(t, errors.Is(err, ErrInvalidOption), "expected error to be ErrorCodeInvalidOption")
+		assert.Contains(t, dbosErr.Message, "priority provided but queue name is missing")
+	})
+
 	t.Run("PartitionKeyWithDeduplicationID", func(t *testing.T) {
 		dbosCtx := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true})
 

--- a/dbos/recovery.go
+++ b/dbos/recovery.go
@@ -1,90 +1,22 @@
 package dbos
 
 import (
-	"errors"
-
+	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/models"
 	"github.com/dbos-inc/dbos-transact-golang/dbos/internal/sysdb"
 )
 
+// recoverPendingWorkflows re-enqueues pending workflows owned by the specified executors and returns handles to them.
 func recoverPendingWorkflows(ctx *dbosContext, executorIDs []string) ([]WorkflowHandle[any], error) {
-	workflowHandles := make([]WorkflowHandle[any], 0)
-	// List pending workflows for the executors
-	pendingWorkflows, err := sysdb.RetryWithResult(ctx, func() ([]WorkflowStatus, error) {
-		appVersion := []string{}
-		if ctx.applicationVersion != "" {
-			appVersion = []string{ctx.applicationVersion}
-		}
-		return ctx.systemDB.ListWorkflows(ctx, sysdb.ListWorkflowsDBInput{
-			Status:             []WorkflowStatusType{WorkflowStatusPending},
-			ExecutorIDs:        executorIDs,
-			ApplicationVersion: appVersion,
-			LoadInput:          true,
-		})
+	recoveredIDs, err := sysdb.RetryWithResult(ctx, func() ([]string, error) {
+		return ctx.systemDB.ReenqueueForRecovery(ctx, executorIDs, ctx.applicationVersion, models.InternalQueueName)
 	}, sysdb.WithRetrierLogger(ctx.logger))
 	if err != nil {
 		return nil, err
 	}
 
-	for _, workflow := range pendingWorkflows {
-		if workflow.QueueName != "" {
-			cleared, err := sysdb.RetryWithResult(ctx, func() (bool, error) {
-				return ctx.systemDB.ClearQueueAssignment(ctx, workflow.ID)
-			}, sysdb.WithRetrierLogger(ctx.logger))
-			if err != nil {
-				ctx.logger.Error("Error clearing queue assignment for workflow", "workflow_id", workflow.ID, "name", workflow.Name, "error", err)
-				continue
-			}
-			if cleared {
-				workflowHandles = append(workflowHandles, newWorkflowPollingHandle[any](ctx, workflow.ID))
-			}
-			continue
-		}
-
-		// Configured instance workflows are registered under a name qualified with their config name.
-		lookupName := workflow.Name
-		if workflow.ConfigName != nil && *workflow.ConfigName != "" {
-			lookupName = instanceQualifiedName(workflow.Name, *workflow.ConfigName)
-		}
-		wfName, ok := ctx.workflowCustomNametoFQN.Load(lookupName)
-		if !ok {
-			ctx.logger.Error("Workflow not found in registry", "workflow_name", workflow.Name)
-			continue
-		}
-
-		registeredWorkflowAny, exists := ctx.workflowRegistry.Load(wfName.(string))
-		if !exists {
-			ctx.logger.Error("Workflow function not found in registry", "workflow_id", workflow.ID, "name", workflow.Name)
-			continue
-		}
-		registeredWorkflow, ok := registeredWorkflowAny.(WorkflowRegistryEntry)
-		if !ok {
-			ctx.logger.Error("invalid workflow registry entry type", "workflow_id", workflow.ID, "name", workflow.Name)
-			continue
-		}
-
-		// Convert workflow parameters to options.
-		// Auth identity is re-attached so child workflows spawned during
-		// recovery inherit the same identity as the original run.
-		opts := []WorkflowOption{
-			WithWorkflowID(workflow.ID),
-			withIsRecovery(),
-			WithAuthenticatedUser(workflow.AuthenticatedUser),
-			WithAssumedRole(workflow.AssumedRole),
-			WithAuthenticatedRoles(workflow.AuthenticatedRoles...),
-		}
-		// Create a workflow context from the executor context
-		// Pass encoded input directly - decoding will happen in workflow wrapper when we know the target type
-		handle, err := registeredWorkflow.wrappedFunction(ctx, workflow.Input, workflow.Serialization, opts...)
-		if err != nil {
-			// A dead-lettered workflow must not abort recovery of the remaining workflows
-			if errors.Is(err, ErrDeadLetterQueue) {
-				ctx.logger.Warn("Workflow exceeded max recovery attempts, moved to dead-letter queue", "workflow_id", workflow.ID, "name", workflow.Name)
-				continue
-			}
-			return nil, err
-		}
-		workflowHandles = append(workflowHandles, handle)
+	workflowHandles := make([]WorkflowHandle[any], 0, len(recoveredIDs))
+	for _, workflowID := range recoveredIDs {
+		workflowHandles = append(workflowHandles, newWorkflowPollingHandle[any](ctx, workflowID))
 	}
-
 	return workflowHandles, nil
 }

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -6170,13 +6170,18 @@ func GetLatestApplicationVersion(ctx Client) (VersionInfo, error) {
 }
 
 // SetLatestApplicationVersion marks the named application version as latest by
-// updating its timestamp to the current time.
+// updating its timestamp to the current time, bumped past the current latest so
+// the promoted version sorts strictly ahead even on same-millisecond ties.
 func (c *dbosContext) SetLatestApplicationVersion(_ Client, versionName string) error {
 	if versionName == "" {
 		return errors.New("version_name is required")
 	}
 	return sysdb.Retry(c, func() error {
-		return c.systemDB.UpdateApplicationVersionTimestamp(c, versionName, time.Now().UnixMilli())
+		ts := time.Now().UnixMilli()
+		if latest, err := c.systemDB.GetLatestApplicationVersion(c, nil); err == nil && latest.Timestamp >= ts {
+			ts = latest.Timestamp + 1
+		}
+		return c.systemDB.UpdateApplicationVersionTimestamp(c, versionName, ts)
 	}, sysdb.WithRetrierLogger(c.logger))
 }
 

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -1184,6 +1184,18 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 		return nil, models.NewInvalidOptionError("partition key provided but queue name is missing")
 	}
 
+	// Validate deduplication ID is not provided without a queue
+	if len(params.DeduplicationID) > 0 && params.queue == nil {
+		c.logger.Error("deduplication ID provided but queue name is missing", "workflow_name", params.WorkflowName)
+		return nil, models.NewInvalidOptionError("deduplication ID provided but queue name is missing")
+	}
+
+	// Validate priority is not provided without a queue
+	if params.Priority > 0 && params.queue == nil {
+		c.logger.Error("priority provided but queue name is missing", "workflow_name", params.WorkflowName)
+		return nil, models.NewInvalidOptionError("priority provided but queue name is missing")
+	}
+
 	// Validate partition key and deduplication ID are not both provided (they are incompatible)
 	if len(params.QueuePartitionKey) > 0 && len(params.DeduplicationID) > 0 {
 		c.logger.Error("partition key and deduplication ID cannot be used together", "workflow_name", params.WorkflowName)

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -840,7 +840,6 @@ type workflowOptions struct {
 	WorkflowAttributes  map[string]any
 	alreadyEncodedInput bool
 	isDequeue           bool
-	isRecovery          bool
 	isPortableWorkflow  bool
 	runInstance         ConfiguredInstance
 	err                 error // invalid option usage, surfaced when options are parsed
@@ -961,13 +960,6 @@ func withAlreadyEncodedInput() WorkflowOption {
 func withIsDequeue() WorkflowOption {
 	return func(p *workflowOptions) {
 		p.isDequeue = true
-	}
-}
-
-// Private option set when RunWorkflow is invoked from the recovery path (dbos/recovery.go).
-func withIsRecovery() WorkflowOption {
-	return func(p *workflowOptions) {
-		p.isRecovery = true
 	}
 }
 
@@ -1227,9 +1219,9 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 	parentWorkflowState, ok := c.Value(workflowStateKey).(*workflowState)
 	isChildWorkflow := ok && parentWorkflowState != nil
 
-	// Direct invocations require a launched runtime. Recovery, dequeue, and
-	// child workflow calls are internal paths that may run before Launch completes.
-	if !c.launched.Load() && !params.isRecovery && !params.isDequeue && !isChildWorkflow {
+	// Direct invocations require a launched runtime. Dequeue and child workflow
+	// calls are internal paths that may run before Launch completes.
+	if !c.launched.Load() && !params.isDequeue && !isChildWorkflow {
 		c.logger.Error("RunWorkflow called before Launch", "workflow_name", params.WorkflowName)
 		return nil, models.NewInitializationError("DBOS must be launched before running workflows; call Launch first")
 	}
@@ -1411,7 +1403,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 			MaxRetries:        params.MaxRetries,
 			Tx:                tx,
 			OwnerXID:          &ownerXID,
-			IncrementAttempts: params.isDequeue || params.isRecovery,
+			IncrementAttempts: params.isDequeue,
 		}
 		insertStatusResult, err = c.systemDB.InsertWorkflowStatus(uncancellableCtx, insertInput)
 		if err != nil {
@@ -1449,7 +1441,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 			len(queueName) > 0 || // We are enqueueing OR
 				insertStatusResult.Status == WorkflowStatusSuccess || // workflow is in a terminal state (success) OR
 				insertStatusResult.Status == WorkflowStatusError || // workflow is in a terminal state (error) OR
-				(!params.isDequeue && !params.isRecovery && insertStatusResult.OwnerXID != ownerXID) || // another executor, not us dequeueing or being instructed to recover, is already owning the workflow OR
+				(!params.isDequeue && insertStatusResult.OwnerXID != ownerXID) || // another executor, not us dequeueing, is already owning the workflow OR
 				loaded // this executor is already running the workflow
 
 		if shouldSkip {

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -5055,14 +5055,14 @@ func TestRecvStepConflict(t *testing.T) {
 		return sysA.RecvNotifier.Has(payload)
 	}, 5*time.Second, 10*time.Millisecond, "executor A never registered as receiver")
 
-	// Executor B recovers the same workflow: a genuinely concurrent second
+	// Executor B runs the same workflow concurrently: a genuinely concurrent second
 	// execution with its own in-memory receiver map, so it proceeds to wait and
-	// later races A to consume+checkpoint the message.
-	setWorkflowStatusPending(t, ctxA, workflowID)
-	recovered, err := recoverPendingWorkflows(ctxB.(*dbosContext), []string{"local"})
-	require.NoError(t, err, "failed to recover workflow on executor B")
-	require.Len(t, recovered, 1, "expected one recovered handle")
-	require.Equal(t, workflowID, recovered[0].GetWorkflowID())
+	// later races A to consume+checkpoint the message. Recovery re-enqueues and the
+	// queue's atomic dequeue admits exactly one runner (either executor could win),
+	// so deterministically force the duplicate dequeue-execution on B, as if B had
+	// dequeued the re-enqueued row while the zombie A still runs.
+	handleB, err := RunWorkflow(ctxB, recvConflictWorkflow, topic, WithWorkflowID(workflowID), withIsDequeue())
+	require.NoError(t, err, "failed to run duplicate execution on executor B")
 
 	// Executor B must actually run the body (register as receiver), not
 	// short-circuit; its separate map confirms a real concurrent execution.
@@ -5079,8 +5079,8 @@ func TestRecvStepConflict(t *testing.T) {
 	require.NoError(t, err, "executor A workflow should succeed")
 	require.Equal(t, "delivered", gotA)
 
-	gotB, err := recovered[0].GetResult()
-	require.NoError(t, err, "the concurrent recovery must converge on the result, not fail")
+	gotB, err := handleB.GetResult()
+	require.NoError(t, err, "the concurrent duplicate must converge on the result, not fail")
 	require.Equal(t, "delivered", gotB)
 }
 
@@ -5955,7 +5955,9 @@ func TestSleep(t *testing.T) {
 	require.NoError(t, Launch(dbosCtx), "failed to launch DBOS")
 
 	t.Run("SleepDurableRecovery", func(t *testing.T) {
-		sleepDuration := 2 * time.Second
+		// Generous duration: recovery dispatches through the internal queue, so the
+		// elapsed bound must absorb queue polling latency on top of the replay.
+		sleepDuration := 5 * time.Second
 		workflowID := uuid.NewString()
 
 		handle1, err := RunWorkflow(dbosCtx, sleepRecoveryWorkflow, sleepDuration, WithWorkflowID(workflowID))
@@ -10644,13 +10646,14 @@ func TestConcurrentStartRaceSameExecutor(t *testing.T) {
 // progress rather than lagging on a stale owner.
 //
 // It reproduces the zombie/recovery race: executor A starts a workflow and blocks
-// inside its only step; executor B recovers the still-PENDING workflow, which
-// transfers the marker to B via the recovery status insert. Both executions are
-// now live in the step body. The still-running A ("zombie") is released first: its
-// step checkpoint must reclaim the marker for A. The recovery insert is not what
-// is under test here — A never re-inserts its status, so only the step-checkpoint
-// re-stamp can flip executor_id back to A. B is released last; losing the
-// checkpoint race, it must not re-stamp.
+// inside its only step; executor B runs a duplicate execution of the still-PENDING
+// workflow (as if it had dequeued the row recovery re-enqueued), which transfers
+// the marker to B via its status insert. Both executions are now live in the step
+// body. The still-running A ("zombie") is released first: its step checkpoint must
+// reclaim the marker for A. The duplicate's insert is not what is under test here —
+// A never re-inserts its status, so only the step-checkpoint re-stamp can flip
+// executor_id back to A. B is released last; losing the checkpoint race, it must
+// not re-stamp.
 func TestStepCheckpointReclaimsExecutorID(t *testing.T) {
 	const (
 		executorA = "executor-a"
@@ -10723,15 +10726,16 @@ func TestStepCheckpointReclaimsExecutorID(t *testing.T) {
 	aInStep.Wait()
 	require.Equal(t, executorA, readExecutorID(), "precondition: A owns the workflow after starting it")
 
-	// B recovers the still-PENDING workflow: the recovery status insert transfers
-	// the marker to B. B now runs the step body concurrently with A and blocks.
-	recovered, err := recoverPendingWorkflows(ctxB.(*dbosContext), []string{executorA})
-	require.NoError(t, err, "failed to recover the workflow on executor B")
-	require.Len(t, recovered, 1, "expected exactly one pending workflow to recover")
-	require.Equal(t, wfID, recovered[0].GetWorkflowID())
+	// B runs the still-PENDING workflow concurrently, as if it had dequeued the
+	// row recovery re-enqueued (the shared queue's dequeue is not deterministic
+	// about which executor wins, so force the duplicate dequeue-execution on B):
+	// the duplicate's status insert transfers the marker to B. B now runs the
+	// step body concurrently with A and blocks.
+	handleB, err := RunWorkflow(ctxB, blockingWorkflow, "", WithWorkflowID(wfID), withIsDequeue())
+	require.NoError(t, err, "failed to run duplicate execution on executor B")
 	bInStep.Wait()
 	require.Equal(t, executorB, readExecutorID(),
-		"recovery must transfer the executor_id marker to B via its status insert")
+		"the duplicate execution must transfer the executor_id marker to B via its status insert")
 
 	// Release the still-running A. Its step checkpoint is the ONLY thing that can
 	// flip the marker back to A (A never re-inserts its status): this is the
@@ -10746,7 +10750,7 @@ func TestStepCheckpointReclaimsExecutorID(t *testing.T) {
 	// Release B. It loses the checkpoint race (A already recorded the step), so it
 	// must observe the conflict, park, and NOT re-stamp the marker.
 	close(releaseB)
-	resB, err := recovered[0].GetResult()
+	resB, err := handleB.GetResult()
 	require.NoError(t, err, "the losing execution should resolve to the winner's result via polling")
 	require.Equal(t, "done", resB)
 	require.EqualValues(t, 2, execCount.Load(), "both executions must have genuinely run the step body")

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -7753,6 +7753,22 @@ func authParentWorkflow(ctx Context, _ string) (authSnapshot, error) {
 	return handle.GetResult()
 }
 
+// authRecoveryParentWorkflow spawns its child only on re-execution, so the child
+// spawn is not checkpointed by the first run: after recovery, the child can only
+// inherit its identity from the auth context re-attached on the dequeue path.
+var authRecoveryRuns atomic.Int64
+
+func authRecoveryParentWorkflow(ctx Context, _ string) (authSnapshot, error) {
+	if authRecoveryRuns.Add(1) == 1 {
+		return authSnapshot{}, nil
+	}
+	handle, err := RunWorkflow(ctx, authChildWorkflow, "")
+	if err != nil {
+		return authSnapshot{}, err
+	}
+	return handle.GetResult()
+}
+
 // authGrandparentWorkflow tests three-level propagation.
 func authGrandparentWorkflow(ctx Context, _ string) (authSnapshot, error) {
 	handle, err := RunWorkflow(ctx, authParentWorkflow, "")
@@ -7781,6 +7797,7 @@ func TestAuthPropagation(t *testing.T) {
 	RegisterWorkflow(dbosCtx, authParentWorkflow)
 	RegisterWorkflow(dbosCtx, authGrandparentWorkflow)
 	RegisterWorkflow(dbosCtx, authParentWithOverrideWorkflow)
+	RegisterWorkflow(dbosCtx, authRecoveryParentWorkflow)
 	require.NoError(t, Launch(dbosCtx), "failed to launch DBOS")
 
 	t.Run("PropagatesFromParentToChild", func(t *testing.T) {
@@ -7837,8 +7854,9 @@ func TestAuthPropagation(t *testing.T) {
 
 	t.Run("PropagatesAfterRecovery", func(t *testing.T) {
 		const wfID = "auth-recovery-test-wf"
+		authRecoveryRuns.Store(0)
 
-		handle, err := RunWorkflow(dbosCtx, authParentWorkflow, "",
+		handle, err := RunWorkflow(dbosCtx, authRecoveryParentWorkflow, "",
 			WithWorkflowID(wfID),
 			WithAuthenticatedUser("alice@example.com"),
 			WithAssumedRole("customer"),
@@ -7848,7 +7866,9 @@ func TestAuthPropagation(t *testing.T) {
 		_, err = handle.GetResult()
 		require.NoError(t, err)
 
-		// Simulate crash: reset parent to PENDING so recovery re-runs it.
+		// Simulate crash: reset parent to PENDING so recovery re-runs it. The
+		// re-run spawns the child fresh (nothing checkpointed), so the child's
+		// identity must come from the re-attached auth context.
 		setWorkflowStatusPending(t, dbosCtx, wfID)
 
 		recoveredHandles, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -3614,15 +3614,16 @@ func TestWorkflowDeadLetterQueue(t *testing.T) {
 			setWorkflowStatusPending(t, dbosCtx, wfID)
 		}
 
-		// Verify an additional attempt dead-letters the workflow; recovery skips it without error
-		dlqHandles, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
+		// Verify an additional attempt dead-letters the workflow.
+		// Recovery re-enqueues, so the DLQ transition happens when the queue dequeues the workflow.
+		_, err = recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
 		require.NoError(t, err, "recovery should not fail on a dead-lettered workflow")
-		require.Empty(t, dlqHandles, "dead-lettered workflow should not be recovered")
 
-		// Verify workflow status is MAX_RECOVERY_ATTEMPTS_EXCEEDED
-		status, err := handle.GetStatus()
-		require.NoError(t, err, "failed to get workflow status")
-		require.Equal(t, WorkflowStatusMaxRecoveryAttemptsExceeded, status.Status)
+		// Verify workflow status eventually becomes MAX_RECOVERY_ATTEMPTS_EXCEEDED
+		require.Eventually(t, func() bool {
+			status, err := handle.GetStatus()
+			return err == nil && status.Status == WorkflowStatusMaxRecoveryAttemptsExceeded
+		}, 10*time.Second, 100*time.Millisecond, "expected workflow to be dead-lettered")
 
 		// Verify that getResult returns the DLQ error. Need a new handle
 		retrievedHandle, err := RetrieveWorkflow[int](dbosCtx, wfID)
@@ -3659,7 +3660,7 @@ func TestWorkflowDeadLetterQueue(t *testing.T) {
 		require.Equal(t, result1, int(result3.(float64)))
 
 		// Verify workflow status is SUCCESS
-		status, err = handle.GetStatus()
+		status, err := handle.GetStatus()
 		require.NoError(t, err, "failed to get final workflow status")
 		require.Equal(t, WorkflowStatusSuccess, status.Status)
 
@@ -3699,7 +3700,8 @@ func TestWorkflowDeadLetterQueue(t *testing.T) {
 
 	t.Run("DeadLetterDoesNotAbortRecovery", func(t *testing.T) {
 		// One poisoned (max attempts already reached) and one healthy pending workflow:
-		// recovery must skip the poisoned one and still recover the healthy one.
+		// recovery re-enqueues both; the poisoned one is dead-lettered at dequeue
+		// while the healthy one still recovers to completion.
 		poisonedID := uuid.NewString()
 		poisonedHandle, err := RunWorkflow(dbosCtx, poisonedDLQWorkflow, "test", WithWorkflowID(poisonedID))
 		require.NoError(t, err, "failed to start poisoned workflow")
@@ -3725,14 +3727,21 @@ func TestWorkflowDeadLetterQueue(t *testing.T) {
 
 		handles, err := recoverPendingWorkflows(dbosCtx.(*dbosContext), []string{"local"})
 		require.NoError(t, err, "dead-lettered workflow must not abort recovery")
-		require.Len(t, handles, 1, "expected only the healthy workflow to be recovered")
-		require.Equal(t, healthyID, handles[0].GetWorkflowID())
-		_, err = handles[0].GetResult()
+		require.Len(t, handles, 2, "expected both pending workflows to be re-enqueued")
+		var healthyRecovered WorkflowHandle[any]
+		for _, h := range handles {
+			if h.GetWorkflowID() == healthyID {
+				healthyRecovered = h
+			}
+		}
+		require.NotNil(t, healthyRecovered, "expected a handle for the healthy workflow")
+		_, err = healthyRecovered.GetResult()
 		require.NoError(t, err, "failed to get result from recovered healthy workflow")
 
-		status, err := poisonedHandle.GetStatus()
-		require.NoError(t, err, "failed to get status of poisoned workflow")
-		require.Equal(t, WorkflowStatusMaxRecoveryAttemptsExceeded, status.Status)
+		require.Eventually(t, func() bool {
+			status, err := poisonedHandle.GetStatus()
+			return err == nil && status.Status == WorkflowStatusMaxRecoveryAttemptsExceeded
+		}, 10*time.Second, 100*time.Millisecond, "expected poisoned workflow to be dead-lettered")
 	})
 }
 

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -7021,6 +7021,9 @@ func TestGarbageCollect(t *testing.T) {
 			require.NoError(t, err, "failed to get result from test workflow %d", i)
 			require.Equal(t, i, result, "expected result %d, got %d", i, result)
 			completedHandles = append(completedHandles, handle)
+			// Keep created_at distinct: GC's rows-threshold cutoff uses strict
+			// created_at comparison, so millisecond ties spare extra rows.
+			time.Sleep(2 * time.Millisecond)
 		}
 
 		// Verify exactly 11 workflows exist before GC (1 blocked + 10 completed)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dbos-inc/dbos-transact-golang
 
 go 1.25.0
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	github.com/containerd/errdefs v1.0.0


### PR DESCRIPTION
Also:
* Batch recovery enqueues
* Filter recovered workflows by the list of executors to recover
* Store non-queued workflows queue name as null instead of an empty string (made backward compatible with `NULLIF`)

Closes #406 