### PR TITLE
Copy workflowScheduler and ctxCancelFunc when cloning contexts

### DIFF
--- a/dbos/dbos.go
+++ b/dbos/dbos.go
@@ -403,9 +403,11 @@ func (c *dbosContext) Value(key any) any {
 func (c *dbosContext) clone(ctx context.Context) *dbosContext {
 	childCtx := &dbosContext{
 		ctx:                     ctx,
+		ctxCancelFunc:           c.ctxCancelFunc,
 		config:                  c.config,
 		logger:                  c.logger,
 		systemDB:                c.systemDB,
+		workflowScheduler:       c.workflowScheduler,
 		workflowsWg:             c.workflowsWg,
 		workflowRegistry:        c.workflowRegistry,
 		workflowCustomNametoFQN: c.workflowCustomNametoFQN,


### PR DESCRIPTION
This PR updates `(*dbosContext).clone` to include `workflowScheduler` and `ctxCancelFunc` from the original context. This fixes two issues. The first is that `(*dbosContext).Launch` panics when using a cloned context, as the context attempts to call `Start` on a nil workflow scheduler. The second issue is that `(*dbosContext).Shutdown` panics when calling a nil `ctxCancelFunc`.

My initial intent was to address #464 by merely copying `workflowScheduler` over from the original context during cloning, but on shutdown the cloned context also panicked because it was missing `ctxCancelFunc`. As a result, this PR adds both fields to the cloned context. There may be additional fields that need to be copied over, or tests that need to be written to exercise launching of cloned contexts.