### PR TITLE
Better step timing

### DIFF
--- a/dbos/admin_server.go
+++ b/dbos/admin_server.go
@@ -71,6 +71,18 @@ type listWorkflowsRequest struct {
 	QueueName          *string       `json:"queue_name"`          // Filter by queue name (for queued workflows)
 }
 
+// queueMetadata is the wire shape of the queues-metadata endpoint. Its
+// camelCase keys match the other SDKs; the rate limit renders as
+// {"limit": n, "period": seconds} via RateLimiter.MarshalJSON.
+type queueMetadata struct {
+	Name              string       `json:"name"`
+	WorkerConcurrency *int         `json:"workerConcurrency,omitempty"`
+	GlobalConcurrency *int         `json:"concurrency,omitempty"`
+	PriorityEnabled   bool         `json:"priorityEnabled,omitempty"`
+	RateLimit         *RateLimiter `json:"rateLimit,omitempty"`
+	PartitionQueue    bool         `json:"partitionQueue,omitempty"`
+}
+
 // buildOptions converts the request struct into a slice of ListWorkflowsOption
 func (req *listWorkflowsRequest) toListWorkflowsOptions() []ListWorkflowsOption {
 	var opts []ListWorkflowsOption
@@ -277,11 +289,22 @@ func newAdminServer(ctx *dbosContext, port int) *adminServer {
 	ctx.logger.Debug("Registering admin server endpoint", "pattern", _WORKFLOW_QUEUES_METADATA_PATTERN)
 	mux.HandleFunc(_WORKFLOW_QUEUES_METADATA_PATTERN, func(w http.ResponseWriter, r *http.Request) {
 		// The internal queue plus all database-backed queues.
-		queueMetadataArray := []workflowQueue{ctx.queueRunner.internalQueue}
+		queues := []workflowQueue{ctx.queueRunner.internalQueue}
 		if dbQueueCfgs, err := ctx.systemDB.ListQueues(ctx); err != nil {
 			ctx.logger.Error("Error listing database-backed queues", "error", err)
 		} else {
-			queueMetadataArray = append(queueMetadataArray, queuesFromConfigs(dbQueueCfgs)...)
+			queues = append(queues, queuesFromConfigs(dbQueueCfgs)...)
+		}
+		queueMetadataArray := make([]queueMetadata, len(queues))
+		for i, q := range queues {
+			queueMetadataArray[i] = queueMetadata{
+				Name:              q.Name,
+				WorkerConcurrency: q.WorkerConcurrency,
+				GlobalConcurrency: q.GlobalConcurrency,
+				PriorityEnabled:   q.PriorityEnabled,
+				RateLimit:         q.RateLimit,
+				PartitionQueue:    q.PartitionQueue,
+			}
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/dbos/admin_server_test.go
+++ b/dbos/admin_server_test.go
@@ -143,15 +143,15 @@ func TestAdminServer(t *testing.T) {
 				endpoint:       fmt.Sprintf("http://localhost:%d/%s", _DEFAULT_ADMIN_SERVER_PORT, strings.TrimPrefix(_WORKFLOW_QUEUES_METADATA_PATTERN, "GET /")),
 				expectedStatus: http.StatusOK,
 				validateResp: func(t *testing.T, resp *http.Response) {
-					var queueMetadata []workflowQueue
-					err := json.NewDecoder(resp.Body).Decode(&queueMetadata)
+					var queues []queueMetadata
+					err := json.NewDecoder(resp.Body).Decode(&queues)
 					require.NoError(t, err, "Failed to decode response as QueueMetadata array")
-					assert.NotNil(t, queueMetadata, "Expected non-nil queue metadata array")
+					assert.NotNil(t, queues, "Expected non-nil queue metadata array")
 					// Should contain at least the internal queue
-					assert.Greater(t, len(queueMetadata), 0, "Expected at least one queue in metadata")
+					assert.Greater(t, len(queues), 0, "Expected at least one queue in metadata")
 					// Verify internal queue fields
 					foundInternalQueue := false
-					for _, queue := range queueMetadata {
+					for _, queue := range queues {
 						if queue.Name == models.InternalQueueName { // Internal queue name
 							foundInternalQueue = true
 							assert.Nil(t, queue.GlobalConcurrency, "Expected internal queue to have no concurrency limit")

--- a/dbos/datasource.go
+++ b/dbos/datasource.go
@@ -187,7 +187,7 @@ func (ds *DataSource) completionTableStatements() []string {
 		fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, pgx.Identifier{ds.schema}.Sanitize()),
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
 	workflow_id TEXT NOT NULL,
-	step_id INT NOT NULL,
+	step_id INT4 NOT NULL,
 	output TEXT,
 	error TEXT,
 	serialization TEXT,

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -2022,4 +2023,36 @@ func TestCustomSqlitePool(t *testing.T) {
 		systemDB.Shutdown(ctx, 2*time.Second)
 		assert.False(t, systemDB.(*sysdb.SysDB).Launched())
 	})
+}
+
+func TestPoolMaxConnsFromURL(t *testing.T) {
+	skipIfSqlite(t, "pool sizing applies to the Postgres pool")
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(testWriter{t}, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	u, err := url.Parse(getDatabaseURL())
+	require.NoError(t, err)
+	q := u.Query()
+	q.Set("pool_max_conns", "7")
+	u.RawQuery = q.Encode()
+
+	systemDB, err := sysdb.NewSystemDatabase(ctx, sysdb.NewSystemDatabaseInput{
+		DatabaseURL:    u.String(),
+		DatabaseSchema: "dbos",
+		Logger:         logger,
+	})
+	require.NoError(t, err)
+	defer systemDB.Shutdown(ctx, 2*time.Second)
+	require.EqualValues(t, 7, PgxPool(systemDB.(*sysdb.SysDB).Pool()).Config().MaxConns,
+		"pool_max_conns from the database URL should be honored")
+
+	systemDB2, err := sysdb.NewSystemDatabase(ctx, sysdb.NewSystemDatabaseInput{
+		DatabaseURL:    getDatabaseURL(),
+		DatabaseSchema: "dbos",
+		Logger:         logger,
+	})
+	require.NoError(t, err)
+	defer systemDB2.Shutdown(ctx, 2*time.Second)
+	require.EqualValues(t, 20, PgxPool(systemDB2.(*sysdb.SysDB).Pool()).Config().MaxConns,
+		"the default pool size should apply when the URL does not set pool_max_conns")
 }

--- a/dbos/internal/models/inputs.go
+++ b/dbos/internal/models/inputs.go
@@ -136,13 +136,13 @@ type GetStepAggregatesInput struct {
 }
 
 type StepInfo struct {
-	StepID          int       // The sequential ID of the step within the workflow
-	StepName        string    // The name of the step function
-	Output          any       // The output returned by the step (if any)
-	Error           error     // The error returned by the step (if any)
-	ChildWorkflowID string    // The ID of a child workflow spawned by this step (if applicable)
-	StartedAt       time.Time `json:",omitzero"` // When the step execution started
-	CompletedAt     time.Time `json:",omitzero"` // When the step execution completed
+	StepID          int       `json:"function_id"`                 // The sequential ID of the step within the workflow
+	StepName        string    `json:"function_name"`               // The name of the step function
+	Output          any       `json:"output,omitempty"`            // The output returned by the step (if any)
+	Error           error     `json:"error,omitempty"`             // The error returned by the step (if any)
+	ChildWorkflowID string    `json:"child_workflow_id,omitempty"` // The ID of a child workflow spawned by this step (if applicable)
+	StartedAt       time.Time `json:"started_at,omitzero"`         // When the step execution started
+	CompletedAt     time.Time `json:"completed_at,omitzero"`       // When the step execution completed
 }
 
 // AlertHandler is a function that handles alerts received from DBOS Conductor.

--- a/dbos/internal/models/queue.go
+++ b/dbos/internal/models/queue.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // InternalQueueName is the reserved queue used internally by DBOS.
 const InternalQueueName = "_dbos_internal_queue"
@@ -10,19 +13,44 @@ const DefaultBasePollingInterval = 1 * time.Second
 
 // RateLimiter's docs live on its public alias in dbos/aliases.go.
 type RateLimiter struct {
-	Limit  int           // Maximum number of workflows to start within the period
-	Period time.Duration // Time period for the rate limit
+	Limit  int           `json:"limit"` // Maximum number of workflows to start within the period
+	Period time.Duration `json:"-"`     // Time period for the rate limit; rendered as period in seconds in JSON (see MarshalJSON)
+}
+
+// MarshalJSON renders Period as seconds (period), matching the other DBOS SDKs
+// and the queues table, instead of Go's nanosecond Duration.
+func (r RateLimiter) MarshalJSON() ([]byte, error) {
+	type alias RateLimiter
+	return json.Marshal(struct {
+		alias
+		Period float64 `json:"period"`
+	}{alias: alias(r), Period: r.Period.Seconds()})
+}
+
+// UnmarshalJSON decodes the shape produced by MarshalJSON: period in seconds
+// back into a Duration.
+func (r *RateLimiter) UnmarshalJSON(data []byte) error {
+	type alias RateLimiter
+	aux := struct {
+		*alias
+		Period float64 `json:"period"`
+	}{alias: (*alias)(r)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	r.Period = time.Duration(aux.Period * float64(time.Second))
+	return nil
 }
 
 // QueueConfig is the persisted configuration of a workflow queue, as stored in
 // the queues table.
 type QueueConfig struct {
 	Name                string        `json:"name"`
-	WorkerConcurrency   *int          `json:"workerConcurrency,omitempty"`
+	WorkerConcurrency   *int          `json:"worker_concurrency,omitempty"`
 	GlobalConcurrency   *int          `json:"concurrency,omitempty"`
-	PriorityEnabled     bool          `json:"priorityEnabled,omitempty"`
-	RateLimit           *RateLimiter  `json:"rateLimit,omitempty"`
-	PartitionQueue      bool          `json:"partitionQueue,omitempty"`
+	PriorityEnabled     bool          `json:"priority_enabled,omitempty"`
+	RateLimit           *RateLimiter  `json:"rate_limit,omitempty"`
+	PartitionQueue      bool          `json:"partition_queue,omitempty"`
 	BasePollingInterval time.Duration `json:"-"`
 	MaxPollingInterval  time.Duration `json:"-"`
 	DatabaseBacked      bool          `json:"-"`

--- a/dbos/internal/sysdb/migrations/14_add_pgsql_client_functions.sql
+++ b/dbos/internal/sysdb/migrations/14_add_pgsql_client_functions.sql
@@ -12,7 +12,7 @@ CREATE FUNCTION %s.enqueue_workflow(
     timeout_ms BIGINT DEFAULT NULL,
     deadline_epoch_ms BIGINT DEFAULT NULL,
     deduplication_id TEXT DEFAULT NULL,
-    priority INTEGER DEFAULT NULL,
+    priority INT4 DEFAULT NULL,
     queue_partition_key TEXT DEFAULT NULL
 ) RETURNS TEXT AS $$
 DECLARE
@@ -20,8 +20,8 @@ DECLARE
     v_serialized_inputs TEXT;
     v_owner_xid TEXT;
     v_now BIGINT;
-    v_recovery_attempts INTEGER := 0;
-    v_priority INTEGER;
+    v_recovery_attempts INT4 := 0;
+    v_priority INT4;
 BEGIN
 
     -- Validate required parameters

--- a/dbos/internal/sysdb/migrations/1_initial_dbos_schema.sql
+++ b/dbos/internal/sysdb/migrations/1_initial_dbos_schema.sql
@@ -22,7 +22,7 @@ CREATE TABLE %s.workflow_status (
     inputs TEXT,
     started_at_epoch_ms BIGINT,
     deduplication_id TEXT,
-    priority INTEGER NOT NULL DEFAULT 0
+    priority INT4 NOT NULL DEFAULT 0
 );
 
 CREATE INDEX workflow_status_created_at_index ON %s.workflow_status (created_at);
@@ -35,7 +35,7 @@ UNIQUE (queue_name, deduplication_id);
 
 CREATE TABLE %s.operation_outputs (
     workflow_uuid TEXT NOT NULL,
-    function_id INTEGER NOT NULL,
+    function_id INT4 NOT NULL,
     function_name TEXT NOT NULL DEFAULT '',
     output TEXT,
     error TEXT,
@@ -69,7 +69,7 @@ CREATE TABLE %s.streams (
     workflow_uuid TEXT NOT NULL,
     key TEXT NOT NULL,
     value TEXT NOT NULL,
-    "offset" INTEGER NOT NULL,
+    "offset" INT4 NOT NULL,
     PRIMARY KEY (workflow_uuid, key, "offset"),
     FOREIGN KEY (workflow_uuid) REFERENCES %s.workflow_status(workflow_uuid)
         ON UPDATE CASCADE ON DELETE CASCADE

--- a/dbos/internal/sysdb/migrations/20_set_function_search_path.sql
+++ b/dbos/internal/sysdb/migrations/20_set_function_search_path.sql
@@ -8,7 +8,7 @@
 -- ALTER FUNCTION ... SET. The runner passes the empty string in that case.
 
 ALTER FUNCTION %s.enqueue_workflow(
-    TEXT, TEXT, JSON[], JSON, TEXT, TEXT, TEXT, TEXT, BIGINT, BIGINT, TEXT, INTEGER, TEXT
+    TEXT, TEXT, JSON[], JSON, TEXT, TEXT, TEXT, TEXT, BIGINT, BIGINT, TEXT, INT4, TEXT
 ) SET search_path = pg_catalog, pg_temp;
 
 ALTER FUNCTION %s.send_message(

--- a/dbos/internal/sysdb/migrations/21_create_queues_table.sql
+++ b/dbos/internal/sysdb/migrations/21_create_queues_table.sql
@@ -6,9 +6,9 @@
 CREATE TABLE %s.queues (
     queue_id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
     name TEXT NOT NULL UNIQUE,
-    concurrency INTEGER,
-    worker_concurrency INTEGER,
-    rate_limit_max INTEGER,
+    concurrency INT4,
+    worker_concurrency INT4,
+    rate_limit_max INT4,
     rate_limit_period_sec DOUBLE PRECISION,
     priority_enabled BOOLEAN NOT NULL DEFAULT FALSE,
     partition_queue BOOLEAN NOT NULL DEFAULT FALSE,

--- a/dbos/internal/sysdb/migrations/38_update_enqueue_workflow.sql
+++ b/dbos/internal/sysdb/migrations/38_update_enqueue_workflow.sql
@@ -4,7 +4,7 @@
 -- function is dropped first so only the new signature remains.
 
 DROP FUNCTION IF EXISTS %s.enqueue_workflow(
-    TEXT, TEXT, JSON[], JSON, TEXT, TEXT, TEXT, TEXT, BIGINT, BIGINT, TEXT, INTEGER, TEXT
+    TEXT, TEXT, JSON[], JSON, TEXT, TEXT, TEXT, TEXT, BIGINT, BIGINT, TEXT, INT4, TEXT
 );
 
 CREATE OR REPLACE FUNCTION %s.enqueue_workflow(

--- a/dbos/internal/sysdb/migrations/6_add_workflow_events_history.sql
+++ b/dbos/internal/sysdb/migrations/6_add_workflow_events_history.sql
@@ -3,7 +3,7 @@
 
 CREATE TABLE %s.workflow_events_history (
     workflow_uuid TEXT NOT NULL,
-    function_id INTEGER NOT NULL,
+    function_id INT4 NOT NULL,
     key TEXT NOT NULL,
     value TEXT NOT NULL,
     PRIMARY KEY (workflow_uuid, function_id, key),
@@ -11,5 +11,5 @@ CREATE TABLE %s.workflow_events_history (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-ALTER TABLE %s.streams ADD COLUMN function_id INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE %s.streams ADD COLUMN function_id INT4 NOT NULL DEFAULT 0;
 

--- a/dbos/internal/sysdb/sysdb_test.go
+++ b/dbos/internal/sysdb/sysdb_test.go
@@ -206,3 +206,21 @@ func TestIsRetryableRejectsContextErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestConnStringSetsPoolMaxConns(t *testing.T) {
+	cases := []struct {
+		connString string
+		want       bool
+	}{
+		{"postgres://user:pass@localhost:5432/dbos?sslmode=disable&pool_max_conns=7", true},
+		{"postgres://user:pass@localhost:5432/dbos?pool_max_conns=7", true},
+		{"postgres://user:pass@localhost:5432/dbos?sslmode=disable", false},
+		{"host=localhost port=5432 dbname=dbos pool_max_conns=7", true},
+		{"host=localhost port=5432 dbname=dbos", false},
+	}
+	for _, c := range cases {
+		if got := connStringSetsPoolMaxConns(c.connString); got != c.want {
+			t.Errorf("connStringSetsPoolMaxConns(%q) = %v, want %v", c.connString, got, c.want)
+		}
+	}
+}

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -3022,14 +3022,14 @@ func (s *SysDB) CheckOperationExecution(ctx context.Context, input CheckOperatio
 
 // StepInfo contains information about a workflow step execution.
 type StepRow struct {
-	StepID          int       // The sequential ID of the step within the workflow
-	StepName        string    // The name of the step function
-	Output          *string   // The output returned by the step (if any)
-	Error           error     // The error returned by the step (if any)
-	ChildWorkflowID string    // The ID of a child workflow spawned by this step (if applicable)
-	StartedAt       time.Time // When the step execution started
-	CompletedAt     time.Time // When the step execution completed
-	Serialization   string    // The serialization format used for this step
+	StepID          int       `json:"function_id"`                 // The sequential ID of the step within the workflow
+	StepName        string    `json:"function_name"`               // The name of the step function
+	Output          *string   `json:"output,omitempty"`            // The output returned by the step (if any)
+	Error           error     `json:"error,omitempty"`             // The error returned by the step (if any)
+	ChildWorkflowID string    `json:"child_workflow_id,omitempty"` // The ID of a child workflow spawned by this step (if applicable)
+	StartedAt       time.Time `json:"started_at,omitzero"`         // When the step execution started
+	CompletedAt     time.Time `json:"completed_at,omitzero"`       // When the step execution completed
+	Serialization   string    `json:"serialization,omitempty"`     // The serialization format used for this step
 }
 
 type GetWorkflowStepsInput struct {
@@ -4396,10 +4396,10 @@ type DebounceDelayedWorkflowDBInput struct {
 
 // DebounceResult reports the outcome of a bounce attempt.
 type DebounceResult struct {
-	BouncedWorkflowID  *string // The extended workflow's ID if an existing debounced DELAYED workflow was bounced; nil if no bounce occurred
-	HolderWorkflowID   *string // The workflow currently holding the deduplication ID, if any, when no bounce occurred
-	HolderIsDebounced  bool    // Whether the holder is itself a debounced workflow
-	HolderWorkflowName string  // The holder's workflow name; a mismatch with the caller's means a debounce-key collision between workflows
+	BouncedWorkflowID  *string `json:"bounced_workflow_id"`  // The extended workflow's ID if an existing debounced DELAYED workflow was bounced; nil if no bounce occurred
+	HolderWorkflowID   *string `json:"holder_workflow_id"`   // The workflow currently holding the deduplication ID, if any, when no bounce occurred
+	HolderIsDebounced  bool    `json:"holder_is_debounced"`  // Whether the holder is itself a debounced workflow
+	HolderWorkflowName string  `json:"holder_workflow_name"` // The holder's workflow name; a mismatch with the caller's means a debounce-key collision between workflows
 }
 
 // DebounceDelayedWorkflow extends an existing debounced DELAYED workflow's delay and

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -2833,6 +2833,7 @@ type RecordChildWorkflowDBInput struct {
 	ChildWorkflowID  string
 	StepID           int
 	StepName         string
+	StartedAt        time.Time
 	Tx               Tx
 }
 
@@ -2843,8 +2844,8 @@ func (s *SysDB) RecordChildWorkflow(ctx context.Context, input RecordChildWorkfl
 	// so a duplicate never aborts the caller's transaction; on conflict, read
 	// back the recorded child and compare.
 	query := s.RenderSQL(`INSERT INTO %soperation_outputs
-            (workflow_uuid, function_id, function_name, child_workflow_id)
-            VALUES ($1, $2, $3, $4)
+            (workflow_uuid, function_id, function_name, child_workflow_id, started_at_epoch_ms)
+            VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT (workflow_uuid, function_id) DO NOTHING`, s.dialect.SchemaPrefix(s.schema))
 
 	var querier Querier = s.pool
@@ -2853,7 +2854,8 @@ func (s *SysDB) RecordChildWorkflow(ctx context.Context, input RecordChildWorkfl
 	}
 
 	result, err := querier.Exec(ctx, query,
-		input.ParentWorkflowID, input.StepID, input.StepName, input.ChildWorkflowID)
+		input.ParentWorkflowID, input.StepID, input.StepName, input.ChildWorkflowID,
+		input.StartedAt.UnixMilli())
 	if err != nil {
 		return fmt.Errorf("failed to record child workflow: %w", err)
 	}

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -786,6 +786,19 @@ func (s *SysDB) RenderSQL(format string, args ...any) string {
 	return s.dialect.RewriteQuery(fmt.Sprintf(format, args...))
 }
 
+// reports whether the connection string specifies pool_max_conns
+func connStringSetsPoolMaxConns(connString string) bool {
+	if u, err := url.Parse(connString); err == nil && u.Scheme != "" {
+		return u.Query().Has("pool_max_conns")
+	}
+	for field := range strings.FieldsSeq(connString) {
+		if strings.HasPrefix(field, "pool_max_conns=") {
+			return true
+		}
+	}
+	return false
+}
+
 // NewSystemDatabase creates a new SystemDatabase instance and runs migrations.
 func NewSystemDatabase(ctx context.Context, inputs NewSystemDatabaseInput) (SystemDatabase, error) {
 	// Dereference fields from inputs
@@ -847,8 +860,11 @@ func NewSystemDatabase(ctx context.Context, inputs NewSystemDatabaseInput) (Syst
 			return nil, fmt.Errorf("failed to parse database URL: %v", err)
 		}
 
-		// Set pool configuration
-		config.MaxConns = 20
+		// Set pool configuration. pgxpool.ParseConfig already applied a
+		// pool_max_conns given in the URL; only default it when absent.
+		if !connStringSetsPoolMaxConns(databaseURL) {
+			config.MaxConns = 20
+		}
 		config.MinConns = 0
 		config.MaxConnLifetime = time.Hour
 		config.MaxConnIdleTime = time.Minute * 5

--- a/dbos/queue.go
+++ b/dbos/queue.go
@@ -18,12 +18,12 @@ const _DEFAULT_MAX_POLLING_INTERVAL = 120 * time.Second
 // workflowQueue is the concrete implementation behind the Queue handle: a
 // queue's configuration plus runtime-only registration state.
 type workflowQueue struct {
-	Name                string        `json:"name"`                        // Unique queue name
-	WorkerConcurrency   *int          `json:"workerConcurrency,omitempty"` // Max concurrent workflows per executor
-	GlobalConcurrency   *int          `json:"concurrency,omitempty"`       // Max concurrent workflows across all executors
-	PriorityEnabled     bool          `json:"priorityEnabled,omitempty"`   // Enable priority-based scheduling
-	RateLimit           *RateLimiter  `json:"rateLimit,omitempty"`         // Rate limiting configuration
-	PartitionQueue      bool          `json:"partitionQueue,omitempty"`    // Enable partitioned queue mode
+	Name                string        `json:"name"`                         // Unique queue name
+	WorkerConcurrency   *int          `json:"worker_concurrency,omitempty"` // Max concurrent workflows per executor
+	GlobalConcurrency   *int          `json:"concurrency,omitempty"`        // Max concurrent workflows across all executors
+	PriorityEnabled     bool          `json:"priority_enabled,omitempty"`   // Enable priority-based scheduling
+	RateLimit           *RateLimiter  `json:"rate_limit,omitempty"`         // Rate limiting configuration
+	PartitionQueue      bool          `json:"partition_queue,omitempty"`    // Enable partitioned queue mode
 	basePollingInterval time.Duration // Base polling interval (minimum, never poll faster)
 	maxPollingInterval  time.Duration // Maximum polling interval (never poll slower)
 

--- a/dbos/serialization.go
+++ b/dbos/serialization.go
@@ -36,12 +36,12 @@ const (
 //     and choose its own nil semantics (typically returning the zero value of T).
 //  2. Encode may be called with a nil or zero value, and the nil round-trip must
 //     be lossless: Decode(Encode(nil-value)) must yield that nil value back.
-//  3. The literal string "__DBOS_NIL" is reserved by the engine and wire-frozen.
-//     A custom Encode must never emit it for non-nil data; a value stored as
-//     "__DBOS_NIL" would be misreported as nil by observability paths.
-//  4. Encode must not return a nil *string. To represent nil data, return a
-//     pointer to a sentinel string (e.g. the built-in gob serializer stores
-//     "__DBOS_NIL"; the portable JSON serializer stores "null").
+//  3. Encode must not return a nil *string. To represent nil data, return a
+//     pointer to a sentinel string of the serializer's choosing (e.g. the
+//     built-in gob serializer stores "__DBOS_NIL"; the portable JSON serializer
+//     stores "null"). The engine never interprets the sentinel: nil detection
+//     always goes through the serializer that wrote the row, so no string is
+//     reserved across formats.
 type Serializer[T any] interface {
 	// Name returns the name of the serialization format (e.g., "DBOS_JSON", "DBOS_GOB").
 	Name() string
@@ -301,12 +301,21 @@ func resolveDecoder[T any](storedSerialization string, customSer Serializer[any]
 // (ListWorkflows, GetWorkflowSteps) based on the stored per-row format:
 //   - portable rows decode into their generic JSON value
 //   - rows matching the configured custom serializer decode with it
+//   - gob rows decode with the built-in gob serializer, so they remain
+//     readable even from a context that has no custom serializer configured
 //   - default JSON rows return their raw JSON text (base64-decoded), leaving
 //     any further decoding to the caller
+//
+// Nil detection is format-aware: each branch applies its own format's nil
+// convention (SQL NULL is nil for every format), so no marker string is
+// reserved across formats.
 //
 // If the format is unknown or decoding fails, it returns the raw stored
 // string alongside the error.
 func decodeListingValue(encoded *string, storedSerialization string, customSer Serializer[any]) (any, error) {
+	if encoded == nil {
+		return nil, nil
+	}
 	switch {
 	case storedSerialization == PortableSerializerName:
 		var decoded any
@@ -320,7 +329,18 @@ func decodeListingValue(encoded *string, storedSerialization string, customSer S
 			return *encoded, err
 		}
 		return decoded, nil
+	case storedSerialization == "DBOS_GOB":
+		decoded, err := NewGobSerializer().Decode(encoded)
+		if err != nil {
+			return *encoded, err
+		}
+		return decoded, nil
 	case storedSerialization == "" || storedSerialization == "DBOS_JSON":
+		// This is not really a decode: because we don't know the concrete type of the list item being decoded
+		// we simply return the raw JSON string and let the user unmarshall themselves.
+		if *encoded == nilMarker {
+			return nil, nil
+		}
 		decodedBytes, err := base64.StdEncoding.DecodeString(*encoded)
 		if err != nil {
 			return *encoded, err

--- a/dbos/serialization_test.go
+++ b/dbos/serialization_test.go
@@ -1297,7 +1297,7 @@ func TestClientCustomSerializer(t *testing.T) {
 		Serializer:  customSer,
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() { client.Shutdown(client, 30 * time.Second) })
+	t.Cleanup(func() { client.Shutdown(client, 30*time.Second) })
 
 	t.Run("EnqueueWithCustomSerializer", func(t *testing.T) {
 		// The chicken serializer always encodes to fixedChicken, so regardless
@@ -1430,11 +1430,14 @@ func makeStreamWorkflow[T any]() Workflow[T, T] {
 
 var (
 	chickenRecoveryWorkflow = makeRecoveryWorkflow[Chicken]()
-	chickenSenderWorkflow   = makeSenderWorkflow[Chicken]()
-	chickenReceiverWorkflow = makeReceiverWorkflow[Chicken]()
-	chickenSetEventWorkflow = makeSetEventWorkflow[Chicken]()
-	chickenGetEventWorkflow = makeGetEventWorkflow[Chicken]()
-	chickenStreamWorkflow   = makeStreamWorkflow[Chicken]()
+	// Pointer-typed variant used to exercise the custom serializer's nil
+	// convention end-to-end (checkpointing, recovery, and listing paths).
+	chickenNilRecoveryWorkflow = makeRecoveryWorkflow[*Chicken]()
+	chickenSenderWorkflow      = makeSenderWorkflow[Chicken]()
+	chickenReceiverWorkflow    = makeReceiverWorkflow[Chicken]()
+	chickenSetEventWorkflow    = makeSetEventWorkflow[Chicken]()
+	chickenGetEventWorkflow    = makeGetEventWorkflow[Chicken]()
+	chickenStreamWorkflow      = makeStreamWorkflow[Chicken]()
 )
 
 // TestChickenSerializer tests a fully custom user-provided serializer.
@@ -1446,6 +1449,7 @@ func TestChickenSerializer(t *testing.T) {
 	executor := setupDBOS(t, setupDBOSOptions{dropDB: true, checkLeaks: true, serializer: &chickenSerializer{}})
 
 	RegisterWorkflow(executor, chickenRecoveryWorkflow)
+	RegisterWorkflow(executor, chickenNilRecoveryWorkflow)
 	RegisterWorkflow(executor, chickenSenderWorkflow)
 	RegisterWorkflow(executor, chickenReceiverWorkflow)
 	RegisterWorkflow(executor, chickenSetEventWorkflow)
@@ -1460,6 +1464,12 @@ func TestChickenSerializer(t *testing.T) {
 	// The recovery workflow returns its input, so the result should be fixedChicken.
 	t.Run("RecoveryReturnsFixedChicken", func(t *testing.T) {
 		testAllSerializationPaths(t, executor, chickenRecoveryWorkflow, fixedChicken, "chicken-wf")
+	})
+
+	// A nil input/output must round-trip as nil through the custom serializer's
+	// own nil convention, including on the ListWorkflows/GetWorkflowSteps paths.
+	t.Run("NilPointer", func(t *testing.T) {
+		testAllSerializationPaths(t, executor, chickenNilRecoveryWorkflow, (*Chicken)(nil), "chicken-nil-wf")
 	})
 
 	t.Run("SendRecv", func(t *testing.T) {
@@ -1485,6 +1495,45 @@ func TestChickenSerializer(t *testing.T) {
 		assert.True(t, closed)
 		require.Len(t, values, 1)
 		assert.Equal(t, fixedChicken, values[0])
+	})
+}
+
+// TestDecodeListingValueGob exercises the dedicated DBOS_GOB branch of
+// decodeListingValue: rows written by the built-in gob serializer must decode
+// in listing paths even when the listing context has no custom serializer
+// configured (e.g. a Client without a serializer reading rows written by an
+// app configured with NewGobSerializer).
+func TestDecodeListingValueGob(t *testing.T) {
+	ser := NewGobSerializer()
+
+	t.Run("ValueDecodesWithoutConfiguredSerializer", func(t *testing.T) {
+		encoded, err := ser.Encode("gob-listing-value")
+		require.NoError(t, err)
+		decoded, err := decodeListingValue(encoded, "DBOS_GOB", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "gob-listing-value", decoded)
+	})
+
+	t.Run("NilSentinelDecodesToNil", func(t *testing.T) {
+		encoded, err := ser.Encode(nil)
+		require.NoError(t, err)
+		require.Equal(t, nilMarker, *encoded, "gob serializer stores its nil sentinel")
+		decoded, err := decodeListingValue(encoded, "DBOS_GOB", nil)
+		require.NoError(t, err)
+		assert.Nil(t, decoded)
+	})
+
+	t.Run("SQLNullDecodesToNil", func(t *testing.T) {
+		decoded, err := decodeListingValue(nil, "DBOS_GOB", nil)
+		require.NoError(t, err)
+		assert.Nil(t, decoded)
+	})
+
+	t.Run("UndecodableReturnsRawAndError", func(t *testing.T) {
+		bad := "not!base64"
+		decoded, err := decodeListingValue(&bad, "DBOS_GOB", nil)
+		require.Error(t, err)
+		assert.Equal(t, bad, decoded)
 	})
 }
 
@@ -1800,7 +1849,7 @@ func TestPortableInterop(t *testing.T) {
 			DatabaseURL: executor.(*dbosContext).config.DatabaseURL,
 		})
 		require.NoError(t, err)
-		t.Cleanup(func() { client.Shutdown(client, 5 * time.Second) })
+		t.Cleanup(func() { client.Shutdown(client, 5*time.Second) })
 
 		portableArgs := PortableWorkflowArgs{
 			PositionalArgs: []any{expectedArgs, "extra-positional", 99},

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -242,6 +242,8 @@ func (h *workflowHandle[R]) GetResult(opts ...GetResultOption) (R, error) {
 		opt(options)
 	}
 
+	startTime := time.Now()
+
 	// If within a workflow, check if we already ran that step
 	result, found, err := checkGetResultExecution[R](h.dbosContext)
 	if found {
@@ -250,7 +252,6 @@ func (h *workflowHandle[R]) GetResult(opts ...GetResultOption) (R, error) {
 	if err != nil { // not found and err means err is an infrastructure error
 		return *new(R), err
 	}
-	startTime := time.Now()
 
 	var timeoutChan <-chan time.Time
 	if options.timeout > 0 {
@@ -346,6 +347,8 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 		opt(options)
 	}
 
+	startTime := time.Now()
+
 	// If within a workflow, check if we already ran that step
 	result, found, err := checkGetResultExecution[R](h.dbosContext)
 	if found {
@@ -354,7 +357,6 @@ func (h *workflowPollingHandle[R]) GetResult(opts ...GetResultOption) (R, error)
 	if err != nil {
 		return *new(R), err
 	}
-	startTime := time.Now()
 
 	// Use timeout if specified, otherwise use DBOS context directly
 	ctx := h.dbosContext
@@ -1277,6 +1279,8 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 	// This detaches it from any deadline or cancellation signal set by the user
 	uncancellableCtx := WithoutCancel(c)
 
+	childStartTime := time.Now()
+
 	// If this is a child workflow that has already been recorded in operations_output, return directly a polling handle
 	if isChildWorkflow {
 		childWorkflowID, err := sysdb.RetryWithResult(c, func() (*string, error) {
@@ -1435,6 +1439,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 				ChildWorkflowID:  workflowID,
 				StepName:         params.WorkflowName,
 				StepID:           parentWorkflowState.stepID,
+				StartedAt:        childStartTime,
 				Tx:               tx,
 			}
 			err = c.systemDB.RecordChildWorkflow(uncancellableCtx, childInput)
@@ -1501,6 +1506,7 @@ func (c *dbosContext) RunWorkflow(_ Context, fn WorkflowFunc, input any, opts ..
 				ChildWorkflowID:  *existingID,
 				StepName:         params.WorkflowName,
 				StepID:           parentWorkflowState.stepID,
+				StartedAt:        childStartTime,
 			}
 			if err := c.systemDB.RecordChildWorkflow(uncancellableCtx, childInput); err != nil {
 				return nil, models.NewWorkflowExecutionError(parentWorkflowState.workflowID, fmt.Errorf("recording child workflow: %w", err))
@@ -2146,6 +2152,7 @@ type stepOptions struct {
 	preGeneratedStepID *int             // Pre generated stepID
 	txIsoLevel         *IsoLevel        // Transaction isolation level for runAsTxn (nil = ReadCommitted)
 	retryPredicate     func(error) bool // Optional predicate: nil = retry all errors up to maxRetries
+	completedAt        *time.Time       // Overrides the recorded completion time (see withCompletedAt)
 }
 
 // setDefaults applies default values to stepOptions
@@ -2255,6 +2262,14 @@ func WithTxIsolation(level IsoLevel) StepOption {
 func withNextStepID(stepID int) StepOption {
 	return func(opts *stepOptions) {
 		opts.preGeneratedStepID = &stepID
+	}
+}
+
+// withCompletedAt records the given time as the step's completion instead of
+// the checkpoint time.
+func withCompletedAt(t time.Time) StepOption {
+	return func(opts *stepOptions) {
+		opts.completedAt = &t
 	}
 }
 
@@ -2530,6 +2545,7 @@ func (c *dbosContext) RunAsStep(_ Context, fn StepFunc, opts ...StepOption) (any
 	uncancellableCtx := WithoutCancel(c)
 	stepState := prep.StepState
 	stepOpts := prep.StepOpts
+	stepStartTime := time.Now()
 
 	// Check the step is cancelled, has already completed, or is called with a different name
 	recordedOutput, err := sysdb.RetryWithResult(c, func() (*sysdb.RecordedResult, error) {
@@ -2549,7 +2565,6 @@ func (c *dbosContext) RunAsStep(_ Context, fn StepFunc, opts ...StepOption) (any
 	}
 
 	stepCtx := WithValue(c, workflowStateKey, stepState)
-	stepStartTime := time.Now()
 	stepOutput, stepError := executeStepWithRetry(c, stepState.workflowID, stepOpts, func() (any, error) {
 		if err := checkStepContext(stepCtx, stepState.workflowID, stepOpts.stepName); err != nil {
 			return nil, err
@@ -2572,6 +2587,9 @@ func (c *dbosContext) RunAsStep(_ Context, fn StepFunc, opts ...StepOption) (any
 
 	// Record the final result
 	stepCompletedTime := time.Now()
+	if stepOpts.completedAt != nil {
+		stepCompletedTime = *stepOpts.completedAt
+	}
 	var serializedStepErr *string
 	if stepError != nil {
 		s := serializeWorkflowError(c.logger, stepError, ser.Name())
@@ -2725,13 +2743,17 @@ func (c *dbosContext) runAsTxn(_ Context, fn TxnFunc, opts ...StepOption) (any, 
 			s := serializeWorkflowError(c.logger, stepError, txnSer.Name())
 			serializedTxnErr = &s
 		}
+		stepCompletedTime := time.Now()
+		if stepOpts.completedAt != nil {
+			stepCompletedTime = *stepOpts.completedAt
+		}
 		dbInput := sysdb.RecordOperationResultDBInput{
 			WorkflowID:    stepState.workflowID,
 			StepName:      stepOpts.stepName,
 			StepID:        stepState.stepID,
 			ErrStr:        serializedTxnErr,
 			StartedAt:     stepStartTime,
-			CompletedAt:   time.Now(),
+			CompletedAt:   stepCompletedTime,
 			Output:        encodedStepOutput,
 			Tx:            tx,
 			Serialization: serialization,
@@ -4039,9 +4061,10 @@ func (c *dbosContext) Sleep(_ Context, duration time.Duration) (time.Duration, e
 	}
 	// Checkpoint the wakeup time as a "DBOS.sleep" step; on re-execution the
 	// recorded deadline is returned, so only the remaining duration is slept.
+	deadline := time.Now().Add(duration)
 	deadlineMs, err := runAsTxn(c, func(ctx context.Context, tx Tx) (int64, error) {
-		return time.Now().Add(duration).UnixMilli(), nil
-	}, WithStepName("DBOS.sleep"))
+		return deadline.UnixMilli(), nil
+	}, WithStepName("DBOS.sleep"), withCompletedAt(deadline))
 	if err != nil {
 		return 0, err
 	}

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -5253,30 +5253,22 @@ func (c *dbosContext) decodeWorkflowsInputOutput(workflows []WorkflowStatus, loa
 				if !ok {
 					return fmt.Errorf("workflow input must be encoded string, got %T", workflows[i].Input)
 				}
-				if encodedInput == nil || *encodedInput == nilMarker {
-					workflows[i].Input = nil
-				} else {
-					decoded, err := decodeListingValue(encodedInput, workflows[i].Serialization, c.serializer)
-					if err != nil {
-						c.logger.Warn("failed to decode workflow input, storing raw value", "workflow_id", workflows[i].ID, "error", err)
-					}
-					workflows[i].Input = decoded
+				decoded, err := decodeListingValue(encodedInput, workflows[i].Serialization, c.serializer)
+				if err != nil {
+					c.logger.Warn("failed to decode workflow input, storing raw value", "workflow_id", workflows[i].ID, "error", err)
 				}
+				workflows[i].Input = decoded
 			}
 			if loadOutput && workflows[i].Output != nil {
 				encodedOutput, ok := workflows[i].Output.(*string)
 				if !ok {
 					return fmt.Errorf("workflow output must be encoded *string, got %T", workflows[i].Output)
 				}
-				if encodedOutput == nil || *encodedOutput == nilMarker {
-					workflows[i].Output = nil
-				} else {
-					decoded, err := decodeListingValue(encodedOutput, workflows[i].Serialization, c.serializer)
-					if err != nil {
-						c.logger.Warn("failed to decode workflow output, storing raw value", "workflow_id", workflows[i].ID, "error", err)
-					}
-					workflows[i].Output = decoded
+				decoded, err := decodeListingValue(encodedOutput, workflows[i].Serialization, c.serializer)
+				if err != nil {
+					c.logger.Warn("failed to decode workflow output, storing raw value", "workflow_id", workflows[i].ID, "error", err)
 				}
+				workflows[i].Output = decoded
 			}
 			if loadOutput && workflows[i].Error != nil {
 				s := workflows[i].Error.Error()
@@ -5417,12 +5409,7 @@ func (c *dbosContext) GetWorkflowSteps(_ Client, workflowID string, opts ...GetW
 	// Deserialize outputs if asked to
 	if loadOutput {
 		for i := range steps {
-			encodedOutput := steps[i].Output
-			if encodedOutput == nil || *encodedOutput == nilMarker {
-				stepInfos[i].Output = nil
-				continue
-			}
-			decoded, err := decodeListingValue(encodedOutput, steps[i].Serialization, c.serializer)
+			decoded, err := decodeListingValue(steps[i].Output, steps[i].Serialization, c.serializer)
 			if err != nil {
 				c.logger.Warn("failed to decode step output, storing raw value", "workflow_id", workflowID, "step_id", steps[i].StepID, "error", err)
 			}

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -1241,6 +1241,8 @@ func TestSteps(t *testing.T) {
 		})
 	}
 	RegisterWorkflow(dbosCtx, conflictCancelWorkflow, WithWorkflowName("conflict-cancel-workflow"))
+	RegisterWorkflow(dbosCtx, stepTimingParentWorkflow)
+	RegisterWorkflow(dbosCtx, stepTimingChildWorkflow)
 
 	// Installed before Launch so no goroutine reads sysDB.Pool() concurrently
 	// with the swap; armed on demand by StepIDNotReallocatedOnDBRetry.
@@ -2083,6 +2085,39 @@ func TestSteps(t *testing.T) {
 				require.Equal(t, tt.wantWarning, strings.Contains(logOutput.String(), "increasing max interval"))
 			})
 		}
+	})
+
+	// Verifies the timing checkpoints hoisted to callers: the child-spawn row
+	// records the launch time only, DBOS.getResult spans the await (not just
+	// the checkpoint write), and DBOS.sleep projects its wake time as the
+	// completion so the recorded duration is the sleep itself.
+	t.Run("StepTimingRecords", func(t *testing.T) {
+		handle, err := RunWorkflow(dbosCtx, stepTimingParentWorkflow, "")
+		require.NoError(t, err, "failed to run parent workflow")
+		_, err = handle.GetResult()
+		require.NoError(t, err, "failed to get parent workflow result")
+
+		steps, err := GetWorkflowSteps(dbosCtx, handle.GetWorkflowID())
+		require.NoError(t, err, "failed to get workflow steps")
+		require.Len(t, steps, 3, "expected child spawn, getResult, and sleep steps")
+
+		// Child spawn: records the launch time only, no completion.
+		spawn := steps[0]
+		require.NotEmpty(t, spawn.ChildWorkflowID, "expected step 0 to be the child spawn")
+		require.False(t, spawn.StartedAt.IsZero(), "expected child spawn StartedAt to be set")
+		require.True(t, spawn.CompletedAt.IsZero(), "the child spawn row must not record a completion time")
+
+		// getResult: the span covers the await of the child's result.
+		getResult := steps[1]
+		require.Equal(t, "DBOS.getResult", getResult.StepName)
+		require.GreaterOrEqual(t, getResult.CompletedAt.Sub(getResult.StartedAt), 100*time.Millisecond,
+			"expected the getResult span to cover the await of the child, not just the checkpoint write")
+
+		// sleep: the wake time is projected as the completion.
+		sleep := steps[2]
+		require.Equal(t, "DBOS.sleep", sleep.StepName)
+		require.GreaterOrEqual(t, sleep.CompletedAt.Sub(sleep.StartedAt), 400*time.Millisecond,
+			"expected the sleep span to be the sleep duration, not the checkpoint write")
 	})
 }
 
@@ -10779,4 +10814,40 @@ func TestStepCheckpointReclaimsExecutorID(t *testing.T) {
 	require.EqualValues(t, 2, execCount.Load(), "both executions must have genuinely run the step body")
 	require.Equal(t, executorA, readExecutorID(),
 		"a losing checkpoint must not re-stamp executor_id")
+}
+
+func stepTimingChildWorkflow(ctx Context, _ string) (string, error) {
+	time.Sleep(300 * time.Millisecond)
+	return "child-done", nil
+}
+
+func stepTimingParentWorkflow(ctx Context, _ string) (string, error) {
+	handle, err := RunWorkflow(ctx, stepTimingChildWorkflow, "")
+	if err != nil {
+		return "", err
+	}
+	if _, err := handle.GetResult(); err != nil {
+		return "", err
+	}
+	if _, err := Sleep(ctx, 500*time.Millisecond); err != nil {
+		return "", err
+	}
+	return "ok", nil
+}
+
+func TestStepInfoJSONShape(t *testing.T) {
+	info := StepInfo{
+		StepID:          3,
+		StepName:        "my-step",
+		ChildWorkflowID: "child-id",
+		StartedAt:       time.UnixMilli(1000).UTC(),
+		CompletedAt:     time.UnixMilli(2000).UTC(),
+	}
+	b, err := json.Marshal(info)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+	for _, key := range []string{"function_id", "function_name", "child_workflow_id", "started_at", "completed_at"} {
+		require.Contains(t, m, key)
+	}
 }

--- a/dbos/workflows_test.go
+++ b/dbos/workflows_test.go
@@ -10834,20 +10834,3 @@ func stepTimingParentWorkflow(ctx Context, _ string) (string, error) {
 	}
 	return "ok", nil
 }
-
-func TestStepInfoJSONShape(t *testing.T) {
-	info := StepInfo{
-		StepID:          3,
-		StepName:        "my-step",
-		ChildWorkflowID: "child-id",
-		StartedAt:       time.UnixMilli(1000).UTC(),
-		CompletedAt:     time.UnixMilli(2000).UTC(),
-	}
-	b, err := json.Marshal(info)
-	require.NoError(t, err)
-	var m map[string]any
-	require.NoError(t, json.Unmarshal(b, &m))
-	for _, key := range []string{"function_id", "function_name", "child_workflow_id", "started_at", "completed_at"} {
-		require.Contains(t, m, key)
-	}
-}


### PR DESCRIPTION
- steps `startTime` now recorded before checking for recorded results
- Sleep now record its expected completion time (can mismatch if interrupted)
- Harmonize structs casing (snake_case to match what we store in the system database)
- Parse pool_max_conns from database url
- Don't impose our internal `__DBOS_NIL` to custom serializers
- Use `INT4` in DB schemas for CRDB compatibility

Closes #410 
Closes #418 
Closes #432 
Closes #419 
Closes #425