### PR TITLE
Application rename

### DIFF
--- a/cmd/dbos/rename.go
+++ b/cmd/dbos/rename.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/dbos-inc/dbos-transact-golang/dbos"
+	"github.com/spf13/cobra"
+)
+
+var renameApplicationCmd = &cobra.Command{
+	Use:   "rename-application",
+	Short: "Re-own a system database's rows after an application is renamed",
+	RunE:  runRenameApplication,
+}
+
+var (
+	renameOldName            string
+	renameNewName            string
+	renameAdoptUnclaimedRows bool
+	renameBatchSize          int
+	renameSkipConfirmation   bool
+)
+
+func init() {
+	renameApplicationCmd.Flags().BoolVarP(&renameSkipConfirmation, "yes", "y", false, "Skip confirmation prompt")
+	renameApplicationCmd.Flags().StringVarP(&renameOldName, "from", "f", "", "The application's previous name. Omit to only adopt unclaimed rows.")
+	renameApplicationCmd.Flags().StringVarP(&renameNewName, "to", "t", "", "The application that ends up owning the rows")
+	renameApplicationCmd.Flags().BoolVar(&renameAdoptUnclaimedRows, "adopt-unclaimed-rows", false, "Also take rows no application owns (application_name=NULL)")
+	renameApplicationCmd.Flags().IntVar(&renameBatchSize, "batch-size", dbos.DefaultRenameBatchSize, "Workflows and steps re-owned per transaction")
+	_ = renameApplicationCmd.MarkFlagRequired("to")
+}
+
+func runRenameApplication(cmd *cobra.Command, args []string) error {
+	var sources []string
+	if renameOldName != "" {
+		sources = append(sources, fmt.Sprintf("'%s's rows", renameOldName))
+	}
+	if renameAdoptUnclaimedRows {
+		sources = append(sources, "rows no application owns")
+	}
+	if len(sources) == 0 {
+		return fmt.Errorf("nothing to re-own: pass --from, --adopt-unclaimed-rows, or both")
+	}
+
+	if !renameSkipConfirmation {
+		prompt := fmt.Sprintf("This command re-owns %s in your DBOS system database as '%s'. "+
+			"Stop the application being renamed before running this. Are you sure you want to proceed?",
+			strings.Join(sources, " and "), renameNewName)
+		if !confirmAction(prompt) {
+			logger.Info("Operation cancelled.")
+			return nil
+		}
+	}
+
+	dbURL, err := getDBURL()
+	if err != nil {
+		return err
+	}
+
+	client, err := createContext(context.Background(), dbURL)
+	if err != nil {
+		return err
+	}
+
+	moved, err := dbos.RenameApplication(client, dbos.RenameApplicationInput{
+		OldName:            renameOldName,
+		NewName:            renameNewName,
+		BatchSize:          renameBatchSize,
+		AdoptUnclaimedRows: renameAdoptUnclaimedRows,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to rename application: %w", err)
+	}
+	return outputJSON(moved)
+}

--- a/cmd/dbos/root.go
+++ b/cmd/dbos/root.go
@@ -44,6 +44,7 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(postgresCmd)
 	rootCmd.AddCommand(workflowCmd)
+	rootCmd.AddCommand(renameApplicationCmd)
 }
 
 func initConfig() {

--- a/dbos/application_name_test.go
+++ b/dbos/application_name_test.go
@@ -730,3 +730,117 @@ func TestClientAppName(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "x-ran", result)
 }
+
+// TestRenameApplication verifies RenameApplication re-owns every table's rows —
+// atomically for the registries and in-flight workflows, in batches for the
+// history — leaving other applications' rows alone.
+func TestRenameApplication(t *testing.T) {
+	ctxA := setupDBOS(t, setupDBOSOptions{dropDB: true, appName: "app-a"})
+	ctxB := setupDBOS(t, setupDBOSOptions{appName: "app-b"})
+
+	twoSteps := func(app string) func(ctx Context, input string) (string, error) {
+		return func(ctx Context, input string) (string, error) {
+			for range 2 {
+				if _, err := RunAsStep(ctx, func(context.Context) (string, error) { return "s", nil }); err != nil {
+					return "", err
+				}
+			}
+			return app + ":" + input, nil
+		}
+	}
+	RegisterWorkflow(ctxA, twoSteps("app-a"), WithWorkflowName("rename-wf"))
+	RegisterWorkflow(ctxB, twoSteps("app-b"), WithWorkflowName("rename-wf"))
+	require.NoError(t, Launch(ctxA))
+	require.NoError(t, Launch(ctxB))
+
+	_, err := RegisterQueue(ctxA, "rename-queue")
+	require.NoError(t, err)
+	require.NoError(t, CreateSchedule(ctxA, ScheduleSpec{
+		ScheduleName: "rename-sched",
+		Schedule:     "0 0 0 1 1 *",
+		WorkflowName: "rename-wf",
+	}))
+
+	// Three completed workflows with two steps each, and one of app-b's for contrast.
+	var done []WorkflowHandle[string]
+	for range 3 {
+		h, err := Enqueue[string, string](ctxA, "rename-queue", "rename-wf", "x")
+		require.NoError(t, err)
+		_, err = h.GetResult()
+		require.NoError(t, err)
+		done = append(done, h)
+	}
+	hB, err := Enqueue[string, string](ctxB, models.InternalQueueName, "rename-wf", "x")
+	require.NoError(t, err)
+	_, err = hB.GetResult()
+	require.NoError(t, err)
+
+	// Stop the application being renamed: its dequeues race the rename.
+	require.NoError(t, Shutdown(ctxA, 30*time.Second))
+
+	client, err := NewClient(context.Background(), ClientConfig{DatabaseURL: backendDatabaseURL(t)})
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Shutdown(client, 30*time.Second) })
+
+	// An ENQUEUED workflow left behind by the stopped app-a: the atomic path.
+	pending, err := Enqueue[string, string](client, "rename-queue", "rename-wf", "x",
+		WithEnqueueApplicationName("app-a"))
+	require.NoError(t, err)
+
+	// Batch size 1 forces the range loop over the terminal history.
+	counts, err := RenameApplication(client, RenameApplicationInput{OldName: "app-a", NewName: "app-c", BatchSize: 1})
+	require.NoError(t, err)
+	assert.Equal(t, ApplicationRowCounts{Queues: 1, Schedules: 1, Versions: 1, Workflows: 4, Steps: 6}, counts)
+
+	for _, h := range done {
+		owner := rowApplicationName(t, ctxB, h.GetWorkflowID())
+		require.NotNil(t, owner)
+		assert.Equal(t, "app-c", *owner)
+		for _, stepOwner := range stepApplicationNames(t, ctxB, h.GetWorkflowID()) {
+			require.NotNil(t, stepOwner)
+			assert.Equal(t, "app-c", *stepOwner)
+		}
+	}
+	ownerB := rowApplicationName(t, ctxB, hB.GetWorkflowID())
+	require.NotNil(t, ownerB)
+	assert.Equal(t, "app-b", *ownerB)
+
+	// Adoption moves only unclaimed rows, and only when asked.
+	unclaimed, err := Enqueue[string, string](client, "rename-queue", "unclaimed-wf", "y")
+	require.NoError(t, err)
+	noAdopt, err := RenameApplication(client, RenameApplicationInput{OldName: "no-such-app", NewName: "app-d"})
+	require.NoError(t, err)
+	assert.Equal(t, ApplicationRowCounts{}, noAdopt)
+	adopted, err := RenameApplication(client, RenameApplicationInput{NewName: "app-d", AdoptUnclaimedRows: true})
+	require.NoError(t, err)
+	assert.Equal(t, ApplicationRowCounts{Workflows: 1}, adopted)
+	adoptedOwner := rowApplicationName(t, ctxB, unclaimed.GetWorkflowID())
+	require.NotNil(t, adoptedOwner)
+	assert.Equal(t, "app-d", *adoptedOwner)
+
+	_, err = RenameApplication(client, RenameApplicationInput{NewName: "app-e"})
+	require.ErrorContains(t, err, "nothing to re-own")
+	_, err = RenameApplication(client, RenameApplicationInput{OldName: "app-e", NewName: "app-e"})
+	require.ErrorContains(t, err, "already holds that name")
+	_, err = RenameApplication(client, RenameApplicationInput{OldName: "app-x", NewName: ""})
+	require.ErrorContains(t, err, "new application name is required")
+	_, err = RenameApplication(client, RenameApplicationInput{OldName: "app-x", NewName: "app-e", BatchSize: -1})
+	require.ErrorContains(t, err, "batch size")
+
+	// app-c owns the moved registries and runs the moved in-flight workflow,
+	// whose version was left unset by the client enqueue.
+	ctxC := setupDBOS(t, setupDBOSOptions{appName: "app-c"})
+	RegisterWorkflow(ctxC, twoSteps("app-c"), WithWorkflowName("rename-wf"))
+	require.NoError(t, Launch(ctxC))
+
+	q, err := RetrieveQueue(ctxC, "rename-queue")
+	require.NoError(t, err)
+	assert.Equal(t, "app-c", q.GetApplicationName())
+	sched, err := GetSchedule(ctxC, "rename-sched")
+	require.NoError(t, err)
+	assert.Equal(t, "app-c", sched.ApplicationName)
+
+	result, err := pending.GetResult()
+	require.NoError(t, err)
+	assert.Equal(t, "app-c:x", result)
+}

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -219,10 +219,11 @@ type Client interface {
 	BackfillSchedule(_ Client, scheduleName string, start, end time.Time) ([]string, error) // Backfill a schedule, returning the IDs of the enqueued workflows
 	TriggerSchedule(_ Client, scheduleName string) (WorkflowHandle[any], error)             // Trigger a schedule immediately, returning a handle to the enqueued workflow
 
-	// Application version management
-	ListApplicationVersions(_ Client) ([]VersionInfo, error)        // List all registered application versions, newest first
-	GetLatestApplicationVersion(_ Client) (VersionInfo, error)      // Get the latest registered application version
-	SetLatestApplicationVersion(_ Client, versionName string) error // Mark the named version as latest by bumping its timestamp to now
+	// Application management
+	ListApplicationVersions(_ Client) ([]VersionInfo, error)                                // List all registered application versions, newest first
+	GetLatestApplicationVersion(_ Client) (VersionInfo, error)                              // Get the latest registered application version
+	SetLatestApplicationVersion(_ Client, versionName string) error                         // Mark the named version as latest by bumping its timestamp to now
+	RenameApplication(_ Client, input RenameApplicationInput) (ApplicationRowCounts, error) // Re-own system database rows after an application is renamed
 
 	Shutdown(_ Client, timeout time.Duration) error // Gracefully shutdown all DBOS resources; returns an error if the timeout expired before they all stopped
 }
@@ -872,10 +873,10 @@ func (c *dbosContext) Launch() error {
 // recovered on the next launch rather than marked CANCELLED.
 // 2. Waits for the queue runner to complete processing
 // 3. Stops the workflow scheduler and waits for scheduled jobs to finish
-// 4. Shuts down conductor
-// 5. Shuts down the admin server
-// 6. Waits for in-flight workflows to finish unwinding
-// 7. Shuts down the system database connection pool and notification listener
+// 4. Shuts down the admin server
+// 5. Waits for in-flight workflows to finish unwinding
+// 6. Shuts down the system database connection pool and notification listener
+// 7. Shuts down conductor
 // 8. Marks the context as not launched
 //
 // Each step respects the provided timeout. If any component doesn't shut down within the timeout,
@@ -939,14 +940,6 @@ func (c *dbosContext) Shutdown(_ Client, timeout time.Duration) error {
 		}
 	}
 
-	// Shutdown the conductor
-	if c.conductor != nil {
-		c.logger.Debug("Shutting down conductor")
-		if err := c.conductor.shutdown(timeout); err != nil {
-			pending = append(pending, "conductor")
-		}
-	}
-
 	// Shutdown the admin server
 	if c.adminServer != nil {
 		c.logger.Debug("Shutting down admin server")
@@ -973,6 +966,9 @@ func (c *dbosContext) Shutdown(_ Client, timeout time.Duration) error {
 		c.logger.Warn("Timeout waiting for workflows to complete", "timeout", timeout)
 		pending = append(pending, "workflows")
 	}
+	if len(pending) > 0 {
+		return fmt.Errorf("shutdown timed out after %v waiting for: %s", timeout, strings.Join(pending, ", "))
+	}
 
 	// Close the system database
 	if c.systemDB != nil {
@@ -982,11 +978,16 @@ func (c *dbosContext) Shutdown(_ Client, timeout time.Duration) error {
 		}
 	}
 
+	// Shutdown the conductor
+	if c.conductor != nil {
+		c.logger.Debug("Shutting down conductor")
+		if err := c.conductor.shutdown(timeout); err != nil {
+			pending = append(pending, "conductor")
+		}
+	}
+
 	c.launched.Store(false)
 
-	if len(pending) > 0 {
-		return fmt.Errorf("shutdown timed out after %v waiting for: %s", timeout, strings.Join(pending, ", "))
-	}
 	return nil
 }
 

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -966,9 +966,6 @@ func (c *dbosContext) Shutdown(_ Client, timeout time.Duration) error {
 		c.logger.Warn("Timeout waiting for workflows to complete", "timeout", timeout)
 		pending = append(pending, "workflows")
 	}
-	if len(pending) > 0 {
-		return fmt.Errorf("shutdown timed out after %v waiting for: %s", timeout, strings.Join(pending, ", "))
-	}
 
 	// Close the system database
 	if c.systemDB != nil {
@@ -988,6 +985,10 @@ func (c *dbosContext) Shutdown(_ Client, timeout time.Duration) error {
 
 	c.launched.Store(false)
 
+	if len(pending) > 0 {
+		c.shutdownStarted.Store(false)
+		return fmt.Errorf("shutdown timed out after %v waiting for: %s", timeout, strings.Join(pending, ", "))
+	}
 	return nil
 }
 

--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -967,19 +967,19 @@ func (c *dbosContext) Shutdown(_ Client, timeout time.Duration) error {
 		pending = append(pending, "workflows")
 	}
 
-	// Close the system database
-	if c.systemDB != nil {
-		c.logger.Debug("Shutting down system database")
-		for _, p := range c.systemDB.Shutdown(c, timeout) {
-			pending = append(pending, "system database "+p)
-		}
-	}
-
 	// Shutdown the conductor
 	if c.conductor != nil {
 		c.logger.Debug("Shutting down conductor")
 		if err := c.conductor.shutdown(timeout); err != nil {
 			pending = append(pending, "conductor")
+		}
+	}
+
+	// Close the system database
+	if c.systemDB != nil {
+		c.logger.Debug("Shutting down system database")
+		for _, p := range c.systemDB.Shutdown(c, timeout) {
+			pending = append(pending, "system database "+p)
 		}
 	}
 

--- a/dbos/dbos_test.go
+++ b/dbos/dbos_test.go
@@ -632,6 +632,11 @@ func TestConcurrentShutdownDoesNotWaitTwice(t *testing.T) {
 	first := <-durations
 	second := <-durations
 	assert.Less(t, min(first, second), timeout/2)
+
+	// Undo the simulated stuck queue runner and close for real: the timed-out
+	// Shutdown returned (unlatched) before closing the system database.
+	dbosCtx.queueRunnerStarted.Store(false)
+	Shutdown(ctx, 5*time.Second)
 }
 
 type blockingScheduleListDB struct {
@@ -1343,6 +1348,7 @@ func TestClientShutdownReportsSystemDBTimeout(t *testing.T) {
 	// A held connection blocks pool.Close() past the timeout
 	conn, err := pool.Acquire(ctx)
 	require.NoError(t, err)
+	defer conn.Release()
 
 	err = client.Shutdown(client, 500 * time.Millisecond)
 	require.Error(t, err)

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -195,7 +195,11 @@ func nameFilterSQL(column string, argNum int) string {
 // This method is used to check whether reading/writing a queue/schedule/application version row
 // with a specified application name, is valid.
 // For example, when we upsert a schedule, the request can come from a context that operates for a specific application
+<<<<<<< HEAD
 // But it is possible that an eponymous entry is owned by another application
+=======
+// But it is possible that a eponymous entry is owned by another application
+>>>>>>> fe48b63 (shared sysdb public api)
 // This method validates whether the "requested" owner is valid for a row.
 func (s *SysDB) resolveRowOwner(ctx context.Context, q Querier, table, nameColumn, name string, owner *string, kind string) (*string, error) {
 	// Read the current application name for the object
@@ -5121,7 +5125,11 @@ func (s *SysDB) getQueueRow(ctx context.Context, db Querier, name string) (*mode
 }
 
 // ListQueues returns database-backed queues owned by these applications plus
+<<<<<<< HEAD
 // unclaimed ones. An empty or nil `applicationName` falls back to this context's application.
+=======
+// unclaimed ones; nil defaults to this handle's own application.
+>>>>>>> fe48b63 (shared sysdb public api)
 func (s *SysDB) ListQueues(ctx context.Context, applicationNames []string) ([]models.QueueConfig, error) {
 	query := s.RenderSQL(`SELECT `+_QUEUE_SELECT_COLUMNS+` FROM %squeues`, s.dialect.SchemaPrefix(s.schema))
 	var args []any
@@ -6122,8 +6130,13 @@ func (s *SysDB) UpdateApplicationVersionTimestamp(ctx context.Context, versionNa
 	return tx.Commit(ctx)
 }
 
+<<<<<<< HEAD
 // ListApplicationVersions returns versions registered by this context's
 // application plus unclaimed ones; an application-less context lists every one.
+=======
+// ListApplicationVersions returns versions registered by this handle's
+// application plus unclaimed ones; a nameless handle lists every one.
+>>>>>>> fe48b63 (shared sysdb public api)
 func (s *SysDB) ListApplicationVersions(ctx context.Context) ([]VersionInfo, error) {
 	query := s.RenderSQL(`
 		SELECT version_id, version_name, version_timestamp, created_at, application_name
@@ -6160,8 +6173,13 @@ func (s *SysDB) ListApplicationVersions(ctx context.Context) ([]VersionInfo, err
 }
 
 // GetLatestApplicationVersion returns the latest version registered by an
+<<<<<<< HEAD
 // application, plus unclaimed ones. applicationName defaults to this context's.
 // An application-less context with no explicit name matches every application.
+=======
+// application, plus unclaimed ones. applicationName defaults to this handle's
+// own; a nameless handle with no explicit name matches every application's.
+>>>>>>> fe48b63 (shared sysdb public api)
 func (s *SysDB) GetLatestApplicationVersion(ctx context.Context, tx Tx, applicationName string) (*VersionInfo, error) {
 	owner := applicationName
 	if owner == "" {

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -129,11 +129,12 @@ type SystemDatabase interface {
 	BackfillSchedule(ctx context.Context, input BackfillScheduleDBInput) ([]string, error)
 	TriggerSchedule(ctx context.Context, scheduleName string) (string, error)
 
-	// Application versions
+	// Applications
 	CreateApplicationVersion(ctx context.Context, versionName string, owner *string) error
 	UpdateApplicationVersionTimestamp(ctx context.Context, versionName string, newTimestamp int64, owner *string) error
 	ListApplicationVersions(ctx context.Context) ([]VersionInfo, error)
 	GetLatestApplicationVersion(ctx context.Context, tx Tx, applicationName string) (*VersionInfo, error)
+	RenameApplication(ctx context.Context, input RenameApplicationDBInput) (ApplicationRowCounts, error)
 
 	// Workflow export/import
 	ExportWorkflow(ctx context.Context, workflowID string, exportChildren bool) ([]ExportedWorkflow, error)
@@ -6230,6 +6231,184 @@ func (s *SysDB) GetLatestApplicationVersion(ctx context.Context, tx Tx, applicat
 		v.ApplicationName = *rowOwner
 	}
 	return &v, nil
+}
+
+/*******************************/
+/**** APPLICATION RENAME *******/
+/*******************************/
+
+// Workflows and steps re-owned per transaction by a rename.
+const DefaultRenameBatchSize = 10_000
+
+// ApplicationRowCounts reports the rows a rename moved, by table.
+type ApplicationRowCounts struct {
+	Queues    int64 `json:"queues"`
+	Schedules int64 `json:"schedules"`
+	Versions  int64 `json:"versions"`
+	Workflows int64 `json:"workflows"`
+	Steps     int64 `json:"steps"`
+}
+
+type RenameApplicationDBInput struct {
+	OldName            string // Previous owner; empty moves only the unclaimed rows.
+	NewName            string
+	BatchSize          int // Terminal workflows and steps re-owned per transaction.
+	AdoptUnclaimedRows bool
+}
+
+// renameSourceSQL matches the rows a rename moves: an application's own, unclaimed
+// ones, or both. Unclaimed rows are not implied and move only when asked.
+// Callers validate that at least one source is named.
+func renameSourceSQL(oldName string, adoptUnclaimedRows bool, args *[]any) string {
+	var clauses []string
+	if oldName != "" {
+		*args = append(*args, oldName)
+		clauses = append(clauses, fmt.Sprintf("application_name = $%d", len(*args)))
+	}
+	if adoptUnclaimedRows {
+		clauses = append(clauses, "application_name IS NULL")
+	}
+	return "(" + strings.Join(clauses, " OR ") + ")"
+}
+
+// renameRowsInBatches re-owns a table's rows in half-open key ranges, so a long
+// history neither moves in one transaction nor rescans what it already moved; a
+// re-run resumes.
+func (s *SysDB) renameRowsInBatches(ctx context.Context, table, keyColumn string, input RenameApplicationDBInput) (int64, error) {
+	schemaPrefix := s.dialect.SchemaPrefix(s.schema)
+	var total int64
+	// Ranges, not LIMIT: a LIMIT repages every row already moved, and an IN list
+	// of keys plans as a whole-table hash join.
+	var watermark *string
+	for {
+		moved, upper, err := func() (int64, *string, error) {
+			tx, err := s.pool.BeginTx(ctx, TxOptions{})
+			if err != nil {
+				return 0, nil, fmt.Errorf("failed to begin transaction: %w", err)
+			}
+			defer tx.Rollback(ctx)
+
+			args := []any{}
+			predicate := renameSourceSQL(input.OldName, input.AdoptUnclaimedRows, &args)
+			scope := predicate
+			if watermark != nil {
+				args = append(args, *watermark)
+				scope = fmt.Sprintf("%s AND %s > $%d", predicate, keyColumn, len(args))
+			}
+			// The batch-size-th matching key bounds this range; distinct, so a
+			// key's rows are never split across batches.
+			args = append(args, input.BatchSize-1)
+			query := s.RenderSQL(`SELECT DISTINCT `+keyColumn+` FROM %s`+table+
+				` WHERE `+scope+` ORDER BY `+keyColumn+fmt.Sprintf(` LIMIT 1 OFFSET $%d`, len(args)), schemaPrefix)
+			var upper *string
+			if err := tx.QueryRow(ctx, s.dialect.RewriteQuery(query), args...).Scan(&upper); err != nil && !errors.Is(err, ErrNoRows) {
+				return 0, nil, fmt.Errorf("failed to bound a %s rename batch: %w", table, err)
+			}
+
+			updateArgs := []any{input.NewName}
+			// The final batch drops the watermark, so rows that appeared below it still move.
+			batch := renameSourceSQL(input.OldName, input.AdoptUnclaimedRows, &updateArgs)
+			if upper != nil {
+				if watermark != nil {
+					updateArgs = append(updateArgs, *watermark)
+					batch = fmt.Sprintf("%s AND %s > $%d", batch, keyColumn, len(updateArgs))
+				}
+				updateArgs = append(updateArgs, *upper)
+				batch = fmt.Sprintf("%s AND %s <= $%d", batch, keyColumn, len(updateArgs))
+			}
+			updateQuery := s.RenderSQL(`UPDATE %s`+table+` SET application_name = $1 WHERE `+batch, schemaPrefix)
+			tag, err := tx.Exec(ctx, s.dialect.RewriteQuery(updateQuery), updateArgs...)
+			if err != nil {
+				return 0, nil, fmt.Errorf("failed to re-own %s rows: %w", table, err)
+			}
+			moved, err := tag.RowsAffected()
+			if err != nil {
+				return 0, nil, fmt.Errorf("failed to count re-owned %s rows: %w", table, err)
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return 0, nil, fmt.Errorf("failed to commit a %s rename batch: %w", table, err)
+			}
+			return moved, upper, nil
+		}()
+		if err != nil {
+			return total, err
+		}
+		total += moved
+		// Fewer than a full batch remained, so that update took the rest.
+		if upper == nil {
+			return total, nil
+		}
+		watermark = upper
+	}
+}
+
+// RenameApplication gives NewName ownership of the rows OldName holds, of the
+// unclaimed rows, or of both. The renamed application must be stopped, or its
+// dequeues race this. Callers validate the input.
+func (s *SysDB) RenameApplication(ctx context.Context, input RenameApplicationDBInput) (ApplicationRowCounts, error) {
+	var counts ApplicationRowCounts
+	schemaPrefix := s.dialect.SchemaPrefix(s.schema)
+
+	tx, err := s.pool.BeginTx(ctx, TxOptions{})
+	if err != nil {
+		return counts, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	move := func(table string) (int64, error) {
+		args := []any{input.NewName}
+		predicate := renameSourceSQL(input.OldName, input.AdoptUnclaimedRows, &args)
+		query := s.RenderSQL(`UPDATE %s`+table+` SET application_name = $1 WHERE `+predicate, schemaPrefix)
+		tag, err := tx.Exec(ctx, s.dialect.RewriteQuery(query), args...)
+		if err != nil {
+			return 0, fmt.Errorf("failed to re-own %s rows: %w", table, err)
+		}
+		moved, err := tag.RowsAffected()
+		if err != nil {
+			return 0, fmt.Errorf("failed to count re-owned %s rows: %w", table, err)
+		}
+		return moved, nil
+	}
+
+	if counts.Queues, err = move("queues"); err != nil {
+		return counts, err
+	}
+	if counts.Schedules, err = move("workflow_schedules"); err != nil {
+		return counts, err
+	}
+	if counts.Versions, err = move("application_versions"); err != nil {
+		return counts, err
+	}
+
+	// Rows a rename must move atomically with the versions above: a half-owned
+	// application dequeues work whose version row it can no longer see.
+	args := []any{input.NewName}
+	predicate := renameSourceSQL(input.OldName, input.AdoptUnclaimedRows, &args)
+	statusClause := fmt.Sprintf(" AND status IN ($%d, $%d, $%d)", len(args)+1, len(args)+2, len(args)+3)
+	args = append(args, models.WorkflowStatusPending, models.WorkflowStatusEnqueued, models.WorkflowStatusDelayed)
+	query := s.RenderSQL(`UPDATE %sworkflow_status SET application_name = $1 WHERE `+predicate+statusClause, schemaPrefix)
+	tag, err := tx.Exec(ctx, s.dialect.RewriteQuery(query), args...)
+	if err != nil {
+		return counts, fmt.Errorf("failed to re-own in-flight workflow rows: %w", err)
+	}
+	inFlight, err := tag.RowsAffected()
+	if err != nil {
+		return counts, fmt.Errorf("failed to count re-owned in-flight workflow rows: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return counts, fmt.Errorf("failed to commit the rename transaction: %w", err)
+	}
+
+	terminal, err := s.renameRowsInBatches(ctx, "workflow_status", "workflow_uuid", input)
+	if err != nil {
+		return counts, err
+	}
+	counts.Workflows = inFlight + terminal
+	if counts.Steps, err = s.renameRowsInBatches(ctx, "operation_outputs", "workflow_uuid", input); err != nil {
+		return counts, err
+	}
+	return counts, nil
 }
 
 /*******************************/

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -196,10 +196,14 @@ func nameFilterSQL(column string, argNum int) string {
 // with a specified application name, is valid.
 // For example, when we upsert a schedule, the request can come from a context that operates for a specific application
 <<<<<<< HEAD
+<<<<<<< HEAD
 // But it is possible that an eponymous entry is owned by another application
 =======
 // But it is possible that a eponymous entry is owned by another application
 >>>>>>> fe48b63 (shared sysdb public api)
+=======
+// But it is possible that an eponymous entry is owned by another application
+>>>>>>> 0f09464 (nits)
 // This method validates whether the "requested" owner is valid for a row.
 func (s *SysDB) resolveRowOwner(ctx context.Context, q Querier, table, nameColumn, name string, owner *string, kind string) (*string, error) {
 	// Read the current application name for the object
@@ -5126,10 +5130,14 @@ func (s *SysDB) getQueueRow(ctx context.Context, db Querier, name string) (*mode
 
 // ListQueues returns database-backed queues owned by these applications plus
 <<<<<<< HEAD
+<<<<<<< HEAD
 // unclaimed ones. An empty or nil `applicationName` falls back to this context's application.
 =======
 // unclaimed ones; nil defaults to this handle's own application.
 >>>>>>> fe48b63 (shared sysdb public api)
+=======
+// unclaimed ones. An empty or nil `applicationName` falls back to this context's application.
+>>>>>>> 0f09464 (nits)
 func (s *SysDB) ListQueues(ctx context.Context, applicationNames []string) ([]models.QueueConfig, error) {
 	query := s.RenderSQL(`SELECT `+_QUEUE_SELECT_COLUMNS+` FROM %squeues`, s.dialect.SchemaPrefix(s.schema))
 	var args []any
@@ -6131,12 +6139,17 @@ func (s *SysDB) UpdateApplicationVersionTimestamp(ctx context.Context, versionNa
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 // ListApplicationVersions returns versions registered by this context's
 // application plus unclaimed ones; an application-less context lists every one.
 =======
 // ListApplicationVersions returns versions registered by this handle's
 // application plus unclaimed ones; a nameless handle lists every one.
 >>>>>>> fe48b63 (shared sysdb public api)
+=======
+// ListApplicationVersions returns versions registered by this context's
+// application plus unclaimed ones; an application-less context lists every one.
+>>>>>>> 0f09464 (nits)
 func (s *SysDB) ListApplicationVersions(ctx context.Context) ([]VersionInfo, error) {
 	query := s.RenderSQL(`
 		SELECT version_id, version_name, version_timestamp, created_at, application_name
@@ -6174,12 +6187,17 @@ func (s *SysDB) ListApplicationVersions(ctx context.Context) ([]VersionInfo, err
 
 // GetLatestApplicationVersion returns the latest version registered by an
 <<<<<<< HEAD
+<<<<<<< HEAD
 // application, plus unclaimed ones. applicationName defaults to this context's.
 // An application-less context with no explicit name matches every application.
 =======
 // application, plus unclaimed ones. applicationName defaults to this handle's
 // own; a nameless handle with no explicit name matches every application's.
 >>>>>>> fe48b63 (shared sysdb public api)
+=======
+// application, plus unclaimed ones. applicationName defaults to this context's.
+// An application-less context with no explicit name matches every application.
+>>>>>>> 0f09464 (nits)
 func (s *SysDB) GetLatestApplicationVersion(ctx context.Context, tx Tx, applicationName string) (*VersionInfo, error) {
 	owner := applicationName
 	if owner == "" {

--- a/dbos/internal/sysdb/system_database.go
+++ b/dbos/internal/sysdb/system_database.go
@@ -196,15 +196,7 @@ func nameFilterSQL(column string, argNum int) string {
 // This method is used to check whether reading/writing a queue/schedule/application version row
 // with a specified application name, is valid.
 // For example, when we upsert a schedule, the request can come from a context that operates for a specific application
-<<<<<<< HEAD
-<<<<<<< HEAD
 // But it is possible that an eponymous entry is owned by another application
-=======
-// But it is possible that a eponymous entry is owned by another application
->>>>>>> fe48b63 (shared sysdb public api)
-=======
-// But it is possible that an eponymous entry is owned by another application
->>>>>>> 0f09464 (nits)
 // This method validates whether the "requested" owner is valid for a row.
 func (s *SysDB) resolveRowOwner(ctx context.Context, q Querier, table, nameColumn, name string, owner *string, kind string) (*string, error) {
 	// Read the current application name for the object
@@ -5130,15 +5122,7 @@ func (s *SysDB) getQueueRow(ctx context.Context, db Querier, name string) (*mode
 }
 
 // ListQueues returns database-backed queues owned by these applications plus
-<<<<<<< HEAD
-<<<<<<< HEAD
 // unclaimed ones. An empty or nil `applicationName` falls back to this context's application.
-=======
-// unclaimed ones; nil defaults to this handle's own application.
->>>>>>> fe48b63 (shared sysdb public api)
-=======
-// unclaimed ones. An empty or nil `applicationName` falls back to this context's application.
->>>>>>> 0f09464 (nits)
 func (s *SysDB) ListQueues(ctx context.Context, applicationNames []string) ([]models.QueueConfig, error) {
 	query := s.RenderSQL(`SELECT `+_QUEUE_SELECT_COLUMNS+` FROM %squeues`, s.dialect.SchemaPrefix(s.schema))
 	var args []any
@@ -6139,18 +6123,8 @@ func (s *SysDB) UpdateApplicationVersionTimestamp(ctx context.Context, versionNa
 	return tx.Commit(ctx)
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 // ListApplicationVersions returns versions registered by this context's
 // application plus unclaimed ones; an application-less context lists every one.
-=======
-// ListApplicationVersions returns versions registered by this handle's
-// application plus unclaimed ones; a nameless handle lists every one.
->>>>>>> fe48b63 (shared sysdb public api)
-=======
-// ListApplicationVersions returns versions registered by this context's
-// application plus unclaimed ones; an application-less context lists every one.
->>>>>>> 0f09464 (nits)
 func (s *SysDB) ListApplicationVersions(ctx context.Context) ([]VersionInfo, error) {
 	query := s.RenderSQL(`
 		SELECT version_id, version_name, version_timestamp, created_at, application_name
@@ -6187,18 +6161,8 @@ func (s *SysDB) ListApplicationVersions(ctx context.Context) ([]VersionInfo, err
 }
 
 // GetLatestApplicationVersion returns the latest version registered by an
-<<<<<<< HEAD
-<<<<<<< HEAD
 // application, plus unclaimed ones. applicationName defaults to this context's.
 // An application-less context with no explicit name matches every application.
-=======
-// application, plus unclaimed ones. applicationName defaults to this handle's
-// own; a nameless handle with no explicit name matches every application's.
->>>>>>> fe48b63 (shared sysdb public api)
-=======
-// application, plus unclaimed ones. applicationName defaults to this context's.
-// An application-less context with no explicit name matches every application.
->>>>>>> 0f09464 (nits)
 func (s *SysDB) GetLatestApplicationVersion(ctx context.Context, tx Tx, applicationName string) (*VersionInfo, error) {
 	owner := applicationName
 	if owner == "" {

--- a/dbos/workflow.go
+++ b/dbos/workflow.go
@@ -6244,3 +6244,50 @@ func SetLatestApplicationVersion(ctx Client, versionName string) error {
 	}
 	return ctx.SetLatestApplicationVersion(ctx, versionName)
 }
+
+const DefaultRenameBatchSize = sysdb.DefaultRenameBatchSize
+
+type ApplicationRowCounts = sysdb.ApplicationRowCounts
+
+type RenameApplicationInput struct {
+	OldName            string // The application's previous name. Empty moves nothing but the unclaimed rows, so it requires AdoptUnclaimedRows.
+	NewName            string // The application that ends up owning the rows.
+	BatchSize          int    // Terminal workflows and steps re-owned per transaction. Zero defaults to DefaultRenameBatchSize.
+	AdoptUnclaimedRows bool   // Also take rows no application owns (application_name = NULL).
+}
+
+func (c *dbosContext) RenameApplication(_ Client, input RenameApplicationInput) (ApplicationRowCounts, error) {
+	if input.OldName == "" && !input.AdoptUnclaimedRows {
+		return ApplicationRowCounts{}, errors.New("nothing to re-own: name the application to rename, adopt unclaimed rows, or both")
+	}
+	if input.NewName == "" {
+		return ApplicationRowCounts{}, errors.New("the new application name is required")
+	}
+	if input.OldName == input.NewName {
+		return ApplicationRowCounts{}, fmt.Errorf("application '%s' already holds that name; nothing to rename", input.NewName)
+	}
+	if input.BatchSize < 0 {
+		return ApplicationRowCounts{}, fmt.Errorf("batch size must be a positive integer, got %d", input.BatchSize)
+	}
+	dbInput := sysdb.RenameApplicationDBInput{
+		OldName:            input.OldName,
+		NewName:            input.NewName,
+		BatchSize:          input.BatchSize,
+		AdoptUnclaimedRows: input.AdoptUnclaimedRows,
+	}
+	if dbInput.BatchSize == 0 {
+		dbInput.BatchSize = DefaultRenameBatchSize
+	}
+	return c.systemDB.RenameApplication(c, dbInput)
+}
+
+// RenameApplication gives an application ownership of the rows another name
+// holds, of the rows nobody holds, or of both. It returns the rows moved, by
+// table. Do not run it while the application being renamed is running: its
+// dequeues race the rename. A re-run resumes after an interruption, where it left off.
+func RenameApplication(ctx Client, input RenameApplicationInput) (ApplicationRowCounts, error) {
+	if ctx == nil {
+		return ApplicationRowCounts{}, errors.New("ctx cannot be nil")
+	}
+	return ctx.RenameApplication(ctx, input)
+}


### PR DESCRIPTION
Also shuts down conductor _after_ waiting for workflows to terminate, during `Shutdown`.